### PR TITLE
fix(acceptance): decouple version-assertion source from TO_VERSION label

### DIFF
--- a/.github/scripts/detect-acceptance-mode.sh
+++ b/.github/scripts/detect-acceptance-mode.sh
@@ -51,6 +51,21 @@
 #   build_locally=<true|false>
 #   to_version=<X.Y.Z>
 #   from_version=<X.Y.Z>
+#   expected_version=<X.Y.Z>   version the running artifact will
+#                              self-report post-install/post-upgrade.
+#                              Equals to_version on the shipped-tarball
+#                              path (label = actual). On the build_locally
+#                              path the to_version label is cosmetic
+#                              (99.99.99 default; PackageAssembler does
+#                              not bake --release-version into
+#                              version.php), so the label cannot equal
+#                              the value sql_upgrade.php writes to the
+#                              DB. expected_version reads the checkout's
+#                              version.php in that case so the
+#                              acceptance version-display / version-api
+#                              groups (ACCEPTANCE_EXPECTED_VERSION) can
+#                              compare against something that actually
+#                              matches. See openemr/openemr#13753.
 #
 # Exit codes
 #   0   Decision emitted successfully.
@@ -67,6 +82,11 @@
 # assigned" check can't see the workflow-side origin.
 
 set -euo pipefail
+
+# Last to_version resolved by emit_to_version. emit_expected_version
+# reads this on the non-build_locally path so the "expected" value
+# tracks the same label the acceptance job's TO_VERSION env sees.
+LAST_RESOLVED_TO_VERSION=""
 
 # emit_to_version <build_locally> [<preferred_version>] —
 # resolves the to_version from dispatch input first, then the
@@ -92,8 +112,88 @@ emit_to_version() {
         echo "::error::resolved to_version '${candidate}' does not match required X.Y.Z"
         exit 1
     fi
+    LAST_RESOLVED_TO_VERSION="${candidate}"
     echo "to_version=${candidate}" >> "${GITHUB_OUTPUT}"
     echo "==> resolved to_version=${candidate}"
+}
+
+# read_tree_version — extracts the shipped self-reported version from
+# the checkout's `version.php` (repo root). Emits X.Y.Z on stdout;
+# exits 1 with an ::error:: line if the file is missing or any of the
+# three components can't be parsed.
+#
+# PackageAssembler ships version.php as-is from the checked-out ref
+# (documented in tools/release/bin/package-assemble.php), so on the
+# build_locally acceptance path this is what the DB `version` table
+# will hold post-install / post-upgrade. Used only by
+# emit_expected_version — see its docstring for the full rationale.
+#
+# Uses awk (not PHP): the detect-mode job runs on ubuntu-24.04 without
+# an apt install of php, and the parse is trivial.
+read_tree_version() {
+    local file="version.php"
+    if [[ ! -r "${file}" ]]; then
+        # `|| true` on the pwd capture to satisfy SC2312 — pwd can't
+        # fail meaningfully here, but the linter can't prove that.
+        local cwd
+        cwd=$(pwd || true)
+        echo "::error::read_tree_version: cannot read ${file} from ${cwd}" >&2
+        return 1
+    fi
+    local major minor patch
+    # Each line looks like: $v_major = '8';
+    # Match: $v_(major|minor|patch)  =  '<digits>' ;
+    major=$(awk -F"'" '/^\$v_major *=/ { print $2; exit }' "${file}")
+    minor=$(awk -F"'" '/^\$v_minor *=/ { print $2; exit }' "${file}")
+    patch=$(awk -F"'" '/^\$v_patch *=/ { print $2; exit }' "${file}")
+    if [[ -z "${major}" || -z "${minor}" || -z "${patch}" ]]; then
+        echo "::error::read_tree_version: failed to parse \$v_major/\$v_minor/\$v_patch from ${file} (got major='${major}' minor='${minor}' patch='${patch}')" >&2
+        return 1
+    fi
+    printf '%s.%s.%s' "${major}" "${minor}" "${patch}"
+}
+
+# emit_expected_version <build_locally> —
+# resolves the version the running artifact will actually self-report
+# post-install/post-upgrade. On the non-build_locally path this equals
+# the just-emitted to_version (label = actual, since a shipped tarball
+# has --release-version baked in). On build_locally=true the label is
+# cosmetic (see the emit_to_version 99.99.99 default) — the shipped
+# self-reported version is whatever version.php in the checkout says,
+# which is what sql_upgrade.php writes into the DB `version` table.
+# Two mutually-exclusive assumptions used to collide here:
+#   - PackageAssembler docs `--release-version` as "naming label only,
+#     not baked in" (staging dir + tarball filename)
+#   - #13635 added assertions asserting the label equals the DB value
+# Which meant build_locally acceptance runs could never pass the
+# post-install/post-upgrade version-display / version-api groups.
+# See openemr/openemr#13753 for the failure trace + rationale.
+#
+# Must be called AFTER emit_to_version so LAST_RESOLVED_TO_VERSION
+# is populated for the else branch. Shape-validates the result for
+# the same defense-in-depth reason as emit_to_version.
+emit_expected_version() {
+    local build_locally="$1"
+    local candidate
+    if [[ "${build_locally}" == "true" ]]; then
+        # Same SC2310 pattern used at emit_from_version's
+        # derive_from_version call — read_tree_version's failure modes
+        # are explicit `return 1` after emitting an ::error:: line, so
+        # the disabled `set -e` inside the function doesn't mask
+        # anything the `if !` guard doesn't already catch.
+        # shellcheck disable=SC2310
+        if ! candidate=$(read_tree_version); then
+            exit 1
+        fi
+    else
+        candidate="${LAST_RESOLVED_TO_VERSION}"
+    fi
+    if [[ ! "${candidate}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "::error::resolved expected_version '${candidate}' does not match required X.Y.Z" >&2
+        exit 1
+    fi
+    echo "expected_version=${candidate}" >> "${GITHUB_OUTPUT}"
+    echo "==> resolved expected_version=${candidate}"
 }
 
 # SHIPPED_VERSIONS_MANIFEST_URL — canonical location of the openemr
@@ -318,6 +418,7 @@ if [[ -n "${CALLER_TARBALL_ARTIFACT}" || -n "${CALLER_ZIP_ARTIFACT}" ]]; then
     echo "==> workflow_call gate mode (tarball=${CALLER_TARBALL_ARTIFACT}, zip=${CALLER_ZIP_ARTIFACT}): forcing build_locally=true"
     echo "build_locally=true" >> "${GITHUB_OUTPUT}"
     emit_to_version "true"
+    emit_expected_version "true"
     emit_from_version
     exit 0
 fi
@@ -376,6 +477,7 @@ if [[ "${HEAD_REF}" == release-prep/* ]]; then
         echo "==> parsed release version from PR title: ${preferred}"
     fi
     emit_to_version "true" "${preferred}"
+    emit_expected_version "true"
     emit_from_version
     exit 0
 fi
@@ -385,6 +487,7 @@ if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
     echo "build_locally=${DISPATCH_BUILD_LOCALLY}" >> "${GITHUB_OUTPUT}"
     echo "==> dispatch mode: build_locally=${DISPATCH_BUILD_LOCALLY}"
     emit_to_version "${DISPATCH_BUILD_LOCALLY}"
+    emit_expected_version "${DISPATCH_BUILD_LOCALLY}"
     emit_from_version
     exit 0
 fi
@@ -396,6 +499,7 @@ case "${EVENT_NAME}" in
         echo "==> ${EVENT_NAME} event: defaulting build_locally=false"
         echo "build_locally=false" >> "${GITHUB_OUTPUT}"
         emit_to_version "false"
+        emit_expected_version "false"
         emit_from_version
         exit 0
         ;;
@@ -405,6 +509,7 @@ if [[ -z "${BASE}" || "${BASE}" == "0000000000000000000000000000000000000000" ]]
     echo "==> branch-creation event (no base ref): defaulting build_locally=false"
     echo "build_locally=false" >> "${GITHUB_OUTPUT}"
     emit_to_version "false"
+    emit_expected_version "false"
     emit_from_version
     exit 0
 fi
@@ -435,6 +540,7 @@ if ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
         fi
         echo "build_locally=false" >> "${GITHUB_OUTPUT}"
         emit_to_version "false"
+        emit_expected_version "false"
         emit_from_version
         exit 0
     fi
@@ -460,10 +566,12 @@ if grep -qE '^(tools/release/|build\.xml$|\.gitattributes$)' <<< "${changed_file
     echo "==> tarball-build surface changed between ${BASE} and ${HEAD}: build_locally=true"
     echo "build_locally=true" >> "${GITHUB_OUTPUT}"
     emit_to_version "true"
+    emit_expected_version "true"
     emit_from_version
 else
     echo "==> tarball-build surface unchanged between ${BASE} and ${HEAD}: build_locally=false"
     echo "build_locally=false" >> "${GITHUB_OUTPUT}"
     emit_to_version "false"
+    emit_expected_version "false"
     emit_from_version
 fi

--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -198,6 +198,19 @@ jobs:
       # resulting version is guaranteed to be in the branch's
       # sql_upgrade.php wizard dropdown (openemr/openemr#13573).
       from_version: ${{ steps.decide.outputs.from_version }}
+      # expected_version is the version the running artifact will
+      # self-report post-install/post-upgrade (i.e. what
+      # sql_upgrade.php writes to the DB `version` table), consumed
+      # via ACCEPTANCE_EXPECTED_VERSION by the version-display /
+      # version-api acceptance groups. Equals to_version on the
+      # shipped-tarball path (label = actual, since a shipped tarball
+      # has --release-version baked in). On the build_locally path
+      # the to_version label is intentionally cosmetic (99.99.99
+      # default; PackageAssembler ships the checked-out version.php
+      # as-is), so the acceptance groups must compare against the
+      # checkout's version.php value instead of the label — otherwise
+      # they can never pass. See openemr/openemr#13753.
+      expected_version: ${{ steps.decide.outputs.expected_version }}
     steps:
     - uses: actions/checkout@v7
       with:
@@ -378,6 +391,14 @@ jobs:
       # detect-mode.outputs.to_version comment for why the auto-fire
       # path resolves this to 99.99.99.
       TO_VERSION: ${{ needs.detect-mode.outputs.to_version }}
+      # Actual version the running artifact will self-report — used
+      # by ACCEPTANCE_EXPECTED_VERSION in the version-display /
+      # version-api groups below. Decoupled from TO_VERSION because
+      # on build_locally the TO_VERSION label is cosmetic (99.99.99)
+      # while sql_upgrade.php writes the checkout's version.php value
+      # into the DB `version` table. See openemr/openemr#13753 for
+      # the failure trace when these two were coupled.
+      EXPECTED_VERSION: ${{ needs.detect-mode.outputs.expected_version }}
       ACCEPTANCE_ARTIFACT_URL: http://localhost:8680
     name: ${{ matrix.scenario }} (${{ matrix.format }})
     steps:
@@ -550,16 +571,19 @@ jobs:
       if: matrix.scenario == 'fresh-install'
       run: composer acceptance -- --group=fresh-install
 
-    # Version-display check: About page shows TO_VERSION. Own group
-    # (not piggybacking fresh-install) so this doesn't leak into
+    # Version-display check: About page shows EXPECTED_VERSION. Own
+    # group (not piggybacking fresh-install) so this doesn't leak into
     # acceptance-docker.yml — that workflow uses floating tags
     # (`latest`, `next`) and doesn't resolve them into X.Y.Z at
     # runtime, so it can't set ACCEPTANCE_EXPECTED_VERSION. See
     # openemr/openemr#13634 for the full signal-source rationale.
-    - name: Run version-display check (fresh-install, expect ${{ env.TO_VERSION }})
+    # EXPECTED_VERSION rather than TO_VERSION because the label and
+    # the shipped self-reported version diverge on build_locally
+    # (label=99.99.99, tree=version.php); see openemr/openemr#13753.
+    - name: Run version-display check (fresh-install, expect ${{ env.EXPECTED_VERSION }})
       if: matrix.scenario == 'fresh-install'
       env:
-        ACCEPTANCE_EXPECTED_VERSION: ${{ env.TO_VERSION }}
+        ACCEPTANCE_EXPECTED_VERSION: ${{ env.EXPECTED_VERSION }}
       run: composer acceptance -- --group=version-display
 
     # api-enable bootstrap fires AFTER the fresh-install group. Order
@@ -577,13 +601,13 @@ jobs:
       if: matrix.scenario == 'fresh-install'
       run: composer acceptance -- --group=api-enabled
 
-    # Version-api check: /api/version returns TO_VERSION. Own group
-    # for the same reason as version-display above (avoid leaking
-    # into acceptance-docker.yml's api-enabled invocation).
-    - name: Run version-api check (fresh-install, expect ${{ env.TO_VERSION }})
+    # Version-api check: /api/version returns EXPECTED_VERSION. Own
+    # group for the same reason as version-display above (avoid
+    # leaking into acceptance-docker.yml's api-enabled invocation).
+    - name: Run version-api check (fresh-install, expect ${{ env.EXPECTED_VERSION }})
       if: matrix.scenario == 'fresh-install'
       env:
-        ACCEPTANCE_EXPECTED_VERSION: ${{ env.TO_VERSION }}
+        ACCEPTANCE_EXPECTED_VERSION: ${{ env.EXPECTED_VERSION }}
       run: composer acceptance -- --group=version-api
 
     # ==== wizard-install scenario ====
@@ -601,10 +625,10 @@ jobs:
       if: matrix.scenario == 'wizard-install'
       run: composer acceptance -- --group=wizard-install
 
-    - name: Run version-display check (wizard-install, expect ${{ env.TO_VERSION }})
+    - name: Run version-display check (wizard-install, expect ${{ env.EXPECTED_VERSION }})
       if: matrix.scenario == 'wizard-install'
       env:
-        ACCEPTANCE_EXPECTED_VERSION: ${{ env.TO_VERSION }}
+        ACCEPTANCE_EXPECTED_VERSION: ${{ env.EXPECTED_VERSION }}
       run: composer acceptance -- --group=version-display
 
     # ==== upgrade scenario ====
@@ -638,12 +662,14 @@ jobs:
       if: matrix.scenario == 'upgrade'
       run: composer acceptance -- --group=post-upgrade
 
-    # Post-upgrade the artifact is running TO_VERSION; version-display
-    # check asserts against that.
-    - name: Run version-display check (post-upgrade, expect ${{ env.TO_VERSION }})
+    # Post-upgrade the artifact is running EXPECTED_VERSION;
+    # version-display check asserts against that. See the
+    # fresh-install version-display block above for why the label
+    # (TO_VERSION) is not the right signal on build_locally.
+    - name: Run version-display check (post-upgrade, expect ${{ env.EXPECTED_VERSION }})
       if: matrix.scenario == 'upgrade'
       env:
-        ACCEPTANCE_EXPECTED_VERSION: ${{ env.TO_VERSION }}
+        ACCEPTANCE_EXPECTED_VERSION: ${{ env.EXPECTED_VERSION }}
       run: composer acceptance -- --group=version-display
 
     # api-enable bootstrap fires AFTER post-upgrade so both the
@@ -668,10 +694,10 @@ jobs:
       if: matrix.scenario == 'upgrade'
       run: composer acceptance -- --group=api-enabled
 
-    - name: Run version-api check (post-upgrade, expect ${{ env.TO_VERSION }})
+    - name: Run version-api check (post-upgrade, expect ${{ env.EXPECTED_VERSION }})
       if: matrix.scenario == 'upgrade'
       env:
-        ACCEPTANCE_EXPECTED_VERSION: ${{ env.TO_VERSION }}
+        ACCEPTANCE_EXPECTED_VERSION: ${{ env.EXPECTED_VERSION }}
       run: composer acceptance -- --group=version-api
 
     # ==== wizard-upgrade scenario ====
@@ -694,10 +720,10 @@ jobs:
       if: matrix.scenario == 'wizard-upgrade'
       run: composer acceptance -- --group=wizard-upgrade
 
-    - name: Run version-display check (wizard-upgrade, expect ${{ env.TO_VERSION }})
+    - name: Run version-display check (wizard-upgrade, expect ${{ env.EXPECTED_VERSION }})
       if: matrix.scenario == 'wizard-upgrade'
       env:
-        ACCEPTANCE_EXPECTED_VERSION: ${{ env.TO_VERSION }}
+        ACCEPTANCE_EXPECTED_VERSION: ${{ env.EXPECTED_VERSION }}
       run: composer acceptance -- --group=version-display
 
     # ==== debug + teardown (all scenarios) ====

--- a/docs/artifact-acceptance-testing-plan.md
+++ b/docs/artifact-acceptance-testing-plan.md
@@ -562,6 +562,30 @@ from the checked-out ref. Using the workflow's `to_version` value
 keeps the artifact filename aligned with what `boot-package.sh`'s
 `<version>` arg + scratch-dir naming expects downstream.
 
+**`TO_VERSION` (label) vs `EXPECTED_VERSION` (actual) split**
+(openemr/openemr#13753): downstream of the label-is-cosmetic
+principle above, the version-display / version-api acceptance
+groups compare the running artifact's self-reported version
+against `ACCEPTANCE_EXPECTED_VERSION`. That env var is populated
+from `detect-mode.outputs.expected_version` (not `to_version`)
+precisely because on `build_locally=true` the two diverge — label
+stays `99.99.99` (cosmetic; drives filenames) while
+`expected_version` reads the checkout's `version.php` (what
+`sql_upgrade.php` actually writes to the DB `version` table). On
+the shipped-tarball path the two are equal (label = actual) because
+the release process bumps `version.php` in the checkout tree to the
+release version BEFORE packaging — so the tarball ships with
+`version.php` already equal to its download-URL label. The equality
+comes from the release-prep flow, NOT from `PackageAssembler` baking
+`--release-version` into anything (see the paragraph above; the
+assembler ships `version.php` as-is from the checked-out ref). On
+build_locally there is no release-prep pass, so `version.php` stays
+at whatever the checkout has (e.g. `8.4.0`) while the label defaults
+to the synthetic `99.99.99` — hence the divergence. Coupling the
+assertion to `TO_VERSION` — the pattern that #13635 originally
+shipped, and #13753 later corrected — made the acceptance groups
+un-passable on `build_locally=true`. Do not re-couple.
+
 Exit criterion (met): end-to-end `build_locally=true` demo on a
 real runner produced 6/6 green — `detect-mode`, `build-tarball`
 (PackageAssembler produced tarball from PR HEAD), `fresh-install`,

--- a/tests/bats/ci-scripts/detect-acceptance-mode/detect.bats
+++ b/tests/bats/ci-scripts/detect-acceptance-mode/detect.bats
@@ -16,6 +16,9 @@
 #   - push/pull_request with no relevant change
 #   - emit_to_version's X.Y.Z validation
 #   - DISPATCH_TO_VERSION overriding the PR-title preferred value
+#   - emit_expected_version + read_tree_version (openemr/openemr#13753):
+#     build_locally=true reads version.php; build_locally=false mirrors
+#     to_version; missing/malformed version.php fails loud
 #
 # What's NOT covered
 #   - actual GitHub Actions expression rendering — the tests set the
@@ -49,6 +52,8 @@ teardown() {
     emitted="$(read_output)"
     [[ "${emitted}" == *"build_locally=true"* ]]
     [[ "${emitted}" == *"to_version=8.2.1"* ]]
+    # build_locally=true: expected_version reads version.php (seeded 8.4.99).
+    [[ "${emitted}" == *"expected_version=8.4.99"* ]]
 }
 
 @test "workflow_call gate half-set (only tarball) -> exit 1 with both-or-neither error" {
@@ -101,6 +106,9 @@ teardown() {
     emitted="$(read_output)"
     [[ "${emitted}" == *"build_locally=true"* ]]
     [[ "${emitted}" == *"to_version=8.2.1"* ]]
+    # build_locally=true: expected_version reads version.php (seeded 8.4.99).
+    # Independent of the PR-title-parsed to_version.
+    [[ "${emitted}" == *"expected_version=8.4.99"* ]]
 }
 
 @test "release-prep branch on pull_request without parseable title -> to_version=99.99.99" {
@@ -117,6 +125,7 @@ teardown() {
     emitted="$(read_output)"
     [[ "${emitted}" == *"build_locally=true"* ]]
     [[ "${emitted}" == *"to_version=99.99.99"* ]]
+    [[ "${emitted}" == *"expected_version=8.4.99"* ]]
 }
 
 @test "release-prep branch on push event -> build_locally=true, to_version resolved" {
@@ -130,6 +139,7 @@ teardown() {
     emitted="$(read_output)"
     [[ "${emitted}" == *"build_locally=true"* ]]
     [[ "${emitted}" == *"to_version=99.99.99"* ]]
+    [[ "${emitted}" == *"expected_version=8.4.99"* ]]
 }
 
 # --- workflow_dispatch ---
@@ -145,6 +155,7 @@ teardown() {
     emitted="$(read_output)"
     [[ "${emitted}" == *"build_locally=true"* ]]
     [[ "${emitted}" == *"to_version=99.99.99"* ]]
+    [[ "${emitted}" == *"expected_version=8.4.99"* ]]
 }
 
 @test "workflow_dispatch with DISPATCH_BUILD_LOCALLY=false + DISPATCH_TO_VERSION=8.2.5 -> honors both" {
@@ -158,6 +169,9 @@ teardown() {
     emitted="$(read_output)"
     [[ "${emitted}" == *"build_locally=false"* ]]
     [[ "${emitted}" == *"to_version=8.2.5"* ]]
+    # build_locally=false: expected_version mirrors to_version
+    # (label=actual on shipped-tarball path).
+    [[ "${emitted}" == *"expected_version=8.2.5"* ]]
 }
 
 # --- non-push/pull_request fallback ---
@@ -171,6 +185,7 @@ teardown() {
     emitted="$(read_output)"
     [[ "${emitted}" == *"build_locally=false"* ]]
     [[ "${emitted}" == *"to_version=8.2.0"* ]]
+    [[ "${emitted}" == *"expected_version=8.2.0"* ]]
 }
 
 # --- branch-creation event (BASE=000...) ---
@@ -187,6 +202,7 @@ teardown() {
     emitted="$(read_output)"
     [[ "${emitted}" == *"build_locally=false"* ]]
     [[ "${emitted}" == *"to_version=8.2.0"* ]]
+    [[ "${emitted}" == *"expected_version=8.2.0"* ]]
 }
 
 # --- diff-based detection ---
@@ -204,6 +220,7 @@ teardown() {
     emitted="$(read_output)"
     [[ "${emitted}" == *"build_locally=true"* ]]
     [[ "${emitted}" == *"to_version=99.99.99"* ]]
+    [[ "${emitted}" == *"expected_version=8.4.99"* ]]
 }
 
 @test "git diff failure surfaces loudly with ::error:: (not silently masked by grep)" {
@@ -242,6 +259,7 @@ teardown() {
     emitted="$(read_output)"
     [[ "${emitted}" == *"build_locally=false"* ]]
     [[ "${emitted}" == *"to_version=8.2.0"* ]]
+    [[ "${emitted}" == *"expected_version=8.2.0"* ]]
 }
 
 @test "pull_request with build.xml change -> build_locally=true" {
@@ -256,6 +274,7 @@ teardown() {
     local emitted
     emitted="$(read_output)"
     [[ "${emitted}" == *"build_locally=true"* ]]
+    [[ "${emitted}" == *"expected_version=8.4.99"* ]]
 }
 
 @test "pull_request with .gitattributes change -> build_locally=true" {
@@ -270,6 +289,7 @@ teardown() {
     local emitted
     emitted="$(read_output)"
     [[ "${emitted}" == *"build_locally=true"* ]]
+    [[ "${emitted}" == *"expected_version=8.4.99"* ]]
 }
 
 # --- emit_to_version validator ---
@@ -301,6 +321,91 @@ teardown() {
     emitted="$(read_output)"
     [[ "${emitted}" == *"to_version=8.3.0"* ]]
     [[ "${emitted}" != *"to_version=8.2.1"* ]]
+    # build_locally=true: expected_version tracks the checkout's
+    # version.php (seeded 8.4.99), independent of the label choice.
+    [[ "${emitted}" == *"expected_version=8.4.99"* ]]
+}
+
+# --- emit_expected_version + read_tree_version (openemr/openemr#13753) ---
+#
+# The build_locally acceptance path historically used `TO_VERSION` as
+# the expected value for the post-install / post-upgrade version-display
+# and version-api acceptance groups. But `TO_VERSION` on that path is a
+# cosmetic 99.99.99 label — PackageAssembler does not bake it into the
+# packaged codebase, so the DB `version` table (populated by
+# sql_upgrade.php from what's actually in version.php) can never equal
+# the label. Assertions therefore couldn't pass. `expected_version` is
+# read from the checkout's version.php on build_locally=true, so the
+# assertions have a chance of matching.
+
+@test "read_tree_version reads seeded version.php (build_locally=true, dispatch)" {
+    # Override the setup default (8.4.99) to prove the value flows
+    # from the file, not a constant baked into the script.
+    seed_version_php 9 1 2
+    export EVENT_NAME="workflow_dispatch"
+    export DISPATCH_BUILD_LOCALLY="true"
+    export DISPATCH_TO_VERSION=""
+    run bash "${DETECT_ACCEPTANCE_MODE_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    local emitted
+    emitted="$(read_output)"
+    [[ "${emitted}" == *"to_version=99.99.99"* ]]
+    [[ "${emitted}" == *"expected_version=9.1.2"* ]]
+    [[ "${output}" == *"resolved expected_version=9.1.2"* ]]
+}
+
+@test "read_tree_version: missing version.php -> exit 1 (build_locally path)" {
+    # Simulate a checkout where version.php is somehow absent — the
+    # script must fail loud rather than emit an empty or bogus
+    # expected_version.
+    rm -f version.php
+    export EVENT_NAME="workflow_dispatch"
+    export DISPATCH_BUILD_LOCALLY="true"
+    export DISPATCH_TO_VERSION=""
+    run bash "${DETECT_ACCEPTANCE_MODE_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::read_tree_version: cannot read version.php"* ]]
+    # Must NOT have emitted expected_version.
+    local emitted
+    emitted="$(read_output)"
+    [[ "${emitted}" != *"expected_version="* ]]
+}
+
+@test "read_tree_version: missing \$v_patch line -> exit 1 (build_locally path)" {
+    # Malformed version.php: has $v_major and $v_minor but not $v_patch.
+    # Must fail loud, not emit a partial value.
+    cat > version.php <<'PHP'
+<?php
+$v_major = '8';
+$v_minor = '4';
+PHP
+    export EVENT_NAME="workflow_dispatch"
+    export DISPATCH_BUILD_LOCALLY="true"
+    export DISPATCH_TO_VERSION=""
+    run bash "${DETECT_ACCEPTANCE_MODE_SCRIPT}"
+    [[ ${status} -eq 1 ]]
+    [[ "${output}" == *"::error::read_tree_version: failed to parse"* ]]
+    [[ "${output}" == *"patch=''"* ]]
+    local emitted
+    emitted="$(read_output)"
+    [[ "${emitted}" != *"expected_version="* ]]
+}
+
+@test "read_tree_version NOT called on build_locally=false (missing version.php ok)" {
+    # Build_locally=false path must not require version.php — the
+    # expected_version mirrors to_version, which is either the
+    # shipped-version default or a dispatch input. Removing
+    # version.php then running a build_locally=false path must not
+    # trip read_tree_version.
+    rm -f version.php
+    export EVENT_NAME="schedule"
+    run bash "${DETECT_ACCEPTANCE_MODE_SCRIPT}"
+    [[ ${status} -eq 0 ]]
+    local emitted
+    emitted="$(read_output)"
+    [[ "${emitted}" == *"build_locally=false"* ]]
+    [[ "${emitted}" == *"to_version=8.2.0"* ]]
+    [[ "${emitted}" == *"expected_version=8.2.0"* ]]
 }
 
 # --- from_version derivation from sql/*-to-*_upgrade.sql (openemr/openemr#13573) ---

--- a/tests/bats/ci-scripts/detect-acceptance-mode/helpers.bash
+++ b/tests/bats/ci-scripts/detect-acceptance-mode/helpers.bash
@@ -87,6 +87,18 @@ setup_test_dir() {
     export PUSH_HEAD_SHA=""
     export PUSH_REF=""
     export MOCK_GIT_DIFF_OUTPUT=""
+
+    # Seed a default version.php in the working dir. The script's
+    # read_tree_version (called by emit_expected_version on the
+    # build_locally=true path) requires this file to exist and to
+    # contain parseable $v_major/$v_minor/$v_patch declarations.
+    # Default is a distinctive-looking `8.4.99` so assertions on the
+    # emitted expected_version can't be silently satisfied by the
+    # to_version default (99.99.99) or by real shipped versions.
+    # Tests that want a specific value re-call seed_version_php;
+    # tests exercising the missing-file / malformed-parse failure
+    # modes rm -f version.php or overwrite it directly.
+    seed_version_php 8 4 99
 }
 
 # Populate the test's temp working dir with a set of empty
@@ -100,6 +112,22 @@ seed_sql_upgrade_fixtures() {
     for pair in "$@"; do
         touch "sql/${pair}_upgrade.sql"
     done
+}
+
+# Write a minimal version.php to the working dir with the given
+# major/minor/patch. Matches the shape the real openemr version.php
+# uses (bash-quoting of PHP-single-quoted strings) so
+# read_tree_version's awk pattern parses it correctly.
+seed_version_php() {
+    local major="$1"
+    local minor="$2"
+    local patch="$3"
+    cat > version.php <<PHP
+<?php
+\$v_major = '${major}';
+\$v_minor = '${minor}';
+\$v_patch = '${patch}';
+PHP
 }
 
 teardown_test_dir() {


### PR DESCRIPTION
Closes #13753. Analysis by @kojiromike in that issue is accurate — this PR implements the "Option A" fix he recommended.

## Summary

The version-display and version-api acceptance groups compare the running artifact's self-reported version against `ACCEPTANCE_EXPECTED_VERSION`. That env was populated from `TO_VERSION` — a naming label that stays at the synthetic `99.99.99` default on `build_locally=true` (documented in `tools/release/bin/package-assemble.php` as cosmetic-only, not baked into the packaged codebase). Since `sql_upgrade.php` writes the checkout's `version.php` value (not the label) into the DB `version` table, the assertion could never pass on the build_locally path — every PR touching `tools/release/**` blocked with all 8 install/upgrade acceptance jobs red (currently blocking #13450).

## Fix

Add a new `detect-mode.outputs.expected_version` output that reads the checkout's `version.php` via a new `read_tree_version` helper on `build_locally=true`, and mirrors `to_version` otherwise (label = actual on the shipped-tarball path, because the release process bumps `version.php` in the tree before packaging, so the shipped tarball has `version.php` matching its download-URL label). Route through a new `EXPECTED_VERSION` env in the acceptance job and switch the six `ACCEPTANCE_EXPECTED_VERSION` consumer sites accordingly. The one `FROM_VERSION` consumer (pre-upgrade check) stays — it already used a real shipped version.

## Rationale

The label choice was designed as cosmetic on purpose so `PackageAssembler` can package any checkout without file rewriting — see the [`docs/artifact-acceptance-testing-plan.md`](docs/artifact-acceptance-testing-plan.md) notes on Phase 3.5 (lines ~555-570 pre-this-PR). #13635 added the version-match assertion with the right *intent* but the wrong *source*; this restores the assertion by fixing the source, not by rewriting `PackageAssembler` to bake `--release-version` into `version.php` (which would ship `99.99.99` in PR-built tarballs).

Also updates the doc with a new `TO_VERSION` vs `EXPECTED_VERSION` split section, so the next person tempted to "simplify" by re-coupling them re-reads the rationale first.

## Confirmed release-line-agnostic (rel-820 / rel-830 / future rel-840 / master)

Traced through all 5 scenarios on a future rel-840 (building the 8.4.0 line) to confirm no branch-specific quirks. The key invariant: `read_tree_version` (bash) and the DB assertion (SQL) both use the same 3 fields, so they always render versions identically:

```
read_tree_version:  awk → "$v_major.$v_minor.$v_patch"
boot-package.sh:    SELECT CONCAT(v_major,'.',v_minor,'.',v_patch) FROM version
```

Both intentionally drop `$v_tag` (`-dev` suffix), so mid-cycle rel-840 state with `-dev` still works.

| # | Trigger | to_version | expected_version | DB after install | Result |
|---|---------|-----------|------------------|------------------|--------|
| 1 | Normal PR (no tools/release/ change) | 8.2.0 (default) | 8.2.0 (mirrors to_version, build_locally=false) | 8.2.0 (from shipped tarball) | ✓ |
| 2 | release-prep/rel-840, title "prep 8.4.1", version.php fully bumped | 8.4.1 (from title) | 8.4.1 (from version.php) | 8.4.1 (PR-built tarball) | ✓ |
| 3 | release-prep/rel-840, title bumped but version.php only partially bumped | 8.4.1 (label, cosmetic) | 8.4.0 (from version.php) | 8.4.0 (PR-built tarball's version.php) | ✓ (assertion correctly tracks reality) |
| 4 | Manual dispatch build_locally=true on rel-840 | 99.99.99 (default) | 8.4.0 (from version.php) | 8.4.0 | ✓ |
| 5 | rel-840 PR touching tools/release/** | 99.99.99 (auto-fired) | 8.4.0 (from version.php) | 8.4.0 | ✓ |

Scenario 3 is the important one — with the old code (TO_VERSION as source) that mid-bump state would have hard-failed (8.4.1 label vs 8.4.0 DB). With the fix, EXPECTED_VERSION tracks what's actually in the tarball, so the assertion passes correctly during the mid-bump window.

No hardcoded version assumptions in the fix; no rel-branch-specific logic; `emit_expected_version` mirrors `to_version` on non-build_locally paths so shipped-tarball flows are unchanged.

## How this fits into the larger acceptance-surface refactor plan

This PR is a **surgical fix**, not part of the broader refactor already scoped in the doc. The bigger cleanup is captured in `docs/artifact-acceptance-testing-plan.md`'s **"Post-8.4.0 acceptance-surface refactor plan"** section (lines ~2589+), deferred until after the next release cut. Notable items from that plan:

- **Item 1** — introduce an `AcceptanceContext` support class as central resolver for "what am I running against?" (expected version, base URL, feature-flag state, scenario name). Tests would call `AcceptanceContext::expectedVersion()` instead of `getenv('ACCEPTANCE_EXPECTED_VERSION')`. Highest leverage, smallest surface. `VersionDisplayAcceptanceTest` + `VersionApiAcceptanceTest` are the natural first consumers.
- **Item 2** — split the currently-overloaded group tags into two dimensions: scenario timeline (`post-install`, `post-upgrade`, `wizard-completed`) + runtime state (`api-enabled`, `demo-data-seeded`). Once this lands, the workaround groups `version-display` / `version-api` (introduced in #13635 purely because acceptance-docker.yml can't resolve floating tags to X.Y.Z at runtime) collapse into `#[Group('post-install')] #[Group('post-upgrade')]`.
- **Item 3** — shared boot-orchestration composite action; kills the YAML duplication between `acceptance-package.yml` and `acceptance-docker.yml` and makes drift impossible.
- **Item 4** — docker workflow tag→version resolution, so `ACCEPTANCE_EXPECTED_VERSION` can be set in docker context too and the `version-display` / `version-api` isolation workaround becomes unnecessary.
- Items 5-6 — hygiene (reference table for invocation contexts, directory structure by concern).

**This PR's `EXPECTED_VERSION` env-var indirection is compatible with all four structural items** — it's a package-workflow-side plumbing fix that doesn't create new debt for the future refactor to unwind. Item 1's `AcceptanceContext::expectedVersion()` would eventually replace the direct env read in the two version test classes, at which point `EXPECTED_VERSION` becomes just one of several inputs to that resolver.

## Test plan

- [x] BATS tests: 32 pass (28 pre-existing, 4 new) — new tests cover `read_tree_version` reading the seeded file, missing `version.php` failure, malformed `version.php` failure, and `build_locally=false` skip-read behavior.
- [x] Actionlint clean on `acceptance-package.yml`.
- [x] Shellcheck clean on `detect-acceptance-mode.sh` (SC2310/SC2312 handled with the same disable/`|| true` patterns already used elsewhere in the file).
- [x] Full pre-commit suite clean (codespell, actionlint, shellcheck, yaml checks).
- [ ] End-to-end: this PR itself touches nothing under `tools/release/**` / `build.xml` / `.gitattributes`, so the build_locally path won't auto-fire on this PR. To exercise it: manually dispatch `acceptance-package.yml` on this branch with `build_locally=true` (or land + push a follow-up PR that touches `tools/release/**`, whichever is more convenient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
