### PR TITLE
ci(dependabot): ungroup phpstan and rector so each bumps solo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,11 +28,17 @@ updates:
       update-types:
       - minor
       - patch
+    # phpstan/* and rector/rector are deliberately absent, so each gets its
+    # own PR. A static-analyzer bump is never just a lock change: PHPStan
+    # sharpens inference and invalidates baseline entries, Rector shuffles
+    # rules between sets and rewrites source. Grouped with phpunit, that
+    # fallout arrives as one PR nobody can review or revert in pieces --
+    # 2.6.x pulled ExplicitPublicClassMethodRector into withPhpSets() and
+    # touched over a thousand files. Solo PRs keep each analyzer's fallout
+    # attributable to the bump that caused it.
     development:
       patterns:
       - phpunit/*
-      - phpstan/*
-      - rector/rector
       - shipmonk/*
       - friendsofphp/*
       update-types:


### PR DESCRIPTION
Removes `phpstan/*` and `rector/rector` from the composer `development` Dependabot group so each bumps in its own PR.

### Why

A static-analyzer bump is never just a lock change. PHPStan sharpens inference between patch releases, which invalidates baseline entries and forces a regeneration. Rector shuffles rules between sets, which rewrites source.

Grouped with `phpunit/*`, that fallout arrives as one PR that can't be reviewed or reverted in pieces. #13450 is the live example: rector 2.6.x pulled `ExplicitPublicClassMethodRector` into `withPhpSets()` and rewrote over a thousand files, bundled with an unrelated phpstan patch bump. Splitting it by hand was the only way to get a reviewable change.

Dropping the patterns doesn't stop the updates — ungrouped dependencies still get PRs, just individually. The fallout then stays attributable to the bump that caused it, and a bad analyzer release can be held without also holding phpunit.

`phpstan/*` covers all five installed phpstan packages (`phpstan`, `extension-installer`, `phpstan-deprecation-rules`, `phpstan-phpunit`, `phpstan-strict-rules`); the extension packages shift analysis output the same way the analyzer does.

### Left alone

`shipmonk/phpstan-baseline-per-identifier` stays in the group. It's a PHPStan extension and it owns the baseline file layout, so arguably it belongs with the analyzers — flagging it rather than deciding unilaterally.

`friendsofphp/*` no longer matches anything in `require-dev` and is dead config; left in place to keep this diff to one concern.
