### PR TITLE
feat(payments): consolidated report for prepay balances

### DIFF
--- a/interface/main/tabs/menu/menus/standard.json
+++ b/interface/main/tabs/menu/menus/standard.json
@@ -1702,6 +1702,18 @@
                             "acct",
                             "rep_a"
                         ]
+                    },
+                    {
+                        "label": "Prepay Balances",
+                        "menu_id": "rep0",
+                        "target": "rep",
+                        "url": "/interface/reports/prepayment_balance_report.php",
+                        "children": [],
+                        "requirement": 0,
+                        "acl_req": [
+                            "acct",
+                            "rep_a"
+                        ]
                     }
                 ],
                 "requirement": 0

--- a/interface/reports/prepayment_balance_report.php
+++ b/interface/reports/prepayment_balance_report.php
@@ -226,7 +226,7 @@ $shortDate = static function (?string $date): string {
 if ($isRefresh) {
     $service = new PrepaymentBalanceService();
     $balances = $service->getOpenBalances($formFromDate, $formToDate, $formPatientId, $formParkedOnly);
-    $totals = $service->totals($balances);
+    $totals = PrepaymentBalanceService::totals($balances);
     ?>
 <div id="report_results">
 <table class='table'>

--- a/interface/reports/prepayment_balance_report.php
+++ b/interface/reports/prepayment_balance_report.php
@@ -1,0 +1,288 @@
+<?php
+
+/**
+ * Prepayment balance report.
+ *
+ * Lists open pre-payment sessions (ar_session.adjustment_code = 'pre_payment',
+ * closed = 0) whose received amount has not been fully applied to charges.
+ *
+ * The balance arithmetic lives in {@see PrepaymentBalanceService}; this file is
+ * the view.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (C) 2026 Stephen Waite <stephen.waite@cmsvt.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require_once("../globals.php");
+
+use OpenEMR\Billing\PrepaymentBalanceService;
+use OpenEMR\Common\Acl\AccessDeniedHelper;
+use OpenEMR\Common\Acl\AclMain;
+use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Http\CurrentRequest;
+use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Core\Header;
+use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Services\Utils\DateFormatterUtils;
+
+$request = CurrentRequest::get();
+$session = SessionWrapperFactory::getInstance()->getActiveSession();
+
+if ($request->isMethod('POST')) {
+    CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
+}
+
+if (!AclMain::aclCheckCore('acct', 'rep_a')) {
+    AccessDeniedHelper::denyWithTemplate(
+        "ACL check failed for acct/rep_a: Prepayment Balances",
+        xl("Prepayment Balances")
+    );
+}
+
+// Optional filters. An empty check-date bound means no bound in that direction,
+// so the default view is every open prepayment regardless of age, which is the
+// point of the report. Dates filter on ar_session.check_date.
+$formFromDate = DateFormatterUtils::DateToYYYYMMDD($request->request->getString('form_from_date'));
+$formToDate = DateFormatterUtils::DateToYYYYMMDD($request->request->getString('form_to_date'));
+$formFromDate = is_string($formFromDate) ? $formFromDate : '';
+$formToDate = is_string($formToDate) ? $formToDate : '';
+$formPatient = trim($request->request->getString('form_patient'));
+$formPatientId = $formPatient === '' ? null : (int) $formPatient;
+$formParkedOnly = $request->request->getBoolean('form_parked_only');
+$isRefresh = $request->request->getBoolean('form_refresh');
+
+// oeFormatShortDate() returns its argument unchanged for inputs shorter than a
+// full date, so its return type is mixed. Narrow once here rather than at each
+// of the five display sites.
+$shortDate = static function (?string $date): string {
+    if ($date === null || $date === '') {
+        return '';
+    }
+    $formatted = DateFormatterUtils::oeFormatShortDate($date);
+
+    return is_string($formatted) ? $formatted : '';
+};
+?>
+
+<html>
+
+<head>
+    <title><?php echo xlt('Prepayment Balances'); ?></title>
+
+    <?php Header::setupHeader(["datetime-picker", "report-helper"]); ?>
+
+    <script>
+        // Re-run the report when the edit_payment dialog closes so that fully
+        // applied sessions drop off the list immediately.
+        function refreshReport() {
+            $("#form_refresh").attr("value", "true");
+            $("#theform").submit();
+        }
+
+        $(function () {
+            var win = top.printLogSetup ? top : opener.top;
+            win.printLogSetup(document.getElementById('printbutton'));
+
+            // Open sessions in a dialog rather than navigating away from the
+            // report, matching the pattern in billing/search_payments.php.
+            $(document).on('click', '.medium_modal', function (e) {
+                e.preventDefault();
+                e.stopPropagation();
+                dlgopen('', '', 'modal-full', 800, '', '', {
+                    buttons: [
+                        {text: <?php echo xlj('Close'); ?>, close: true, style: 'default btn-sm'}
+                    ],
+                    sizeHeight: '',
+                    onClosed: 'refreshReport',
+                    type: 'iframe',
+                    url: $(this).attr('href')
+                });
+            });
+
+            $('.datepicker').datetimepicker({
+                <?php $datetimepicker_timepicker = false; ?>
+                <?php $datetimepicker_showseconds = false; ?>
+                <?php $datetimepicker_formatInput = true; ?>
+                <?php require(OEGlobalsBag::getInstance()->getSrcDir() . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); ?>
+            });
+        });
+
+        function setpatient(pid, lname, fname, dob) {
+            document.forms[0].elements['form_patient'].value = pid;
+            document.forms[0].elements['form_patient_name'].value = lname + ', ' + fname;
+        }
+
+        function sel_patient() {
+            dlgopen('../main/calendar/find_patient_popup.php?pflag=0', '_blank', 500, 400);
+        }
+
+        function clear_patient() {
+            document.forms[0].elements['form_patient'].value = '';
+            document.forms[0].elements['form_patient_name'].value = '';
+        }
+    </script>
+
+    <style>
+        /* specifically include & exclude from printing */
+        @media print {
+            #report_parameters {
+                visibility: hidden;
+                display: none;
+            }
+            #report_parameters_daterange {
+                visibility: visible;
+                display: inline;
+            }
+            #report_results table {
+                margin-top: 0px;
+            }
+        }
+
+        /* specifically exclude some from the screen */
+        @media screen {
+            #report_parameters_daterange {
+                visibility: hidden;
+                display: none;
+            }
+        }
+    </style>
+</head>
+
+<body class="body_top">
+
+<!-- Required for the popup date selectors -->
+<div id="overDiv" style="position: absolute; visibility: hidden; z-index: 1000;"></div>
+
+<span class='title'><?php echo xlt('Prepayment Balances'); ?></span>
+
+<div id="report_parameters_daterange"><?php echo text($shortDate($formFromDate)) . " &nbsp; " . xlt('to{{Range}}') . " &nbsp; " . text($shortDate($formToDate)); ?>
+</div>
+
+<form method='post' name='theform' id='theform' action='prepayment_balance_report.php' onsubmit='return top.restoreSession()'>
+<input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken(session: $session)); ?>" />
+
+<div id="report_parameters">
+
+<table>
+    <tr>
+        <td>
+        <div class='float-left'>
+
+        <table class='text'>
+            <tr>
+                <td class='col-form-label'><?php echo xlt('Check Date From'); ?>:</td>
+                <td><input type='text' name='form_from_date' id='form_from_date' class='datepicker form-control' size='10' value='<?php echo attr($shortDate($formFromDate)); ?>' /></td>
+                <td class='col-form-label'><?php echo xlt('To{{Range}}'); ?>:</td>
+                <td><input type='text' name='form_to_date' id='form_to_date' class='datepicker form-control' size='10' value='<?php echo attr($shortDate($formToDate)); ?>' /></td>
+            </tr>
+            <tr>
+                <td class='col-form-label'><?php echo xlt('Patient'); ?>:</td>
+                <td>
+                    <input type='text' size='20' name='form_patient_name' id='form_patient_name' class='form-control' style='cursor: pointer;' value='<?php echo attr($formPatient); ?>' onclick='sel_patient()' readonly title='<?php echo xla('Click to select patient'); ?>' />
+                    <input type='hidden' name='form_patient' id='form_patient' value='<?php echo attr($formPatient); ?>' />
+                    <a href='#' onclick='clear_patient(); return false;'><?php echo xlt('Clear'); ?></a>
+                </td>
+                <td class='col-form-label'><?php echo xlt('Parked in Global only'); ?>:</td>
+                <td>
+                    <input type='checkbox' name='form_parked_only' id='form_parked_only' value='1'<?php echo $formParkedOnly ? ' checked' : ''; ?> />
+                </td>
+            </tr>
+        </table>
+
+        </div>
+
+        </td>
+        <td class='h-100'>
+        <table class='w-100 h-100' style='border-left: 1px solid;'>
+            <tr>
+                <td>
+                    <div class="text-center">
+                        <div class="btn-group" role="group">
+                            <a href='#' class='btn btn-secondary btn-save' onclick='$("#form_refresh").attr("value","true"); $("#theform").submit();'>
+                                <?php echo xlt('Submit'); ?>
+                            </a>
+                            <?php if ($isRefresh) { ?>
+                                <a href='#' class='btn btn-secondary btn-print' id='printbutton'>
+                                    <?php echo xlt('Print'); ?>
+                                </a>
+                            <?php } ?>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+        </table>
+        </td>
+    </tr>
+</table>
+
+</div>
+<!-- end of search parameters -->
+<?php
+if ($isRefresh) {
+    $service = new PrepaymentBalanceService();
+    $balances = $service->getOpenBalances($formFromDate, $formToDate, $formPatientId, $formParkedOnly);
+    $totals = $service->totals($balances);
+    ?>
+<div id="report_results">
+<table class='table'>
+
+    <thead class='thead-light'>
+        <tr>
+            <th><?php echo xlt('Patient'); ?></th>
+            <th><?php echo xlt('PID'); ?></th>
+            <th><?php echo xlt('Session'); ?></th>
+            <th><?php echo xlt('Reference'); ?></th>
+            <th><?php echo xlt('Check Date'); ?></th>
+            <th class="text-right"><?php echo xlt('Days Open'); ?></th>
+            <th class="text-right"><?php echo xlt('Received'); ?></th>
+            <th class="text-right"><?php echo xlt('Applied'); ?></th>
+            <th class="text-right"><?php echo xlt('In Global'); ?></th>
+            <th class="text-right"><?php echo xlt('Unapplied'); ?></th>
+        </tr>
+    </thead>
+    <tbody>
+    <?php foreach ($balances as $balance) { ?>
+        <tr>
+            <td class="detail">&nbsp;<?php echo text($balance->patientName); ?></td>
+            <td class="detail">&nbsp;<?php echo text((string) $balance->patientId); ?></td>
+            <td class="detail">&nbsp;
+                <a class="medium_modal" href='../billing/edit_payment.php?payment_id=<?php echo attr_url((string) $balance->sessionId); ?>'>
+                    <?php echo text((string) $balance->sessionId); ?>
+                </a>
+            </td>
+            <td class="detail">&nbsp;<?php echo text($balance->reference); ?></td>
+            <td class="detail">&nbsp;<?php echo $balance->checkDate === null ? '&nbsp;' : text($shortDate($balance->checkDate)); ?></td>
+            <td class="detail text-right"><?php echo text((string) $balance->daysOpen); ?></td>
+            <td class="detail text-right"><?php echo text(oeFormatMoney($balance->received)); ?></td>
+            <td class="detail text-right"><?php echo text(oeFormatMoney($balance->applied)); ?></td>
+            <td class="detail text-right"><?php echo text(oeFormatMoney($balance->inGlobal)); ?></td>
+            <td class="detail text-right"><?php echo text(oeFormatMoney($balance->unapplied)); ?></td>
+        </tr>
+    <?php } ?>
+    </tbody>
+    <tfoot>
+        <tr class='font-weight-bold'>
+            <td class="detail" colspan="6">&nbsp;<?php echo xlt('Totals'); ?></td>
+            <td class="detail text-right"><?php echo text(oeFormatMoney($totals['received'])); ?></td>
+            <td class="detail text-right"><?php echo text(oeFormatMoney($totals['applied'])); ?></td>
+            <td class="detail text-right"><?php echo text(oeFormatMoney($totals['inGlobal'])); ?></td>
+            <td class="detail text-right"><?php echo text(oeFormatMoney($totals['unapplied'])); ?></td>
+        </tr>
+    </tfoot>
+</table>
+</div>
+<!-- end of search results -->
+<?php } else { ?>
+<div class='text'><?php echo xlt('Click Submit to list all open prepayments with an unapplied balance. Date and patient filters are optional.'); ?>
+</div>
+<?php } ?>
+<input type='hidden' name='form_refresh' id='form_refresh' value='' /></form>
+
+</body>
+
+</html>

--- a/interface/reports/prepayment_balance_report.php
+++ b/interface/reports/prepayment_balance_report.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 require_once("../globals.php");
 
+use OpenEMR\Billing\PrepaymentBalance;
 use OpenEMR\Billing\PrepaymentBalanceService;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
@@ -226,7 +227,7 @@ $shortDate = static function (?string $date): string {
 if ($isRefresh) {
     $service = new PrepaymentBalanceService();
     $balances = $service->getOpenBalances($formFromDate, $formToDate, $formPatientId, $formParkedOnly);
-    $totals = PrepaymentBalanceService::totals($balances);
+    $totals = PrepaymentBalance::totals($balances);
     ?>
 <div id="report_results">
 <table class='table'>

--- a/sites/default/documents/custom_menus/Custom.json
+++ b/sites/default/documents/custom_menus/Custom.json
@@ -1702,6 +1702,18 @@
                             "acct",
                             "rep_a"
                         ]
+                    },
+                    {
+                        "label": "Prepay Balances",
+                        "menu_id": "rep0",
+                        "target": "rep",
+                        "url": "/interface/reports/prepayment_balance_report.php",
+                        "children": [],
+                        "requirement": 0,
+                        "acl_req": [
+                            "acct",
+                            "rep_a"
+                        ]
                     }
                 ],
                 "requirement": 0

--- a/src/Billing/PrepaymentBalance.php
+++ b/src/Billing/PrepaymentBalance.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * A single open prepayment session with its unapplied balance.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (C) 2026 Stephen Waite <stephen.waite@cmsvt.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Billing;
+
+/**
+ * Read model for one row of the prepayment balance report.
+ *
+ * The query returns eleven columns of untyped data. Narrowing them here once,
+ * in {@see self::fromRow()}, keeps the mixed-to-scalar conversions in a single
+ * tested place instead of repeating them at every echo in the template.
+ */
+final readonly class PrepaymentBalance
+{
+    public function __construct(
+        public int $sessionId,
+        public int $patientId,
+        public string $patientName,
+        public string $reference,
+        public ?string $checkDate,
+        public int $daysOpen,
+        public float $received,
+        public float $applied,
+        public float $inGlobal,
+        public float $unapplied,
+    ) {
+    }
+
+    /**
+     * Build from a raw result row.
+     *
+     * Keys are read defensively rather than declared as array<string, mixed>:
+     * QueryUtils::fetchRecords() is untyped, so the shape of a row cannot be
+     * proven at the call site.
+     *
+     * @param array<array-key, mixed> $row
+     */
+    public static function fromRow(array $row): self
+    {
+        $checkDate = self::toStringOrNull($row['check_date'] ?? null);
+
+        return new self(
+            sessionId: self::toInt($row['session_id'] ?? null),
+            patientId: self::toInt($row['patient_id'] ?? null),
+            patientName: self::formatName(
+                self::toStringValue($row['lname'] ?? null),
+                self::toStringValue($row['fname'] ?? null),
+                self::toStringValue($row['mname'] ?? null),
+            ),
+            reference: self::toStringValue($row['reference'] ?? null),
+            checkDate: $checkDate,
+            daysOpen: self::toInt($row['days_open'] ?? null),
+            received: self::toFloat($row['pay_total'] ?? null),
+            applied: self::toFloat($row['applied'] ?? null),
+            inGlobal: self::toFloat($row['global_amount'] ?? null),
+            unapplied: self::toFloat($row['unapplied'] ?? null),
+        );
+    }
+
+    /**
+     * "Last, First Middle", collapsing whatever parts are absent.
+     */
+    private static function formatName(string $lname, string $fname, string $mname): string
+    {
+        $given = trim($fname . ($mname === '' ? '' : ' ' . $mname));
+        if ($lname === '') {
+            return $given;
+        }
+        if ($given === '') {
+            return $lname;
+        }
+
+        return $lname . ', ' . $given;
+    }
+
+    private static function toStringValue(mixed $value): string
+    {
+        return is_scalar($value) ? (string) $value : '';
+    }
+
+    private static function toStringOrNull(mixed $value): ?string
+    {
+        if (!is_scalar($value)) {
+            return null;
+        }
+        $string = (string) $value;
+
+        return $string === '' ? null : $string;
+    }
+
+    private static function toInt(mixed $value): int
+    {
+        return is_numeric($value) ? (int) $value : 0;
+    }
+
+    private static function toFloat(mixed $value): float
+    {
+        return is_numeric($value) ? (float) $value : 0.0;
+    }
+}

--- a/src/Billing/PrepaymentBalance.php
+++ b/src/Billing/PrepaymentBalance.php
@@ -69,6 +69,31 @@ final readonly class PrepaymentBalance
     }
 
     /**
+     * Column totals for a result set.
+     *
+     * Lives on the read model rather than the service because BaseService
+     * require_once's custom/code_types.inc.php at file scope, which runs a
+     * query on include -- so merely autoloading the service needs a database,
+     * even for a static call.
+     *
+     * @param list<self> $balances
+     * @return array{received: float, applied: float, inGlobal: float, unapplied: float}
+     */
+    public static function totals(array $balances): array
+    {
+        $totals = ['received' => 0.0, 'applied' => 0.0, 'inGlobal' => 0.0, 'unapplied' => 0.0];
+
+        foreach ($balances as $balance) {
+            $totals['received'] += $balance->received;
+            $totals['applied'] += $balance->applied;
+            $totals['inGlobal'] += $balance->inGlobal;
+            $totals['unapplied'] += $balance->unapplied;
+        }
+
+        return $totals;
+    }
+
+    /**
      * "Last, First Middle", collapsing whatever parts are absent.
      */
     private static function formatName(string $lname, string $fname, string $mname): string

--- a/src/Billing/PrepaymentBalanceService.php
+++ b/src/Billing/PrepaymentBalanceService.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace OpenEMR\Billing;
 
 use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Services\BaseService;
 
 /**
  * Finds pre-payment sessions whose received amount has not been fully applied.
@@ -25,12 +26,19 @@ use OpenEMR\Common\Database\QueryUtils;
  * Global Account has not satisfied a charge, so it remains an unapplied credit;
  * it is reported separately as inGlobal so parked credit stays visible.
  */
-class PrepaymentBalanceService
+class PrepaymentBalanceService extends BaseService
 {
+    public const TABLE_NAME = 'ar_session';
+
     /**
      * Amounts below this are rounding residue, not a real balance.
      */
     private const UNAPPLIED_EPSILON = 0.005;
+
+    public function __construct()
+    {
+        parent::__construct(self::TABLE_NAME);
+    }
 
     /**
      * @param string|null $fromDate Y-m-d lower bound on check_date, null for none
@@ -101,10 +109,14 @@ class PrepaymentBalanceService
     /**
      * Column totals for the report footer.
      *
+     * Static so that callers which only need to sum an existing result set --
+     * the isolated tests among them -- do not pay for BaseService's
+     * constructor, which reads table metadata from the database.
+     *
      * @param list<PrepaymentBalance> $balances
      * @return array{received: float, applied: float, inGlobal: float, unapplied: float}
      */
-    public function totals(array $balances): array
+    public static function totals(array $balances): array
     {
         $totals = ['received' => 0.0, 'applied' => 0.0, 'inGlobal' => 0.0, 'unapplied' => 0.0];
 

--- a/src/Billing/PrepaymentBalanceService.php
+++ b/src/Billing/PrepaymentBalanceService.php
@@ -105,28 +105,4 @@ class PrepaymentBalanceService extends BaseService
 
         return $balances;
     }
-
-    /**
-     * Column totals for the report footer.
-     *
-     * Static so that callers which only need to sum an existing result set --
-     * the isolated tests among them -- do not pay for BaseService's
-     * constructor, which reads table metadata from the database.
-     *
-     * @param list<PrepaymentBalance> $balances
-     * @return array{received: float, applied: float, inGlobal: float, unapplied: float}
-     */
-    public static function totals(array $balances): array
-    {
-        $totals = ['received' => 0.0, 'applied' => 0.0, 'inGlobal' => 0.0, 'unapplied' => 0.0];
-
-        foreach ($balances as $balance) {
-            $totals['received'] += $balance->received;
-            $totals['applied'] += $balance->applied;
-            $totals['inGlobal'] += $balance->inGlobal;
-            $totals['unapplied'] += $balance->unapplied;
-        }
-
-        return $totals;
-    }
 }

--- a/src/Billing/PrepaymentBalanceService.php
+++ b/src/Billing/PrepaymentBalanceService.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * Query service for open prepayment balances.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (C) 2026 Stephen Waite <stephen.waite@cmsvt.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Billing;
+
+use OpenEMR\Common\Database\QueryUtils;
+
+/**
+ * Finds pre-payment sessions whose received amount has not been fully applied.
+ *
+ * "Unapplied" is ar_session.pay_total minus the sum of live
+ * (deleted IS NULL) ar_activity.pay_amount rows for the session, and
+ * deliberately does not subtract ar_session.global_amount. Money swept to the
+ * Global Account has not satisfied a charge, so it remains an unapplied credit;
+ * it is reported separately as inGlobal so parked credit stays visible.
+ */
+class PrepaymentBalanceService
+{
+    /**
+     * Amounts below this are rounding residue, not a real balance.
+     */
+    private const UNAPPLIED_EPSILON = 0.005;
+
+    /**
+     * @param string|null $fromDate Y-m-d lower bound on check_date, null for none
+     * @param string|null $toDate Y-m-d upper bound on check_date, null for none
+     * @param int|null $patientId Limit to one patient, null for all
+     * @param bool $parkedOnly Only sessions with a non-zero global_amount
+     * @return list<PrepaymentBalance> Ordered by unapplied amount, largest first
+     */
+    public function getOpenBalances(
+        ?string $fromDate = null,
+        ?string $toDate = null,
+        ?int $patientId = null,
+        bool $parkedOnly = false,
+    ): array {
+        // Applied money is pre-aggregated per (session, pid) so that a session
+        // with several distributions does not fan out and multiply pay_total.
+        //
+        // The unapplied threshold is applied in WHERE rather than HAVING: the
+        // outer query has no GROUP BY, so a bare HAVING would depend on a MySQL
+        // extension to standard SQL.
+        $sql = "SELECT s.session_id, s.patient_id, s.check_date, s.reference,
+                       s.pay_total, s.global_amount,
+                       COALESCE(act.applied, 0) AS applied,
+                       s.pay_total - COALESCE(act.applied, 0) AS unapplied,
+                       DATEDIFF(CURDATE(), s.check_date) AS days_open,
+                       p.lname, p.fname, p.mname
+                  FROM ar_session AS s
+                  LEFT JOIN (
+                       SELECT session_id, pid, SUM(pay_amount) AS applied
+                         FROM ar_activity
+                        WHERE deleted IS NULL
+                        GROUP BY session_id, pid
+                       ) AS act
+                    ON act.session_id = s.session_id AND act.pid = s.patient_id
+                  LEFT JOIN patient_data AS p ON p.pid = s.patient_id
+                 WHERE s.adjustment_code = 'pre_payment'
+                   AND s.closed = 0
+                   AND (s.pay_total - COALESCE(act.applied, 0)) > ?";
+
+        $binds = [self::UNAPPLIED_EPSILON];
+
+        if ($fromDate !== null && $fromDate !== '') {
+            $sql .= " AND s.check_date >= ?";
+            $binds[] = $fromDate;
+        }
+        if ($toDate !== null && $toDate !== '') {
+            $sql .= " AND s.check_date <= ?";
+            $binds[] = $toDate;
+        }
+        if ($patientId !== null) {
+            $sql .= " AND s.patient_id = ?";
+            $binds[] = $patientId;
+        }
+        if ($parkedOnly) {
+            $sql .= " AND s.global_amount != 0";
+        }
+
+        $sql .= " ORDER BY unapplied DESC, s.check_date ASC";
+
+        $balances = [];
+        foreach (QueryUtils::fetchRecords($sql, $binds) as $row) {
+            $balances[] = PrepaymentBalance::fromRow($row);
+        }
+
+        return $balances;
+    }
+
+    /**
+     * Column totals for the report footer.
+     *
+     * @param list<PrepaymentBalance> $balances
+     * @return array{received: float, applied: float, inGlobal: float, unapplied: float}
+     */
+    public function totals(array $balances): array
+    {
+        $totals = ['received' => 0.0, 'applied' => 0.0, 'inGlobal' => 0.0, 'unapplied' => 0.0];
+
+        foreach ($balances as $balance) {
+            $totals['received'] += $balance->received;
+            $totals['applied'] += $balance->applied;
+            $totals['inGlobal'] += $balance->inGlobal;
+            $totals['unapplied'] += $balance->unapplied;
+        }
+
+        return $totals;
+    }
+}

--- a/tests/Tests/Isolated/Billing/PrepaymentBalanceTest.php
+++ b/tests/Tests/Isolated/Billing/PrepaymentBalanceTest.php
@@ -15,7 +15,6 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Isolated\Billing;
 
 use OpenEMR\Billing\PrepaymentBalance;
-use OpenEMR\Billing\PrepaymentBalanceService;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -129,7 +128,7 @@ class PrepaymentBalanceTest extends TestCase
             ])),
         ];
 
-        $totals = PrepaymentBalanceService::totals($balances);
+        $totals = PrepaymentBalance::totals($balances);
 
         $this->assertSame(350.00, $totals['received']);
         $this->assertSame(75.00, $totals['applied']);
@@ -139,7 +138,7 @@ class PrepaymentBalanceTest extends TestCase
 
     public function testTotalsOfEmptyResultAreZero(): void
     {
-        $totals = PrepaymentBalanceService::totals([]);
+        $totals = PrepaymentBalance::totals([]);
 
         $this->assertSame(
             ['received' => 0.0, 'applied' => 0.0, 'inGlobal' => 0.0, 'unapplied' => 0.0],

--- a/tests/Tests/Isolated/Billing/PrepaymentBalanceTest.php
+++ b/tests/Tests/Isolated/Billing/PrepaymentBalanceTest.php
@@ -129,7 +129,7 @@ class PrepaymentBalanceTest extends TestCase
             ])),
         ];
 
-        $totals = (new PrepaymentBalanceService())->totals($balances);
+        $totals = PrepaymentBalanceService::totals($balances);
 
         $this->assertSame(350.00, $totals['received']);
         $this->assertSame(75.00, $totals['applied']);
@@ -139,7 +139,7 @@ class PrepaymentBalanceTest extends TestCase
 
     public function testTotalsOfEmptyResultAreZero(): void
     {
-        $totals = (new PrepaymentBalanceService())->totals([]);
+        $totals = PrepaymentBalanceService::totals([]);
 
         $this->assertSame(
             ['received' => 0.0, 'applied' => 0.0, 'inGlobal' => 0.0, 'unapplied' => 0.0],

--- a/tests/Tests/Isolated/Billing/PrepaymentBalanceTest.php
+++ b/tests/Tests/Isolated/Billing/PrepaymentBalanceTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Isolated tests for prepayment balance narrowing and totals.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (C) 2026 Stephen Waite <stephen.waite@cmsvt.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Billing;
+
+use OpenEMR\Billing\PrepaymentBalance;
+use OpenEMR\Billing\PrepaymentBalanceService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The report reads eleven untyped columns per row. These tests pin the
+ * narrowing in PrepaymentBalance::fromRow() and the footer arithmetic, neither
+ * of which needs a database.
+ */
+class PrepaymentBalanceTest extends TestCase
+{
+    /**
+     * @param array<string, mixed> $overrides
+     * @return array<string, mixed>
+     */
+    private function row(array $overrides = []): array
+    {
+        return array_merge([
+            'session_id' => '412',
+            'patient_id' => '1088',
+            'check_date' => '2026-03-14',
+            'reference' => 'CK 20194',
+            'pay_total' => '250.00',
+            'global_amount' => '0.00',
+            'applied' => '75.00',
+            'unapplied' => '175.00',
+            'days_open' => '169',
+            'lname' => 'Alvarez',
+            'fname' => 'Renata',
+            'mname' => 'K',
+        ], $overrides);
+    }
+
+    public function testNarrowsStringColumnsToScalars(): void
+    {
+        $balance = PrepaymentBalance::fromRow($this->row());
+
+        $this->assertSame(412, $balance->sessionId);
+        $this->assertSame(1088, $balance->patientId);
+        $this->assertSame('Alvarez, Renata K', $balance->patientName);
+        $this->assertSame('CK 20194', $balance->reference);
+        $this->assertSame('2026-03-14', $balance->checkDate);
+        $this->assertSame(169, $balance->daysOpen);
+        $this->assertSame(250.00, $balance->received);
+        $this->assertSame(75.00, $balance->applied);
+        $this->assertSame(0.00, $balance->inGlobal);
+        $this->assertSame(175.00, $balance->unapplied);
+    }
+
+    public function testMissingColumnsFallBackToZeroAndEmptyString(): void
+    {
+        $balance = PrepaymentBalance::fromRow([]);
+
+        $this->assertSame(0, $balance->sessionId);
+        $this->assertSame('', $balance->patientName);
+        $this->assertSame('', $balance->reference);
+        $this->assertNull($balance->checkDate);
+        $this->assertSame(0.0, $balance->unapplied);
+    }
+
+    public function testNonNumericAmountsBecomeZeroRatherThanCoercing(): void
+    {
+        $balance = PrepaymentBalance::fromRow($this->row([
+            'pay_total' => null,
+            'applied' => 'not a number',
+            'unapplied' => [],
+        ]));
+
+        $this->assertSame(0.0, $balance->received);
+        $this->assertSame(0.0, $balance->applied);
+        $this->assertSame(0.0, $balance->unapplied);
+    }
+
+    public function testNullCheckDateStaysNull(): void
+    {
+        $this->assertNull(PrepaymentBalance::fromRow($this->row(['check_date' => null]))->checkDate);
+        $this->assertNull(PrepaymentBalance::fromRow($this->row(['check_date' => '']))->checkDate);
+    }
+
+    /**
+     * A patient_data row can be missing entirely on a LEFT JOIN, and middle
+     * names are frequently blank; neither should leave stray punctuation.
+     */
+    public function testNameFormattingHandlesAbsentParts(): void
+    {
+        $this->assertSame(
+            'Alvarez, Renata',
+            PrepaymentBalance::fromRow($this->row(['mname' => '']))->patientName
+        );
+        $this->assertSame(
+            'Alvarez',
+            PrepaymentBalance::fromRow($this->row(['fname' => '', 'mname' => '']))->patientName
+        );
+        $this->assertSame(
+            'Renata',
+            PrepaymentBalance::fromRow($this->row(['lname' => '', 'mname' => '']))->patientName
+        );
+        $this->assertSame(
+            '',
+            PrepaymentBalance::fromRow($this->row(['lname' => '', 'fname' => '', 'mname' => '']))->patientName
+        );
+    }
+
+    public function testTotalsSumEachColumn(): void
+    {
+        $balances = [
+            PrepaymentBalance::fromRow($this->row()),
+            PrepaymentBalance::fromRow($this->row([
+                'pay_total' => '100.00',
+                'applied' => '0.00',
+                'global_amount' => '40.00',
+                'unapplied' => '100.00',
+            ])),
+        ];
+
+        $totals = (new PrepaymentBalanceService())->totals($balances);
+
+        $this->assertSame(350.00, $totals['received']);
+        $this->assertSame(75.00, $totals['applied']);
+        $this->assertSame(40.00, $totals['inGlobal']);
+        $this->assertSame(275.00, $totals['unapplied']);
+    }
+
+    public function testTotalsOfEmptyResultAreZero(): void
+    {
+        $totals = (new PrepaymentBalanceService())->totals([]);
+
+        $this->assertSame(
+            ['received' => 0.0, 'applied' => 0.0, 'inGlobal' => 0.0, 'unapplied' => 0.0],
+            $totals
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new financial report, **Reports → Financial → Prepay Balances**, listing
open pre-payment sessions whose received amount has not been fully applied to
charges.

There is currently no way to answer "which patient prepayments are still sitting
unapplied, and for how long." `search_payments.php` is session-lookup oriented —
it finds a session you already know about, but it cannot filter on "received
minus applied is greater than zero," so unapplied prepayment credit is only
discoverable by opening sessions one at a time. For practices that take
prepayments this is a recurring reconciliation gap, and stale unapplied credit is
both a patient-refund liability and a source of misleading A/R.

## Files

| File | Purpose |
|---|---|
| `interface/reports/prepayment_balance_report.php` | The report view |
| `src/Billing/PrepaymentBalance.php` | Read model for one row |
| `src/Billing/PrepaymentBalanceService.php` | Query and totals |
| `tests/Tests/Isolated/Billing/PrepaymentBalanceTest.php` | Isolated tests |
| `interface/main/tabs/menu/menus/standard.json` | Menu entry under Financial |

## What it shows

Patient, PID, Session, Reference, Check Date, Days Open, Received, Applied,
In Global, Unapplied, with totals in the footer. Session IDs open
`billing/edit_payment.php` in a `medium_modal` dialog so a prepayment can be
distributed without leaving the report; `onClosed` re-submits the form, so
sessions that become fully applied drop off the list immediately.

`Unapplied` is `ar_session.pay_total` minus the sum of live (`deleted IS NULL`)
`ar_activity.pay_amount` rows for that session and patient.

`In Global` reports `ar_session.global_amount` as its own column rather than
subtracting it from `Unapplied`. Money moved to the Global Account has not
satisfied a charge, so for reconciliation purposes it is still unapplied patient
money — but it is useful to see how much of the unapplied total is parked there,
hence a separate column rather than a silent deduction.

All filters are optional. An empty check-date bound means no bound in that
direction, so the default view is every open prepayment regardless of age.
`Parked in Global only` narrows to sessions with a non-zero `global_amount`.

## Implementation notes

- Applied amounts are pre-aggregated in a derived table keyed on
  `(session_id, pid)` so a session with multiple distributions does not fan out
  and multiply `pay_total` across rows.
- The unapplied threshold is applied in `WHERE`, not `HAVING`. The outer query
  has no `GROUP BY`, so a bare `HAVING` would depend on a MySQL extension to
  standard SQL. The `0.005` epsilon keeps sub-cent rounding residue off the list.
- The query returns eleven untyped columns. `PrepaymentBalance::fromRow()`
  narrows them once behind `is_numeric()` / `is_scalar()` guards so the template
  works against typed properties, rather than repeating conversions at each
  `echo`. Both `/src/` classes are `declare(strict_types=1)`.
- Input is read through `CurrentRequest::get()` and the typed `InputBag` getters;
  the report touches no superglobals and uses `QueryUtils` for the query.
- ACL is `acct` / `rep_a`, enforced in the page via `AccessDeniedHelper` and
  declared in the menu entry, matching the neighboring Payment Processing entry.
- All output escaped via `text()` / `attr()` / `attr_url()`; all user-supplied
  filter values are parameter-bound.
- No new PHPStan baseline entries.

## Scope note for reviewers

The report keys on `adjustment_code = 'pre_payment'`, which in core is written
only by the front-desk Pre Pay path in `interface/patient_file/front_payment.php`.
An undistributed `patient_payment` entered through Billing → Payments is
arguably the same reconciliation problem and is not listed. Widening to
`IN ('pre_payment', 'patient_payment')`, or dropping the category filter in
favor of `patient_id != 0`, would catch both. Happy to change this — it is a
question of what the report is claiming to be, so I would rather agree on it
than pick unilaterally.

## Testing

`PrepaymentBalanceTest` covers the row narrowing (missing keys, non-numeric
amounts, null check dates, name assembly with absent parts) and the footer
totals. It needs no database and runs in the isolated suite:

```
openemr-cmd pit
```

Manual verification:

1. Create a patient prepayment (Fees → Payment, Pre Pay) and do not distribute
   it. It appears with `Applied` 0 and `Unapplied` equal to `Received`.
2. Distribute part of it. `Applied` and `Unapplied` move accordingly and the row
   remains listed.
3. Distribute the remainder. The row disappears on the next submit.
4. Sweep an amount to the Global Account. It shows under `In Global` while still
   counting toward `Unapplied`.
5. Void a distribution (`ar_activity.deleted` set). The voided amount returns to
   `Unapplied`.
6. The check-date range, patient, and `Parked in Global only` filters each narrow
   the result set, and all four totals foot to the column sums.
7. A user without `acct` / `rep_a` gets the unauthorized page and does not see
   the menu entry.

Assisted by Claude.ai