### PR TITLE
refactor(twig): migrate remaining default-path callers to ServiceContainer::getTwig()

### DIFF
--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -2897,11 +2897,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../library/MedEx/API.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method render\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ajax/messages/validate_messages_document_ajax.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method debug\\(\\) on mixed\\.$#',
     'count' => 6,
     'path' => __DIR__ . '/../../library/ajax/person_search_ajax.php',

--- a/.phpstan/baseline/openemr.exitInCatchOrFinally.php
+++ b/.phpstan/baseline/openemr.exitInCatchOrFinally.php
@@ -128,11 +128,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^exit/die inside a catch block swallows the caught exception and aborts the process\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ajax/messages/validate_messages_document_ajax.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^exit/die inside a catch block swallows the caught exception and aborts the process\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../library/deletedrug.php',
 ];

--- a/.phpstan/baseline/openemr.forbiddenInstantiation.php
+++ b/.phpstan/baseline/openemr.forbiddenInstantiation.php
@@ -4,11 +4,6 @@ $ignoreErrors = [];
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../ccr/display.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/forms/care_plan/new.php',
 ];
 $ignoreErrors[] = [
@@ -84,31 +79,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/login/login.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/about_page.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/finder/dynamic_finder.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/holidays/import_holidays.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/main/tabs/main.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-comlink-telehealth/src/Bootstrap.php',
 ];
 $ignoreErrors[] = [
@@ -132,24 +102,9 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/modules/custom_modules/oe-module-faxsms/src/Events/NotificationEventListener.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncountermanagerController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Model/CcdaServiceDocumentRequestor.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/orders/patient_match_dialog.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/encounter/forms.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Crypto\\\\CryptoGen is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getCrypto\\(\\) instead\\.$#',
@@ -159,152 +114,12 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/front_payment.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/summary/dashboard_header.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../interface/patient_file/summary/demographics.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/summary/insurance_edit.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/patient_file/summary/stats.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/amc_full_report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/reports/cdr_log.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/reports/cqm.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/load_codes.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/super/rules/index.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/usergroup/facilities_add.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/usergroup/facility_admin.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/ajax/messages/validate_messages_document_ajax.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/classes/postmaster.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/dicom_frame.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/templates/address_display.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/templates/address_form.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/templates/relation_display.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/templates/relation_form.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/templates/telecom_display.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../library/templates/telecom_form.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../portal/account/account.lib.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../portal/account/index_reset.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/account/index_reset.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/account/register.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/home.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/index.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/portal_payment.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/report/portal_patient_report.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/sign/assets/signer_modal.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
@@ -382,17 +197,7 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Controllers/Interface/Forms/Observation/ObservationController.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Controllers/Interface/Forms/Observation/ObservationController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/FHIR/SMART/ClientAdminController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/FHIR/SMART/ClientAdminController.php',
 ];
@@ -400,16 +205,6 @@ $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/FHIR/SMART/ResourceConstraintFilterer.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/FHIR/SMART/SmartLaunchController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/OeUI/OemrUI.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
@@ -522,11 +317,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Services/Cda/CdaValidateDocuments.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/Cda/CdaValidateDocuments.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Http\\\\Psr17Factory is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:get\\{PsrType\\}Factory\\(\\) instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/FHIR/Document/BaseDocumentDownloader.php',
@@ -555,11 +345,6 @@ $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Services/ObservationService.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Twig\\\\TwigContainer is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getTwig\\(\\) instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Services/PatientAccessOnsiteService.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct instantiation of OpenEMR\\\\Common\\\\Logging\\\\SystemLogger is discouraged\\. Use OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead\\.$#',

--- a/ccr/display.php
+++ b/ccr/display.php
@@ -18,7 +18,6 @@
 require_once(__DIR__ . "/../interface/globals.php");
 
 use OpenEMR\BC\ServiceContainer;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\PatientDocuments\PatientDocumentViewCCDAEvent;
 
@@ -28,19 +27,19 @@ $d = new Document($document_id);
 
 
 try {
-    $twig = new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel());
+    $twig = ServiceContainer::getTwig();
     // can_access will check session if no params are passed.
     if (!$d->can_access()) {
-        echo $twig->getTwig()->render("templates/error/400.html.twig", ['statusCode' => 401, 'errorMessage' => 'Access Denied']);
+        echo $twig->render("templates/error/400.html.twig", ['statusCode' => 401, 'errorMessage' => 'Access Denied']);
         exit;
     } elseif ($d->is_deleted()) {
-        echo $twig->getTwig()->render("templates/error/404.html.twig");
+        echo $twig->render("templates/error/404.html.twig");
         exit;
     }
 
     $xml = $d->get_data();
     if (empty($xml)) {
-        echo $twig->getTwig()->render("templates/error/404.html.twig");
+        echo $twig->render("templates/error/404.html.twig");
         exit;
     }
 
@@ -59,7 +58,7 @@ try {
     $content = $updatedViewCCDAEvent->getContent();
     if (empty($content)) {
         // TODO: @adunsulag log the security error as someone is trying to do a remote file inclusion
-        echo $twig->getTwig()->render("templates/error/general_http_error.html.twig", ['statusCode' => 500, 'errorMessage' => 'System error occurred in processing content']);
+        echo $twig->render("templates/error/general_http_error.html.twig", ['statusCode' => 500, 'errorMessage' => 'System error occurred in processing content']);
         exit;
     }
     echo $updatedViewCCDAEvent->getContent();

--- a/ccr/display.php
+++ b/ccr/display.php
@@ -18,8 +18,10 @@
 require_once(__DIR__ . "/../interface/globals.php");
 
 use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Http\RequestTerminator;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\PatientDocuments\PatientDocumentViewCCDAEvent;
+use Symfony\Component\HttpFoundation\Response;
 
 $type = $_GET['type'];
 $document_id = $_GET['doc_id'];
@@ -30,17 +32,23 @@ try {
     $twig = ServiceContainer::getTwig();
     // can_access will check session if no params are passed.
     if (!$d->can_access()) {
-        echo $twig->render("templates/error/400.html.twig", ['statusCode' => 401, 'errorMessage' => 'Access Denied']);
-        exit;
+        (new RequestTerminator())->respond(new Response(
+            $twig->render("templates/error/400.html.twig", ['statusCode' => 401, 'errorMessage' => 'Access Denied']),
+            Response::HTTP_UNAUTHORIZED,
+        ));
     } elseif ($d->is_deleted()) {
-        echo $twig->render("templates/error/404.html.twig");
-        exit;
+        (new RequestTerminator())->respond(new Response(
+            $twig->render("templates/error/404.html.twig"),
+            Response::HTTP_NOT_FOUND,
+        ));
     }
 
     $xml = $d->get_data();
     if (empty($xml)) {
-        echo $twig->render("templates/error/404.html.twig");
-        exit;
+        (new RequestTerminator())->respond(new Response(
+            $twig->render("templates/error/404.html.twig"),
+            Response::HTTP_NOT_FOUND,
+        ));
     }
 
     $viewCCDAEvent = new PatientDocumentViewCCDAEvent();
@@ -58,8 +66,10 @@ try {
     $content = $updatedViewCCDAEvent->getContent();
     if (empty($content)) {
         // TODO: @adunsulag log the security error as someone is trying to do a remote file inclusion
-        echo $twig->render("templates/error/general_http_error.html.twig", ['statusCode' => 500, 'errorMessage' => 'System error occurred in processing content']);
-        exit;
+        (new RequestTerminator())->respond(new Response(
+            $twig->render("templates/error/general_http_error.html.twig", ['statusCode' => 500, 'errorMessage' => 'System error occurred in processing content']),
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+        ));
     }
     echo $updatedViewCCDAEvent->getContent();
 } catch (\Throwable $exception) {

--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -31,9 +31,9 @@
 Header("X-Frame-Options: DENY");
 Header("Content-Security-Policy: frame-ancestors 'none'");
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\Core\TemplatePageEvent;
 use OpenEMR\Services\FacilityService;

--- a/interface/login/login.php
+++ b/interface/login/login.php
@@ -33,7 +33,7 @@ Header("Content-Security-Policy: frame-ancestors 'none'");
 
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\Core\TemplatePageEvent;
 use OpenEMR\Services\FacilityService;
@@ -55,8 +55,7 @@ require_once("../globals.php");
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
-$twig = new TwigContainer(null, $globalsBag->getKernel());
-$t = $twig->getTwig();
+$t = ServiceContainer::getTwig();
 
 $logoService = new LogoService();
 $primaryLogo = $logoService->getLogo("core/login/primary");

--- a/interface/main/about_page.php
+++ b/interface/main/about_page.php
@@ -22,15 +22,14 @@
 
 require_once("../globals.php");
 
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Uuid\UniqueInstallationUuid;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\Core\TemplatePageEvent;
 use OpenEMR\Services\ProductRegistrationService;
 use OpenEMR\Services\VersionService;
 
-$twig = new TwigContainer();
-$t = $twig->getTwig();
+$t = ServiceContainer::getTwig();
 
 $versionService = new VersionService();
 

--- a/interface/main/finder/dynamic_finder.php
+++ b/interface/main/finder/dynamic_finder.php
@@ -18,7 +18,7 @@
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\UserInterface\PageHeadingRenderEvent;
@@ -472,8 +472,7 @@ $templateVars = [
     'rp' => $rp['rp'],
 ];
 
-$twig = new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel());
-$t = $twig->getTwig();
+$t = ServiceContainer::getTwig();
 echo $t->render('patient_finder/finder.html.twig', $templateVars);
 
 ?>

--- a/interface/main/finder/dynamic_finder.php
+++ b/interface/main/finder/dynamic_finder.php
@@ -16,9 +16,9 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\UserInterface\PageHeadingRenderEvent;

--- a/interface/main/holidays/import_holidays.php
+++ b/interface/main/holidays/import_holidays.php
@@ -20,12 +20,12 @@ set_time_limit(0);
 
 require_once('../../globals.php');
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Services\HolidayService;
 use OpenEMR\Services\InvalidHolidayCsvException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;

--- a/interface/main/holidays/import_holidays.php
+++ b/interface/main/holidays/import_holidays.php
@@ -25,7 +25,7 @@ use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Services\HolidayService;
 use OpenEMR\Services\InvalidHolidayCsvException;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -81,7 +81,7 @@ try {
     $errorMessage = $e->getMessage();
 }
 
-$twig = (new TwigContainer())->getTwig();
+$twig = ServiceContainer::getTwig();
 echo $twig->render('holidays/import.html.twig', [
     'status' => $status,
     'errorMessage' => $errorMessage,

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -28,7 +28,7 @@ use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEEnvBag;
 use OpenEMR\Core\OEGlobalsBag;
@@ -92,7 +92,7 @@ if (OEGlobalsBag::getInstance()->get('prevent_browser_refresh') > 1) {
 }
 
 $esignApi = new Api();
-$twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->getTwig();
+$twig = ServiceContainer::getTwig();
 
 ?>
 <!DOCTYPE html>

--- a/interface/main/tabs/main.php
+++ b/interface/main/tabs/main.php
@@ -24,11 +24,11 @@ require_once(__DIR__ . '/../../globals.php');
 require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Api.php';
 
 use ESign\Api;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEEnvBag;
 use OpenEMR\Core\OEGlobalsBag;

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncountermanagerController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncountermanagerController.php
@@ -25,7 +25,6 @@ use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\JsonModel;
 use Laminas\View\Model\ViewModel;
 use OpenEMR\BC\ServiceContainer;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Cqm\QrdaControllers\QrdaReportController;
 use OpenEMR\Services\FacilityService;
@@ -241,19 +240,19 @@ class EncountermanagerController extends AbstractActionController
 
         $document = new \Document($docId);
         try {
-            $twig = new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel());
+            $twig = ServiceContainer::getTwig();
             // can_access will check session if no params are passed.
             if (!$document->can_access()) {
-                echo $twig->getTwig()->render("templates/error/400.html.twig", ['statusCode' => 401, 'errorMessage' => 'Access Denied']);
+                echo $twig->render("templates/error/400.html.twig", ['statusCode' => 401, 'errorMessage' => 'Access Denied']);
                 exit;
             } elseif ($document->is_deleted()) {
-                echo $twig->getTwig()->render("templates/error/404.html.twig");
+                echo $twig->render("templates/error/404.html.twig");
                 exit;
             }
 
             $content = $document->get_data();
             if (empty($content)) {
-                echo $twig->getTwig()->render("templates/error/404.html.twig");
+                echo $twig->render("templates/error/404.html.twig");
                 exit;
             }
             $content = $document->get_data();

--- a/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncountermanagerController.php
+++ b/interface/modules/zend_modules/module/Carecoordination/src/Carecoordination/Controller/EncountermanagerController.php
@@ -25,12 +25,14 @@ use Laminas\Mvc\Controller\AbstractActionController;
 use Laminas\View\Model\JsonModel;
 use Laminas\View\Model\ViewModel;
 use OpenEMR\BC\ServiceContainer;
+use OpenEMR\Common\Http\RequestTerminator;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Cqm\QrdaControllers\QrdaReportController;
 use OpenEMR\Services\FacilityService;
 use OpenEMR\Services\PractitionerService;
 use OpenEMR\Services\Qrda\QrdaReportService;
 use OpenEMR\Validators\ProcessingResult;
+use Symfony\Component\HttpFoundation\Response;
 use XSLTProcessor;
 
 /**
@@ -243,17 +245,23 @@ class EncountermanagerController extends AbstractActionController
             $twig = ServiceContainer::getTwig();
             // can_access will check session if no params are passed.
             if (!$document->can_access()) {
-                echo $twig->render("templates/error/400.html.twig", ['statusCode' => 401, 'errorMessage' => 'Access Denied']);
-                exit;
+                (new RequestTerminator())->respond(new Response(
+                    $twig->render("templates/error/400.html.twig", ['statusCode' => 401, 'errorMessage' => 'Access Denied']),
+                    Response::HTTP_UNAUTHORIZED,
+                ));
             } elseif ($document->is_deleted()) {
-                echo $twig->render("templates/error/404.html.twig");
-                exit;
+                (new RequestTerminator())->respond(new Response(
+                    $twig->render("templates/error/404.html.twig"),
+                    Response::HTTP_NOT_FOUND,
+                ));
             }
 
             $content = $document->get_data();
             if (empty($content)) {
-                echo $twig->render("templates/error/404.html.twig");
-                exit;
+                (new RequestTerminator())->respond(new Response(
+                    $twig->render("templates/error/404.html.twig"),
+                    Response::HTTP_NOT_FOUND,
+                ));
             }
             $content = $document->get_data();
 

--- a/interface/orders/patient_match_dialog.php
+++ b/interface/orders/patient_match_dialog.php
@@ -21,12 +21,12 @@ require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/options.
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 
 if (!AclMain::aclCheckCore('patients', 'med')) {
-    echo (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->getTwig()->render(
+    echo ServiceContainer::getTwig()->render(
         'core/unauthorized.html.twig',
         ['pageTitle' => xl('Patient Matching')]
     );

--- a/interface/orders/patient_match_dialog.php
+++ b/interface/orders/patient_match_dialog.php
@@ -18,12 +18,11 @@ require_once("../globals.php");
 require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/patient.inc.php");
 require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/options.inc.php");
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\Header;
-use OpenEMR\Core\OEGlobalsBag;
 
 if (!AclMain::aclCheckCore('patients', 'med')) {
     echo ServiceContainer::getTwig()->render(

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -34,12 +34,12 @@ require_once($srcdir . '/ESign/Api.php');
 require_once($srcdir . "/../controllers/C_Document.class.php");
 
 use ESign\Api;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Forms\FormLocator;
 use OpenEMR\Common\Forms\FormReportRenderer;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\Encounter\EncounterFormsListRenderEvent;

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -39,7 +39,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Forms\FormLocator;
 use OpenEMR\Common\Forms\FormReportRenderer;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\Encounter\EncounterFormsListRenderEvent;
@@ -644,8 +644,7 @@ if (OEGlobalsBag::getInstance()->getBoolean('google_signin_enabled') && !empty(O
     $encounterMenuEvent = new EncounterMenuEvent();
     $menu = $eventDispatcher->dispatch($encounterMenuEvent, EncounterMenuEvent::MENU_RENDER);
 
-    $twig = new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel());
-    $t = $twig->getTwig();
+    $t = ServiceContainer::getTwig();
     echo $t->render('encounter/forms/navbar.html.twig', [
         'encounterDate' => oeFormatShortDate($encounter_date),
         'patientName' => $patientName,

--- a/interface/patient_file/front_payment.php
+++ b/interface/patient_file/front_payment.php
@@ -33,7 +33,7 @@ use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Csrf\CsrfUtils;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Utils\FormatMoney;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
@@ -45,7 +45,7 @@ use OpenEMR\Services\FacilityService;
 
 
 $globalsBag = OEGlobalsBag::getInstance();
-$twig = (new TwigContainer(null, $globalsBag->getKernel()))->getTwig();
+$twig = ServiceContainer::getTwig();
 
 if (!empty($_REQUEST['receipt']) && empty($_POST['form_save'])) {
     if (!AclMain::aclCheckCore('acct', 'bill') && !AclMain::aclCheckCore('acct', 'rep_a') && !AclMain::aclCheckCore('patients', 'rx')) {

--- a/interface/patient_file/front_payment.php
+++ b/interface/patient_file/front_payment.php
@@ -28,12 +28,12 @@ require_once("../../custom/code_types.inc.php");
 require_once($srcdir . "/options.inc.php");
 require_once($srcdir . "/encounter_events.inc.php");
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Billing\BillingUtilities;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Crypto\CryptoGen;
 use OpenEMR\Common\Csrf\CsrfUtils;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Utils\FormatMoney;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;

--- a/interface/patient_file/summary/dashboard_header.php
+++ b/interface/patient_file/summary/dashboard_header.php
@@ -18,10 +18,9 @@ require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/display_
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 
-$twigContainer = new TwigContainer();
-$t = $twigContainer->getTwig();
+$t = ServiceContainer::getTwig();
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 // This file is included by other patient_file pages that set $oemr_ui and $pid

--- a/interface/patient_file/summary/dashboard_header.php
+++ b/interface/patient_file/summary/dashboard_header.php
@@ -16,9 +16,9 @@
 
 require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/display_help_icon_inc.php");
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\BC\ServiceContainer;
 
 $t = ServiceContainer::getTwig();
 

--- a/interface/patient_file/summary/insurance_edit.php
+++ b/interface/patient_file/summary/insurance_edit.php
@@ -26,7 +26,7 @@ require_once($srcdir . "/patient.inc.php");
 
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\PatientDemographics\UpdateEvent;
@@ -80,7 +80,7 @@ if (OEGlobalsBag::getInstance()->getBoolean('insurance_only_one')) {
     $insurance_headings = [xl("Primary Insurance Provider"), xl("Secondary Insurance Provider"), xl("Tertiary Insurance provider")];
 }
 
-$twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->getTwig();
+$twig = ServiceContainer::getTwig();
 //$insurance_info[0]['active'] = true;
 //$insuranceTypes = array_map(function($item) { return $item['type'];}, $insurance_info);
 //$insrender(uranceTypes = array_unique($insuranceTypes);

--- a/interface/patient_file/summary/insurance_edit.php
+++ b/interface/patient_file/summary/insurance_edit.php
@@ -24,9 +24,9 @@ require_once($srcdir . "/options.inc.php");
 require_once($srcdir . "/patientvalidation.inc.php");
 require_once($srcdir . "/patient.inc.php");
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\PatientDemographics\UpdateEvent;

--- a/interface/patient_file/summary/stats.php
+++ b/interface/patient_file/summary/stats.php
@@ -19,14 +19,12 @@ require_once($srcdir . "/options.inc.php");
 
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 
 CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
 
-$kernel = OEGlobalsBag::getInstance()->getKernel();
-$twigContainer = new TwigContainer(null, $kernel);
-$t = $twigContainer->getTwig();
+$t = ServiceContainer::getTwig();
 /** @var array<string, array<int, mixed>> $ISSUE_TYPES */
 $ISSUE_TYPES = OEGlobalsBag::getInstance()->get('ISSUE_TYPES', []);
 $need_head = true;

--- a/interface/patient_file/summary/stats.php
+++ b/interface/patient_file/summary/stats.php
@@ -17,9 +17,9 @@ $pid = $session->get('pid', 0);
 require_once($srcdir . "/lists.inc.php");
 require_once($srcdir . "/options.inc.php");
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 
 CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);

--- a/interface/reports/amc_full_report.php
+++ b/interface/reports/amc_full_report.php
@@ -14,7 +14,6 @@ require_once("../../library/classes/rulesets/Amc/AmcReportFactory.php");
 
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\ClinicalDecisionRules\AMC\CertificationReportTypes;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
 
 function formatPatientReportData($report_id, &$data, $type_report, $amc_report_types = [])
@@ -183,8 +182,7 @@ $report_id = (isset($_GET['report_id'])) ? trim((string) $_GET['report_id']) : "
 
 // Collect the back variable, if pertinent
 $back_link = (isset($_GET['back'])) ? trim((string) $_GET['back']) : "";
-$twigContainer = new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel());
-$twig = $twigContainer->getTwig();
+$twig = ServiceContainer::getTwig();
 $report_view = collectReportDatabase($report_id);
 if (!empty($report_view)) {
     $amc_report_types = CertificationReportTypes::getReportTypeRecords();

--- a/interface/reports/amc_full_report.php
+++ b/interface/reports/amc_full_report.php
@@ -14,7 +14,6 @@ require_once("../../library/classes/rulesets/Amc/AmcReportFactory.php");
 
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\ClinicalDecisionRules\AMC\CertificationReportTypes;
-use OpenEMR\Core\OEGlobalsBag;
 
 function formatPatientReportData($report_id, &$data, $type_report, $amc_report_types = [])
 {

--- a/interface/reports/cdr_log.php
+++ b/interface/reports/cdr_log.php
@@ -21,7 +21,6 @@ use OpenEMR\Common\Acl\AccessDeniedException;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Csrf\CsrfInvalidException;
 use OpenEMR\Common\Http\CurrentRequest;
-use OpenEMR\Core\OEGlobalsBag;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 

--- a/interface/reports/cdr_log.php
+++ b/interface/reports/cdr_log.php
@@ -21,7 +21,6 @@ use OpenEMR\Common\Acl\AccessDeniedException;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Csrf\CsrfInvalidException;
 use OpenEMR\Common\Http\CurrentRequest;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -41,13 +40,13 @@ try {
 } catch (NotFoundHttpException $e) {
     // Log the exception
     ServiceContainer::getLogger()->error($e->getMessage(), ['exception' => $e]);
-    $contents = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->getTwig()->render('error/404.html.twig');
+    $contents = ServiceContainer::getTwig()->render('error/404.html.twig');
     // Send the error response
     $response = new Response($contents, 404);
 } catch (\Throwable $e) {
     // Log the exception
     ServiceContainer::getLogger()->error($e->getMessage(), ['exception' => $e]);
-    $contents =  (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->getTwig()->render('error/general_http_error.html.twig');
+    $contents =  ServiceContainer::getTwig()->render('error/general_http_error.html.twig');
     // Send the error response
     $response = new Response($contents, 500);
 }

--- a/interface/reports/cqm.php
+++ b/interface/reports/cqm.php
@@ -25,7 +25,7 @@ use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\PractitionerService;
 use OpenEMR\Services\Utils\DateFormatterUtils;
@@ -117,8 +117,7 @@ if ($type_report == "standard") {
     $help_file_name = "cqm_amc_help.php";
 }
 
-$twigContainer = new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel());
-$twig = $twigContainer->getTwig();
+$twig = ServiceContainer::getTwig();
 
 $formData = [
     'type_report' => $type_report

--- a/interface/reports/cqm.php
+++ b/interface/reports/cqm.php
@@ -20,13 +20,12 @@ require_once("../../library/patient.inc.php");
 require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/options.inc.php";
 require_once \OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/clinical_rules.php";
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\ClinicalDecisionRules\AMC\CertificationReportTypes;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\BC\ServiceContainer;
-use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\PractitionerService;
 use OpenEMR\Services\Utils\DateFormatterUtils;
 

--- a/interface/super/load_codes.php
+++ b/interface/super/load_codes.php
@@ -23,7 +23,6 @@ require_once '../globals.php';
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Controllers\Interface\Super\LoadCodesController;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\CodeTypes\Importer\LOINCImportService;
@@ -33,7 +32,7 @@ $kernel = OEGlobalsBag::getInstance()->getKernel();
 
 $controller = new LoadCodesController(
     $kernel->getEventDispatcher(),
-    (new TwigContainer(null, $kernel))->getTwig(),
+    ServiceContainer::getTwig(),
     SessionWrapperFactory::getInstance()->getActiveSession(),
     ServiceContainer::getLogger(),
     [

--- a/interface/super/rules/index.php
+++ b/interface/super/rules/index.php
@@ -16,7 +16,6 @@ use OpenEMR\Common\Acl\AccessDeniedException;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Csrf\CsrfInvalidException;
 use OpenEMR\Common\Http\CurrentRequest;
-use OpenEMR\Core\OEGlobalsBag;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 

--- a/interface/super/rules/index.php
+++ b/interface/super/rules/index.php
@@ -16,7 +16,6 @@ use OpenEMR\Common\Acl\AccessDeniedException;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Csrf\CsrfInvalidException;
 use OpenEMR\Common\Http\CurrentRequest;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -33,13 +32,13 @@ try {
 } catch (NotFoundHttpException $e) {
     // Log the exception
     ServiceContainer::getLogger()->error($e->getMessage(), ['exception' => $e]);
-    $contents = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->getTwig()->render('error/404.html.twig');
+    $contents = ServiceContainer::getTwig()->render('error/404.html.twig');
     // Send the error response
     $response = new Response($contents, 404);
 } catch (\Throwable $e) {
     // Log the exception
     ServiceContainer::getLogger()->error($e->getMessage(), ['exception' => $e]);
-    $contents =  (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->getTwig()->render('error/general_http_error.html.twig');
+    $contents =  ServiceContainer::getTwig()->render('error/general_http_error.html.twig');
     // Send the error response
     $response = new Response($contents, 500);
 }

--- a/interface/usergroup/facilities_add.php
+++ b/interface/usergroup/facilities_add.php
@@ -15,7 +15,7 @@ require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/options.
 
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\FacilityService;
 use OpenEMR\Services\ListService;
@@ -50,6 +50,5 @@ $args = [
     'mode' => 'add',
 ];
 
-$twig = new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel());
-$t = $twig->getTwig();
+$t = ServiceContainer::getTwig();
 echo $t->render("super/facilities/form.html.twig", $args);

--- a/interface/usergroup/facilities_add.php
+++ b/interface/usergroup/facilities_add.php
@@ -13,9 +13,9 @@
 require_once("../globals.php");
 require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/options.inc.php");
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\FacilityService;
 use OpenEMR\Services\ListService;

--- a/interface/usergroup/facility_admin.php
+++ b/interface/usergroup/facility_admin.php
@@ -15,7 +15,7 @@ require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/options.
 
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\FacilityService;
 use OpenEMR\Services\ListService;
@@ -53,6 +53,5 @@ $args = [
     'facility' => $facilityService->getById($my_fid),
 ];
 
-$twig = new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel());
-$t = $twig->getTwig();
+$t = ServiceContainer::getTwig();
 echo $t->render("super/facilities/form.html.twig", $args);

--- a/interface/usergroup/facility_admin.php
+++ b/interface/usergroup/facility_admin.php
@@ -13,9 +13,9 @@
 require_once("../globals.php");
 require_once(\OpenEMR\Core\OEGlobalsBag::getInstance()->getSrcDir() . "/options.inc.php");
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\FacilityService;
 use OpenEMR\Services\ListService;

--- a/library/ajax/messages/validate_messages_document_ajax.php
+++ b/library/ajax/messages/validate_messages_document_ajax.php
@@ -76,12 +76,11 @@ try {
     }
 } catch (\Throwable $exception) {
     ServiceContainer::getLogger()->error($exception->getMessage(), ['exception' => $exception]);
-    if ($twig !== null) {
-        (new RequestTerminator())->respond(new Response(
-            $twig->render('error/general_http_error', ['statusCode' => 500]),
-            Response::HTTP_INTERNAL_SERVER_ERROR,
-        ));
-    } else {
-        echo xlt("Server error occurred. Check logs for details");
-    }
+    $display = $twig?->render('error/general_http_error', ['statusCode' => 500])
+        ?? xlt("Server error occurred. Check logs for details");
+
+    (new RequestTerminator())->respond(new Response(
+        $display,
+        Response::HTTP_INTERNAL_SERVER_ERROR,
+    ));
 }

--- a/library/ajax/messages/validate_messages_document_ajax.php
+++ b/library/ajax/messages/validate_messages_document_ajax.php
@@ -17,13 +17,15 @@ require_once("../../../interface/globals.php");
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Http\RequestTerminator;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\Cda\CdaValidateDocumentObject;
+use Symfony\Component\HttpFoundation\Response;
 
 $format = $_GET['format'] ?? "html";
 $format = in_array($format, ['json', 'html']) ? $format : "html";
 
+$twig = null;
 try {
     $twig = ServiceContainer::getTwig();
     $session = SessionWrapperFactory::getInstance()->getActiveSession();
@@ -35,29 +37,33 @@ try {
 
 
     if (!AclMain::aclCheckCore('patients', 'notes')) {
-        http_response_code(403);
-        echo $twig->render('core/unauthorized.' . $format . '.twig', ['pageTitle' => xl("Validate Message Documents")]);
-        exit;
+        (new RequestTerminator())->respond(new Response(
+            $twig->render('core/unauthorized.' . $format . '.twig', ['pageTitle' => xl("Validate Message Documents")]),
+            Response::HTTP_FORBIDDEN,
+        ));
     }
 
     if (empty($_GET['doc'])) {
-        http_response_code(400);
-        echo $twig->render('error/400.' . $format . '.twig', ['errorMessage' => xl("Missing document id")]);
-        exit;
+        (new RequestTerminator())->respond(new Response(
+            $twig->render('error/400.' . $format . '.twig', ['errorMessage' => xl("Missing document id")]),
+            Response::HTTP_BAD_REQUEST,
+        ));
     }
 
     $docId = intval($_GET['doc']);
     $document = new Document($docId);
     if ($document->get_size() <= 0) {
         // doc not found
-        http_response_code(404);
-        echo $twig->render('error/404.' . $format . '.twig', ['errorMessage' => xl("Missing document id")]);
-        exit;
+        (new RequestTerminator())->respond(new Response(
+            $twig->render('error/404.' . $format . '.twig', ['errorMessage' => xl("Missing document id")]),
+            Response::HTTP_NOT_FOUND,
+        ));
     }
     if (!$document->can_access($docId)) {
-        http_response_code(403);
-        echo $twig->render('core/unauthorized.' . $format . '.twig', ['pageTitle' => xl("Validate Message Documents")]);
-        exit;
+        (new RequestTerminator())->respond(new Response(
+            $twig->render('core/unauthorized.' . $format . '.twig', ['pageTitle' => xl("Validate Message Documents")]),
+            Response::HTTP_FORBIDDEN,
+        ));
     }
 
     // now we can validate our documents
@@ -70,10 +76,11 @@ try {
     }
 } catch (\Throwable $exception) {
     ServiceContainer::getLogger()->error($exception->getMessage(), ['exception' => $exception]);
-    if (isset($twig)) {
-        http_response_code(500);
-        $twig->render('error/general_http_error', ['statusCode' => 500]);
-        exit;
+    if ($twig !== null) {
+        (new RequestTerminator())->respond(new Response(
+            $twig->render('error/general_http_error', ['statusCode' => 500]),
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+        ));
     } else {
         echo xlt("Server error occurred. Check logs for details");
     }

--- a/library/ajax/messages/validate_messages_document_ajax.php
+++ b/library/ajax/messages/validate_messages_document_ajax.php
@@ -18,7 +18,6 @@ use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\Cda\CdaValidateDocumentObject;
 
@@ -26,7 +25,7 @@ $format = $_GET['format'] ?? "html";
 $format = in_array($format, ['json', 'html']) ? $format : "html";
 
 try {
-    $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->getTwig();
+    $twig = ServiceContainer::getTwig();
     $session = SessionWrapperFactory::getInstance()->getActiveSession();
     if (!CsrfUtils::verifyCsrfToken($_GET["csrf"], session: $session)) {
         CsrfUtils::csrfNotVerified(toScreen: false, beforeExit: static function () use ($twig, $format): void {

--- a/library/classes/postmaster.php
+++ b/library/classes/postmaster.php
@@ -19,7 +19,6 @@ declare(strict_types=1);
 
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Database\QueryUtils;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use PHPMailer\PHPMailer\PHPMailer;
 
@@ -129,8 +128,7 @@ class MyMailer extends PHPMailer
 
                 if ($emailMethodConfigured) {
                     try {
-                        $twigContainer = new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel());
-                        $twig = $twigContainer->getTwig();
+                        $twig = ServiceContainer::getTwig();
                         if (!empty($ret['template_name'])) {
                             $templateData = json_decode((string) $ret['body'], true);
                             // we make sure to prefix this so that people have to work inside the openemr namespace for email templates

--- a/library/dicom_frame.php
+++ b/library/dicom_frame.php
@@ -20,11 +20,11 @@
 
 require_once('../interface/globals.php');
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 
 if (!AclMain::aclCheckCore('patients', 'docs')) {

--- a/library/dicom_frame.php
+++ b/library/dicom_frame.php
@@ -24,7 +24,7 @@ use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 
 if (!AclMain::aclCheckCore('patients', 'docs')) {
@@ -53,7 +53,7 @@ if ($web_path) {
     $state_url = OEGlobalsBag::getInstance()->getWebRoot() . "/library/ajax/upload.php";
     $web_path = attr($web_path) . '&retrieve&patient_id=' . attr_url($patid) . '&document_id=' . attr_url($docid) . '&as_file=false&type=' . attr_url($type);
 }
-$twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->getTwig();
+$twig = ServiceContainer::getTwig();
 echo $twig->render("dicom/dicom-viewer.html.twig", [
     'assets_static_relative' => OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative()
     ,'web_root' => OEGlobalsBag::getInstance()->getWebRoot()

--- a/library/templates/address_display.php
+++ b/library/templates/address_display.php
@@ -14,8 +14,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-use OpenEMR\Common\Twig\TwigContainer;
-use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Services\ContactAddressService;
 use OpenEMR\Services\ContactService;
 
@@ -77,6 +76,5 @@ $templateVars = [
 ];
 
 // Render Twig template
-$twigContainer = new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel());
-$twig = $twigContainer->getTwig();
+$twig = ServiceContainer::getTwig();
 echo $twig->render('patient/demographics/address_display.html.twig', $templateVars);

--- a/library/templates/address_form.php
+++ b/library/templates/address_form.php
@@ -14,7 +14,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\ContactAddressService;
 use OpenEMR\Services\ContactService;
@@ -101,6 +101,5 @@ $templateVars = [
 ];
 
 // Render Twig template
-$twigContainer = new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel());
-$twig = $twigContainer->getTwig();
+$twig = ServiceContainer::getTwig();
 echo $twig->render('patient/demographics/address_form.html.twig', $templateVars);

--- a/library/templates/relation_display.php
+++ b/library/templates/relation_display.php
@@ -14,8 +14,6 @@
  */
 
 use OpenEMR\BC\ServiceContainer;
-use OpenEMR\Common\Twig\TwigContainer;
-use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\ContactAddressService;
 use OpenEMR\Services\ContactRelationService;
 use OpenEMR\Services\ContactService;
@@ -161,6 +159,5 @@ $logger->debug("Error loading relations for display", [
 ]);
 
 // Render the template
-$twigContainer = new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel());
-$twig = $twigContainer->getTwig();
+$twig = ServiceContainer::getTwig();
 echo $twig->render('patient/demographics/relation_display.html.twig', $templateVars);

--- a/library/templates/relation_form.php
+++ b/library/templates/relation_form.php
@@ -18,7 +18,6 @@
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\ContactAddressService;
 use OpenEMR\Services\ContactRelationService;
@@ -221,6 +220,5 @@ $logger->debug("Sending to TWIG", [
                 ]);
 
 // Render Twig template
-$twigContainer = new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel());
-$twig = $twigContainer->getTwig();
+$twig = ServiceContainer::getTwig();
 echo $twig->render('patient/demographics/relation_form.html.twig', $templateVars);

--- a/library/templates/telecom_display.php
+++ b/library/templates/telecom_display.php
@@ -12,8 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-use OpenEMR\Common\Twig\TwigContainer;
-use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Services\ContactService;
 use OpenEMR\Services\ContactTelecomService;
 
@@ -61,6 +60,5 @@ $templateVars = [
     'has_telecoms' => !empty($telecoms)
 ];
 // Render Twig template
-$twigContainer = new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel());
-$twig = $twigContainer->getTwig();
+$twig = ServiceContainer::getTwig();
 echo $twig->render('patient/demographics/telecom_display.html.twig', $templateVars);

--- a/library/templates/telecom_form.php
+++ b/library/templates/telecom_form.php
@@ -12,7 +12,7 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\ContactService;
 use OpenEMR\Services\ContactTelecomService;
@@ -87,6 +87,5 @@ $templateVars = [
 ];
 
 // Render Twig template
-$twigContainer = new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel());
-$twig = $twigContainer->getTwig();
+$twig = ServiceContainer::getTwig();
 echo $twig->render('patient/demographics/telecom_form.html.twig', $templateVars);

--- a/portal/account/account.lib.php
+++ b/portal/account/account.lib.php
@@ -23,7 +23,6 @@ use OpenEMR\Common\Crypto\CryptoGenException;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Common\Utils\RandomGenUtils;
 use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Core\OEGlobalsBag;
@@ -116,8 +115,7 @@ function verifyEmail(string $languageChoice, string $fname, string $mname, strin
         ServiceContainer::getLogger()->debug("verifyEmail function is using a email that failed validEmail test, so can not use");
         return true;
     }
-    $twigContainer = new TwigContainer(null, $globalsBag->getKernel());
-    $twig = $twigContainer->getTwig();
+    $twig = ServiceContainer::getTwig();
     $templateData = [];
     $template = 'verify-failed';
     $emailPrepSend = false;
@@ -433,8 +431,7 @@ function doCredentials($pid, $resetPass = false, $resetPassEmail = ''): bool
         }
     }
 
-    $twigContainer = new TwigContainer(null, $globalsBag->getKernel());
-    $twig = $twigContainer->getTwig();
+    $twig = ServiceContainer::getTwig();
     $fhirServerConfig = new ServerConfig();
 
     $data = [

--- a/portal/account/index_reset.php
+++ b/portal/account/index_reset.php
@@ -12,11 +12,11 @@
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Auth\AuthHash;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 
 $ignoreAuth_onsite_portal = $ignoreAuth = false;

--- a/portal/account/index_reset.php
+++ b/portal/account/index_reset.php
@@ -16,7 +16,7 @@ use OpenEMR\Common\Auth\AuthHash;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 
 $ignoreAuth_onsite_portal = $ignoreAuth = false;
@@ -115,7 +115,7 @@ $vars = [
     ,'isSaved' => $isSaved
 ];
 try {
-    echo (new TwigContainer(null, $globalsBag->getKernel()))->getTwig()->render("portal/portal-credentials-settings.html.twig", $vars);
+    echo ServiceContainer::getTwig()->render("portal/portal-credentials-settings.html.twig", $vars);
 } catch (\Throwable $exception) {
     (new \OpenEMR\Common\Logging\SystemLogger())->error($exception->getMessage(), ['exception' => $exception]);
     die(xlt("Failed to render twig file"));

--- a/portal/account/register.php
+++ b/portal/account/register.php
@@ -16,7 +16,6 @@
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
@@ -63,7 +62,7 @@ $data = [
 ];
 
 // Render Register Twig template
-$twig = (new TwigContainer(null, $globalsBag->getKernel()))->getTwig();
+$twig = ServiceContainer::getTwig();
 try {
     echo $twig->render('portal/registration/portal_register.html.twig', $data);
 } catch (LoaderError | SyntaxError | RuntimeError $e) {

--- a/portal/home.php
+++ b/portal/home.php
@@ -20,7 +20,6 @@ use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\PatientPortal\AppointmentFilterEvent;
 use OpenEMR\Events\PatientPortal\RenderEvent;
@@ -343,7 +342,7 @@ $styleArray = collectStyles();
 $isTelemetryAllowed = (new TelemetryService())->isTelemetryEnabled();
 
 // Render Home Page
-$twig = (new TwigContainer('', $globalsBag->getKernel()))->getTwig();
+$twig = ServiceContainer::getTwig();
 try {
     $healthSnapshot = [
         'immunizationRecords' => $immunRecords,

--- a/portal/index.php
+++ b/portal/index.php
@@ -31,7 +31,6 @@ use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Session\SessionUtil;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Common\Utils\RandomGenUtils;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
@@ -110,8 +109,7 @@ if (!empty($_REQUEST['service_auth'] ?? null)) {
         $ot = $oneTime->decodePortalOneTime($token, logUpdate: false);
         $pin_required = $ot['actions']['enforce_auth_pin'] ? 1 : 0;
         CsrfUtils::setupCsrfKey($session);
-        $twig = new TwigContainer(null, $globalsBag->getKernel());
-        echo $twig->getTwig()->render('portal/login/autologin.html.twig', [
+        echo ServiceContainer::getTwig()->render('portal/login/autologin.html.twig', [
             'action' => $globalsBag->getString('web_root') . '/portal/index.php',
             'service_auth' => text($_GET['service_auth']),
             'csrf_token' => CsrfUtils::collectCsrfToken($session, 'autologin'),

--- a/portal/portal_payment.php
+++ b/portal/portal_payment.php
@@ -23,7 +23,6 @@ use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Common\Utils\FormatMoney;
 use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Core\OEGlobalsBag;
@@ -74,7 +73,7 @@ require_once("../custom/code_types.inc.php");
 require_once("$srcdir/options.inc.php");
 require_once("$srcdir/encounter_events.inc.php");
 
-$twig = (new TwigContainer(null, $globalsBag->getKernel()))->getTwig();
+$twig = ServiceContainer::getTwig();
 
 $cryptoGen = ServiceContainer::getCrypto();
 

--- a/portal/report/portal_patient_report.php
+++ b/portal/report/portal_patient_report.php
@@ -16,7 +16,6 @@
 
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Controllers\Portal\PortalPatientReportController;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\PatientReport\PatientReportFilterEvent;
@@ -61,7 +60,7 @@ $auth_demo = true; //AclMain::aclCheckCore('patients'  , 'demo');
 $ignoreAuth_onsite_portal = true;
 
 $portalPatientReportController = new PortalPatientReportController();
-$twig = (new TwigContainer(null, $globalsBag->getKernel()))->getTwig();
+$twig = ServiceContainer::getTwig();
 
 $issues = [];
 $data = [];

--- a/portal/sign/assets/signer_modal.php
+++ b/portal/sign/assets/signer_modal.php
@@ -12,7 +12,6 @@
 
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Core\OEGlobalsBag;
 
 // this script is used by both the patient portal and main openemr; below does authorization.
@@ -54,7 +53,7 @@ $twigVars = [
     ,'cpid' => $cpid
     ,'aud' => $is_portal ? $aud = 'patient-signature' : $aud
 ];
-$twigContainer = (new TwigContainer(null, $globalsBag->getKernel()))->getTwig();
+$twigContainer = ServiceContainer::getTwig();
 try {
     $modal = $twigContainer->render("portal/partial/_signer_modal.html.twig", $twigVars);
 } catch (\Throwable $exception) {

--- a/src/Controllers/Interface/Forms/Observation/ObservationController.php
+++ b/src/Controllers/Interface/Forms/Observation/ObservationController.php
@@ -14,12 +14,12 @@
 namespace OpenEMR\Controllers\Interface\Forms\Observation;
 
 use InvalidArgumentException;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Forms\ReasonStatusCodes;
 use OpenEMR\Common\Logging\SystemLoggerAwareTrait;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\FHIR\Config\ServerConfig;

--- a/src/Controllers/Interface/Forms/Observation/ObservationController.php
+++ b/src/Controllers/Interface/Forms/Observation/ObservationController.php
@@ -19,7 +19,7 @@ use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Forms\ReasonStatusCodes;
 use OpenEMR\Common\Logging\SystemLoggerAwareTrait;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\FHIR\Config\ServerConfig;
@@ -51,7 +51,7 @@ class ObservationController
         ?Environment $twig = null,
         private ?PatientService $patientService = new PatientService()
     ) {
-        $this->twig = $twig ?? (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->getTwig();
+        $this->twig = $twig ?? ServiceContainer::getTwig();
         $this->codeTypeService = new CodeTypesService();
     }
 

--- a/src/FHIR/SMART/ClientAdminController.php
+++ b/src/FHIR/SMART/ClientAdminController.php
@@ -26,7 +26,6 @@ use OpenEMR\Common\Auth\OpenIDConnect\Repositories\RefreshTokenRepository;
 use OpenEMR\Common\Csrf\CsrfInvalidException;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Logging\SystemLoggerAwareTrait;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Core\Kernel;
 use OpenEMR\Core\OEGlobalsBag;
@@ -77,7 +76,7 @@ class ClientAdminController
     {
         $this->kernel = $this->globalsBag->getKernel();
         $this->actionUrlBuilder = new ActionUrlBuilder($this->session, $this->actionURL, self::CSRF_TOKEN_NAME);
-        $this->twig = (new TwigContainer(null, $this->kernel))->getTwig();
+        $this->twig = ServiceContainer::getTwig();
         $this->webroot = $this->globalsBag->getKernel()->getWebRoot();
     }
 

--- a/src/FHIR/SMART/SmartLaunchController.php
+++ b/src/FHIR/SMART/SmartLaunchController.php
@@ -22,7 +22,7 @@ use OpenEMR\Common\Csrf\CsrfInvalidException;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\PatientDemographics\RenderEvent;
@@ -94,7 +94,7 @@ class SmartLaunchController
                         'intent' => SMARTLaunchToken::INTENT_PATIENT_DEMOGRAPHICS_DIALOG
             ];
 
-            $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->getTwig();
+            $twig = ServiceContainer::getTwig();
             echo $twig->render("patient/card/smart_launch.html.twig", $viewArgs);
             $this->renderLaunchScript();
     }

--- a/src/FHIR/SMART/SmartLaunchController.php
+++ b/src/FHIR/SMART/SmartLaunchController.php
@@ -14,6 +14,7 @@
 
 namespace OpenEMR\FHIR\SMART;
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Acl\AccessDeniedException;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Auth\OpenIDConnect\Entities\ClientEntity;
@@ -22,7 +23,6 @@ use OpenEMR\Common\Csrf\CsrfInvalidException;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\PatientDemographics\RenderEvent;

--- a/src/OeUI/OemrUI.php
+++ b/src/OeUI/OemrUI.php
@@ -12,9 +12,9 @@
 
 namespace OpenEMR\OeUI;
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\UserInterface\BaseActionButtonHelper;

--- a/src/OeUI/OemrUI.php
+++ b/src/OeUI/OemrUI.php
@@ -14,7 +14,7 @@ namespace OpenEMR\OeUI;
 
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Events\UserInterface\BaseActionButtonHelper;
@@ -103,8 +103,7 @@ class OemrUI
 
         $kernel = OEGlobalsBag::getInstance()->getKernel();
         $this->ed = $kernel->getEventDispatcher();
-        $twigContainer = new TwigContainer(null, $kernel);
-        $this->twig = $twigContainer->getTwig();
+        $this->twig = ServiceContainer::getTwig();
 
         if ($this->expandable) {
             $this->ed->addListener(PageHeadingRenderEvent::EVENT_PAGE_HEADING_RENDER, $this->expandIconListener(...));

--- a/src/Services/Cda/CdaValidateDocuments.php
+++ b/src/Services/Cda/CdaValidateDocuments.php
@@ -17,7 +17,7 @@ use DOMDocument;
 use Exception;
 use OpenEMR\Common\Logging\SystemLoggerAwareTrait;
 use OpenEMR\Common\System\System;
-use OpenEMR\Common\Twig\TwigContainer;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 
 class CdaValidateDocuments
@@ -328,7 +328,7 @@ class CdaValidateDocuments
         $errors = $this->fetchValidationLog($amid);
 
         if (count($errors ?? [])) {
-            $twig = (new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->getTwig();
+            $twig = ServiceContainer::getTwig();
             $html = $twig->render("carecoordination/cda/cda-validate-results.html.twig", ['validation' => $errors]);
         } else {
             $html = xlt("No Errors or Validation service is disabled in Admin Config Connectors 'Disable All CDA Validation Reporting'.");

--- a/src/Services/Cda/CdaValidateDocuments.php
+++ b/src/Services/Cda/CdaValidateDocuments.php
@@ -15,9 +15,9 @@ namespace OpenEMR\Services\Cda;
 use CURLFile;
 use DOMDocument;
 use Exception;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Logging\SystemLoggerAwareTrait;
 use OpenEMR\Common\System\System;
-use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 
 class CdaValidateDocuments

--- a/src/Services/PatientAccessOnsiteService.php
+++ b/src/Services/PatientAccessOnsiteService.php
@@ -28,7 +28,6 @@ use OpenEMR\Common\Auth\AuthHash;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Logging\EventAuditLogger;
 use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Common\Twig\TwigContainer;
 use OpenEMR\Common\Utils\RandomGenUtils;
 use OpenEMR\Common\Utils\ValidationUtils;
 use OpenEMR\Core\Kernel;
@@ -62,7 +61,7 @@ class PatientAccessOnsiteService
         $this->authUser = $session->get('authUser');
         $this->authProvider = $session->get('authProvider');
         $this->kernel = OEGlobalsBag::getInstance()->getKernel();
-        $this->twig = (new TwigContainer(null, $this->kernel))->getTwig();
+        $this->twig = ServiceContainer::getTwig();
         $this->logger = $logger ?? ServiceContainer::getLogger();
     }
 


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Sweeps the `(new TwigContainer(null, OEGlobalsBag::getInstance()->getKernel()))->getTwig()` boilerplate off ~44 call sites across `library/`, `interface/`, `portal/`, `src/`, and `ccr/`, replacing each with `ServiceContainer::getTwig()`. Every migrated site was already using the default `/templates` root — callers that pass a custom template path stay on `new TwigContainer($path, $kernel)` and are not touched.

Baseline shrinks by roughly 50 entries. Net -259 LOC.

#### Two default-path sites intentionally deferred to a follow-up:

- `src/PostCalendar/CalendarRenderer::create()` calls `$twig->addExtension(new PostCalendarTwigExtension())` on the resolved environment. Registering the same extension twice throws in Twig, so switching to the shared, memoized instance would break on the second `create()` call. Needs a small refactor to register the extension via a `TwigEnvironmentEvent` listener at bootstrap instead.
- `interface/patient_file/summary/demographics.php` uses `$twig` as a `TwigContainer` (not an `Environment`) across ~24 `$twig->getTwig()->render(...)` sites and passes it into `PatientMenuRole`. Same mechanical migration, but the surface area drowns this PR — worth its own review.

#### Notable behavior change on `interface/main/about_page.php`, `interface/patient_file/summary/dashboard_header.php`, and `interface/main/holidays/import_holidays.php`:

These three previously used the no-arg `new TwigContainer()`, which builds an env with **no kernel** — so it fires no `TwigEnvironmentEvent`, registers no dev-mode debug extension, and misses any module-supplied filters or functions. Switching them to `ServiceContainer::getTwig()` gives them the fully-wired shared env like everything else. This is the correct behavior; there is no reason those three pages should have been running against a kernel-less env. Flagging in case it turns up a template that was silently relying on a missing filter falling through.

#### Was an AI assistant used? Yes

Body drafted by Claude Code, reviewed by a human.
