### PR TITLE
ci(docker): loosen fpm dockerhub readme push gate to fire on any weekly-build completion

### DIFF
--- a/.github/workflows/docker-push-dockerhub-readme-fpm.yml
+++ b/.github/workflows/docker-push-dockerhub-readme-fpm.yml
@@ -51,10 +51,24 @@ concurrency:
 
 jobs:
   render-and-push:
-    # Gate on success when triggered by the weekly build's workflow_run.
-    # workflow_run fires on completed regardless of conclusion, so without
-    # this check a failed weekly build would still update the readme.
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    # No conclusion gate: the readme reflects what the weekly workflow
+    # *declares* it will build (parsed from the workflow YAML at the
+    # triggering head_sha), not what individual jobs pushed. That stays
+    # accurate even when some builds fail -- a common state while
+    # PHP 8.6 tracks pre-release master and periodically breaks on
+    # upstream extension incompatibilities like pcov. Requiring
+    # all-green would let a long-standing single-job failure freeze
+    # the readme indefinitely, forcing manual dispatch every Sunday.
+    #
+    # Safety of skipping the gate:
+    #   - on.workflow_run.workflows already restricts the trigger to
+    #     the Weekly Build php-fpm Dockers workflow.
+    #   - actions/checkout below pins to
+    #     github.event.workflow_run.head_sha so we always read the
+    #     workflow YAML at the exact commit the build ran against
+    #     (no master-drift window).
+    #   - dockerhub-description is effectively a no-op when the
+    #     rendered markdown matches what's already on Docker Hub.
     name: Render and push
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
## Summary

Drop the `workflow_run.conclusion == 'success'` gate on the fpm dockerhub readme push job. Follow-up to #13766.

## Motivation

Watched the first dispatched weekly run tonight — `build_8_2` through `build_8_5` all pushed fresh phpredis-baked images successfully, but `build_8_6` broke on the same PHP-master pcov `INI_BOOL`/`INI_INT`/`INI_STR` implicit-declaration errors we've had at the top of that thread for weeks. Overall run conclusion `failure` → readme push skipped → had to manually dispatch `docker-push-dockerhub-readme-fpm.yml` with `dry_run=false` to actually update Docker Hub.

That'll happen every Sunday for as long as 8.6 is broken upstream. Manual dispatch every week is friction that shouldn't be there.

## What changes

Remove the `if:` gate on the `render-and-push` job. Add a comment explaining the design decision and the safety analysis.

## Safety analysis

The readme content is derived from parsing the weekly workflow YAML at the triggering `head_sha`, **not** from what individual jobs pushed. It stays accurate through partial failures, so gating on all-green was strictly harmful (readme freezes for as long as one job stays broken).

Concrete safeguards remain in place:
- `on.workflow_run.workflows` restricts the trigger to the Weekly Build php-fpm Dockers workflow. Unrelated workflow_run events can't reach here.
- `actions/checkout` pins `ref: ${{ github.event.workflow_run.head_sha || github.sha }}` (added per CodeRabbit's earlier feedback), so the render sees the exact commit the build ran against — no master-drift window.
- `peter-evans/dockerhub-description` is effectively a no-op when the rendered markdown already matches the current Docker Hub description.

## Test plan

- [ ] Reviewer sanity-check: next Sunday's weekly build (still expected to fail on 8.6) triggers the readme push and it completes rather than skipping.
- [ ] Docker Hub description for `openemr/dev-php-fpm` refreshes automatically without needing a manual `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
