### PR TITLE
fix(logging): default audit_events_query to off, document as ONC-required

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -2814,8 +2814,10 @@ $GLOBALS_METADATA = [
         'audit_events_query' => [
             xl('Audit Logging SELECT Query'),
             'bool',                           // data type
-            '1',                              // default
+            '0',                              // default off; enable for ONC certified deployments
             xl('Enable logging of all SQL SELECT queries.') . ' (' . xl('Note that Audit Logging needs to be enabled above') . ')'
+                . ' ' . xl('Required for ONC certified deployments.')
+                . ' ' . xl('Warning: this logs every SELECT, so the audit log grows with query volume and can become far larger than the clinical data it describes.')
         ],
 
         'audit_events_cdr' => [


### PR DESCRIPTION
# Default `audit_events_query` to off; document it as an ONC-required setting

## What this changes

`library/globals.inc.php` — the default for `audit_events_query` ("Audit Logging
SELECT Query") changes from `'1'` to `'0'`, and the help text gains a note that the
setting is required for certified deployments plus a warning about how it grows.

```diff
         'audit_events_query' => [
             xl('Audit Logging SELECT Query'),
             'bool',                           // data type
-            '1',                              // default
+            '0',                              // default off; enable for ONC certified deployments
             xl('Enable logging of all SQL SELECT queries.') . ' (' . xl('Note that Audit Logging needs to be enabled above') . ')'
+                . ' ' . xl('Required for ONC certified deployments.')
+                . ' ' . xl('Warning: this logs every SELECT rather than each record access, so the audit log grows with query volume and can become far larger than the clinical data it describes.')
         ],
```

The setting, its label, and the code path behind it are otherwise untouched. Two
new translatable strings are introduced.

## Why

`audit_events_query` writes an audit row for every SQL `SELECT` issued against
patient tables. Because a single chart view issues many such queries, the row
count scales with query volume rather than with clinical activity.

Measured on a production ambulatory deployment with **13,517 encounters** and
**~200 MB of clinical data**:

| Table | Size | Rows |
| --- | --- | --- |
| `log` | 21.91 GB | 48,553,072 |
| `log_comment_encrypt` | 7.25 GB | 48,405,676 |

Event distribution over the most recent 200,000 rows:

| event | count | share |
| --- | --- | --- |
| `patient-record-select` | 158,256 | 79.1% |
| `security-administration-select` | 27,430 | 13.7% |
| `scheduling-select` | 5,956 | 3.0% |
| `http-request-update` | 4,496 | 2.2% |
| `http-request-select` | 2,742 | 1.4% |
| all others | 1,120 | 0.6% |

So the audit log was roughly **150× the size of the clinical data it describes**,
and `-select` events generated by this setting accounted for ~96% of it.

Growth rate was accelerating, since it tracks concurrent usage rather than record
count:

| id range | period | elapsed |
| --- | --- | --- |
| 1 → 10 M | Jan 2024 → Apr 2025 | ~15.5 months |
| 10 M → 20 M | Apr 2025 → Nov 2025 | ~6.5 months |
| 20 M → 30 M | Nov 2025 → Mar 2026 | ~4.3 months |
| 30 M → 40 M | Mar 2026 → Jun 2026 | ~2.9 months |
| 40 M → 48 M | Jun 2026 → Aug 2026 | ~2.1 months |

At the point of measurement: ~125,000 rows/day, ~2.5 GB/month. Setting
`audit_events_query = 0` on that instance dropped the rate to roughly 1 row/minute
— a >98% reduction — with no other change.

### The part that makes this more than a performance issue

`utilities/xbackup.sh`, used by the appliance and legacy cloud deployments,
refuses to run when the dataset exceeds available disk:

```
xbackup INFO: Checking disk space ... (data: 34917560) (disk: 18377404)
xbackup ERROR: Insufficient space on backup directory!
```

On the instance above, audit growth pushed the database to 34 GB and the backup
job began failing this preflight. **The audit-log default had made the database
unbackupable by the tooling shipped alongside it.** A logical dump excluding the
two audit tables was 17 MB.

That is a direct conflict between two obligations a covered entity has: audit
controls under 45 CFR §164.312(b), and a data backup plan under §164.308(a)(7)(ii)(A).
Nothing in either requires per-`SELECT` logging, but the current default makes the
first defeat the second at modest scale.

## Why off is the right default

Per-`SELECT` logging is a capability some deployments want and most do not.
Deployments operating OpenEMR as a certified EHR should enable it; the majority of
installs — practices not attesting to any program, evaluation instances, self-hosted
single-provider setups — inherit tens of millions of rows they never asked for and
will never read.

This is already how the project handles other certification-dependent settings.
[OpenEMR ONC Ambulatory EHR Certification Requirements][wiki] lists settings a
certified deployment must turn on:

- `Admin → Config → Security → Hash Algorithm for Authentication → SHA512`
- `Admin → Config → Connectors → Enable OpenEMR Standard FHIR REST API → On`

Both default to off in code and are documented as required for certification. This
PR makes `audit_events_query` consistent with that pattern rather than introducing a
new one.

The wiki page currently approaches it from the opposite direction, under
"For users NOT NEEDING ONC certification":

- `Admin → Config → Logging → Audit Logging SELECT Query → Off`
- `Admin → Config → Logging → Printing Log Option → No logging`

A companion wiki edit moves both into the Requirements list alongside SHA512 and
the FHIR API, and removes the conditional paragraph. **That edit should land first
or alongside this PR** so the default change is not read as reducing certification
support. The page is protected; the change is being made by a maintainer with edit
rights.

## Upgrade behavior

**Existing deployments are unaffected. This changes behavior for new
installations only.**

`sql/database.sql` creates the `globals` table but contains no `INSERT INTO
globals` statements. Rows are populated by the backfill loop in `sql_upgrade.php`
(and the equivalent in `sql_patch.php`), which inserts a default **only where no
row already exists**:

```php
$row = sqlQuery("SELECT count(*) AS count FROM globals WHERE gl_name = '$fldid'");
if (empty($row['count'])) {
    sqlStatement("INSERT INTO globals ( gl_name, gl_index, gl_value ) " .
        "VALUES ( '$fldid', '0', '$flddef' )");
}
```

There is no `ON DUPLICATE KEY UPDATE` and no `REPLACE`, so a stored value always
wins over the declared default. Any deployment that has been through an upgrade
already holds a row for `audit_events_query` — a sample instance carries 536 of
the ~540 defined globals — and will keep its current value.

Consequently:

- No existing site loses audit coverage, and no migration is required.
- Certified deployments keep `audit_events_query = 1` with no action.
- New installations get the setting off, and enable it per the wiki Requirements
  list if they need it.

The corollary is that this PR does **not** remediate existing deployments; the
companion wiki edit is what reaches those, by making the setting an explicit,
documented choice rather than an unexamined default. Both changes are needed.

### A related pattern worth noting

Because that loop inserts newly added globals at their declared default,
**introducing a global with default `'1'` silently enables new behavior on every
deployment at the next upgrade or patch**, with no administrator action.

This has already happened once: `audit_events_http-request` was added to
`globals.inc.php` with default `'1'` in a 7.0.3 patch release
(`$v_realpatch = '4'`), and the backfill in `sql_patch.php` then turned HTTP
request logging on fleet-wide. It is worth being deliberate about defaults for any
new global that writes to `log`.

## Testing

- New install: confirm `audit_events_query` is unchecked in
 Admin → Config → Logging, and that no `-select` events appear in `log`
  during normal use.
- Enable the setting: confirm `-select` events resume.
- Existing install with a stored `1`: confirm the setting remains enabled after
  upgrade.
- Confirm the other audit categories (`patient-record`, `order`, `lab-results`,
  `scheduling`, `security-administration`, `other`) are unaffected — record
  additions, changes, deletions, logins, and e-sign events continue to be logged.

## Related, not included here

Filed separately to keep this change reviewable:

- **`gbl_print_log_option` defaults to `2` ("Log entire document"),** storing full
  printed document content in `log`. Same class of change; belongs in the same wiki
  Requirements list.
- **Internal bookkeeping writes are logged in full.** `INSERT INTO recent_patients`
  — a serialized 50-entry recently-viewed-charts array — is logged at ~4.1 KB per
  chart view under `other-insert`, as is `clinical_rules_log`'s own insert at ~892
  bytes. These are not PHI records and arguably should be excluded from audit
  logging, or long statement payloads truncated.
- **`audit_events_http-request`** (added in a 7.0.3 patch release with default `'1'`)
  logs a row per HTTP request, including the application's own AJAX polling of
  `execute_background_services.php` and `dated_reminders_counter.php`. Low volume by
  bytes, but it scales with concurrent sessions and records no user action.

[wiki]: https://www.open-emr.org/wiki/index.php/OpenEMR_ONC_Ambulatory_EHR_Certification_Requirements

Assisted-by: Claude (claude.ai)