### PR TITLE
fix(deleter): enhance form deletion logic for clinical notes

### DIFF
--- a/interface/patient_file/deleter.php
+++ b/interface/patient_file/deleter.php
@@ -173,7 +173,10 @@ function form_delete($formdir, $formid, $patient_id, $encounter_id): void
         }
         deleter_row_delete("form_eye_mag_impplan", "form_id = ?", [$formid]);
         deleter_row_delete("form_eye_mag_wearing", "FORM_ID = ?", [$formid]);
-    } else {
+    }else if ($formdir == 'clinical_notes') {
+        deleter_row_delete("form_clinical_notes", "form_id = '" . add_escape_custom($formid) . "'");
+    }
+    else {
         deleter_row_delete("form_$formdir", "id = ?", [$formid]);
     }
 }


### PR DESCRIPTION
Updated the form_delete function to handle deletion of clinical notes specifically when the form directory is 'clinical_notes'. This change ensures that the correct database table is targeted for deletion based on the form directory, improving the accuracy of the deletion process.

<!--
Thanks for sending a pull request!

Your PR title must follow Conventional Commits: type(scope): description
Examples: feat(api): add patient search, fix(calendar): correct date parsing
See CONTRIBUTING.md for details

Please provide context about the nature of your change so that reviewers understand the motivation and we can generate changelogs.

If this resolves an existing issue, link to one or more issues in the short description section, e.g. `Fixes #12345`.

-->

#### Short description of what this changes or resolves:


#### Changes proposed in this pull request:


#### Was an AI assistant used? Yes / No

<!--
If yes, add an `Assisted-by` trailer to each commit that used AI assistance:

```
git commit --trailer "Assisted-by: Claude Code" -m "fix(calendar): correct date parsing"
```

Use the name of the specific tool (e.g. `GitHub Copilot`, `Claude Code`, `ChatGPT`).
If the AI made the commit(s), this trailer was probably added automatically.
-->
