### PR TITLE
fix(acceptance): shell guards read ACCEPTANCE_EXPECTED_VERSION env

### DIFF
--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -399,6 +399,18 @@ jobs:
       # into the DB `version` table. See openemr/openemr#13753 for
       # the failure trace when these two were coupled.
       EXPECTED_VERSION: ${{ needs.detect-mode.outputs.expected_version }}
+      # ACCEPTANCE_EXPECTED_VERSION at job level so every step can
+      # read it: the PHPUnit version-display / version-api groups
+      # (the six per-step assignments below still exist for readability
+      # + intent; they resolve to the same value so are effectively
+      # no-op overrides), AND the boot-package.sh / upgrade-package.sh
+      # post-install/post-upgrade DB-version guards. Those two shell
+      # guards previously compared DB_VERSION against the positional
+      # VERSION/TO_VERSION arg (i.e. the label), which on build_locally
+      # can never equal the DB value. Making them read this env
+      # completes the #13753 fix; the shell scripts fall back to their
+      # positional arg when the env is unset (dev-time standalone use).
+      ACCEPTANCE_EXPECTED_VERSION: ${{ needs.detect-mode.outputs.expected_version }}
       ACCEPTANCE_ARTIFACT_URL: http://localhost:8680
     name: ${{ matrix.scenario }} (${{ matrix.format }})
     steps:
@@ -640,6 +652,14 @@ jobs:
     # empty string when build-tarball didn't run).
     - name: Boot tarball artifact (from_version)
       if: matrix.scenario == 'upgrade'
+      # Override ACCEPTANCE_EXPECTED_VERSION from its job-level default
+      # (which points at the TO-side expected version) to FROM_VERSION —
+      # this step boots the from-side artifact, so the DB will contain
+      # FROM_VERSION at this point, not the TO-side expected. Without
+      # this override boot-package.sh's DB-version guard hard-fails
+      # comparing DB=<from> against expected=<to>.
+      env:
+        ACCEPTANCE_EXPECTED_VERSION: ${{ env.FROM_VERSION }}
       run: tests/Acceptance/bin/boot-package.sh "${FROM_VERSION}"
 
     - name: Run acceptance suite (fresh-install of from_version)
@@ -710,6 +730,10 @@ jobs:
     # select → submit → verify / redirects to login).
     - name: Boot tarball artifact (from_version)
       if: matrix.scenario == 'wizard-upgrade'
+      # Same override as the upgrade scenario's from-side boot: the DB
+      # will contain FROM_VERSION at this point, not the TO expected.
+      env:
+        ACCEPTANCE_EXPECTED_VERSION: ${{ env.FROM_VERSION }}
       run: tests/Acceptance/bin/boot-package.sh "${FROM_VERSION}"
 
     - name: Swap bind mount to to_version without running CLI upgrade

--- a/docs/artifact-acceptance-testing-plan.md
+++ b/docs/artifact-acceptance-testing-plan.md
@@ -586,6 +586,24 @@ assertion to `TO_VERSION` — the pattern that #13635 originally
 shipped, and #13753 later corrected — made the acceptance groups
 un-passable on `build_locally=true`. Do not re-couple.
 
+**Follow-up fix (openemr/openemr#13786)**: #13761 covered the six
+workflow-level `ACCEPTANCE_EXPECTED_VERSION` sites (the PHPUnit
+version-display / version-api groups) but missed the two identical
+shell-level DB assertions in `boot-package.sh` and `upgrade-package.sh`,
+which compared `DB_VERSION` against their positional `VERSION` /
+`TO_VERSION` args (i.e. the cosmetic label). Same divergence, same
+symptom (`post-install DB version '8.4.0' does not match expected
+'99.99.99'`), same failure mode as before the label-vs-actual split
+was recognized. Follow-up makes both shell guards read
+`ACCEPTANCE_EXPECTED_VERSION` env if set (falling back to the
+positional arg for dev-time standalone runs), and promotes
+`ACCEPTANCE_EXPECTED_VERSION` from per-step assignments to a job-level
+env so both the PHPUnit consumers and the shell scripts see the same
+value automatically. Discovered by a `workflow_dispatch -f
+build_locally=true` smoke test against master post-#13761 merge —
+that PR's own CI hadn't exercised the build_locally path because
+#13761 didn't touch `tools/release/**`.
+
 Exit criterion (met): end-to-end `build_locally=true` demo on a
 real runner produced 6/6 green — `detect-mode`, `build-tarball`
 (PackageAssembler produced tarball from PR HEAD), `fresh-install`,

--- a/tests/Acceptance/bin/boot-package.sh
+++ b/tests/Acceptance/bin/boot-package.sh
@@ -292,18 +292,31 @@ done
 # wasn't seeded correctly. Same signal /api/version reads later, but
 # available immediately without needing the REST API bootstrap.
 #
+# Assertion source: ACCEPTANCE_EXPECTED_VERSION env if set, else the
+# positional VERSION arg. The env variant is set by the acceptance
+# workflow to the same value it feeds the PHPUnit version-display /
+# version-api groups — on the build_locally path this reads the
+# checkout's version.php (the actual shipped self-reported version),
+# NOT the cosmetic `--release-version` label passed to PackageAssembler
+# (99.99.99 default). VERSION as fallback keeps this script usable
+# standalone (dev-time boot without the workflow's env-plumbing) and
+# on the shipped-tarball path where label == actual anyway. See
+# openemr/openemr#13753 for the full failure trace when the two
+# diverged.
+#
 # Root creds `root/root` are the acceptance stack default
 # (`.github/docker/acceptance-package-compose.yml:MYSQL_ROOT_PASSWORD`).
 # `-sN` = silent + no column headers; direct scalar output.
 # `mariadb` (not `mysql`) — the mariadb 11.8 image ships only the
 # `mariadb` client binary; `mysql` is not on $PATH.
-echo "==> Asserting DB version matches ${VERSION}"
+EXPECTED="${ACCEPTANCE_EXPECTED_VERSION:-${VERSION}}"
+echo "==> Asserting DB version matches ${EXPECTED}"
 DB_VERSION="$(docker compose exec -T mysql \
     mariadb -uroot -proot openemr -sN \
     -e "SELECT CONCAT(v_major,'.',v_minor,'.',v_patch) FROM version" \
     2>/dev/null || echo "query-failed")"
-if [[ "${DB_VERSION}" != "${VERSION}" ]]; then
-    echo "::error::post-install DB version '${DB_VERSION}' does not match expected '${VERSION}' (see openemr/openemr#13634)" >&2
+if [[ "${DB_VERSION}" != "${EXPECTED}" ]]; then
+    echo "::error::post-install DB version '${DB_VERSION}' does not match expected '${EXPECTED}' (see openemr/openemr#13634)" >&2
     exit 1
 fi
 echo "    DB version=${DB_VERSION}"

--- a/tests/Acceptance/bin/upgrade-package.sh
+++ b/tests/Acceptance/bin/upgrade-package.sh
@@ -307,21 +307,35 @@ done
 
 # Post-upgrade DB version assertion (openemr/openemr#13634).
 # sql_upgrade.php bumps the `version` row as its final step, so a
-# successful upgrade leaves DB=TO_VERSION. Catches the exact bug
-# class fixed in #13586/#13587 (fsupgrade sed pattern targeted a
-# refactored-away line → silent no-op → version row never advanced,
-# upgrade replayed from 2.9.0 on every run). Skipped in
-# --skip-sql-upgrade mode: that path exits before this point (line
-# ~281) because the Panther wizard test runs the upgrade later.
+# successful upgrade leaves DB matching the to-side tarball's
+# version.php. Catches the exact bug class fixed in #13586/#13587
+# (fsupgrade sed pattern targeted a refactored-away line → silent
+# no-op → version row never advanced, upgrade replayed from 2.9.0
+# on every run). Skipped in --skip-sql-upgrade mode: that path exits
+# before this point (line ~281) because the Panther wizard test runs
+# the upgrade later.
+#
+# Assertion source: ACCEPTANCE_EXPECTED_VERSION env if set, else
+# TO_VERSION. The env variant is set by the acceptance workflow to
+# the same value it feeds the PHPUnit version-display / version-api
+# groups — on the build_locally path this reads the checkout's
+# version.php (the actual shipped self-reported version), NOT the
+# cosmetic `--release-version` label passed to PackageAssembler
+# (99.99.99 default). TO_VERSION as fallback keeps this script usable
+# standalone (dev-time upgrade without the workflow's env-plumbing)
+# and on the shipped-tarball path where label == actual anyway. See
+# openemr/openemr#13753 for the full failure trace when the two
+# diverged.
 # `mariadb` (not `mysql`) — the mariadb 11.8 image ships only the
 # `mariadb` client binary; `mysql` is not on $PATH.
-echo "==> Asserting DB version matches ${TO_VERSION}"
+EXPECTED="${ACCEPTANCE_EXPECTED_VERSION:-${TO_VERSION}}"
+echo "==> Asserting DB version matches ${EXPECTED}"
 DB_VERSION="$(docker compose exec -T mysql \
     mariadb -uroot -proot openemr -sN \
     -e "SELECT CONCAT(v_major,'.',v_minor,'.',v_patch) FROM version" \
     2>/dev/null || echo "query-failed")"
-if [[ "${DB_VERSION}" != "${TO_VERSION}" ]]; then
-    echo "::error::post-upgrade DB version '${DB_VERSION}' does not match expected '${TO_VERSION}' (see openemr/openemr#13634)" >&2
+if [[ "${DB_VERSION}" != "${EXPECTED}" ]]; then
+    echo "::error::post-upgrade DB version '${DB_VERSION}' does not match expected '${EXPECTED}' (see openemr/openemr#13634)" >&2
     exit 1
 fi
 echo "    DB version=${DB_VERSION}"


### PR DESCRIPTION
Follow-up to #13761. Closes the remainder of #13753.

## The gap

#13761 covered the **six workflow-level `ACCEPTANCE_EXPECTED_VERSION` sites** (PHPUnit version-display / version-api groups) but missed the **two identical shell-level DB assertions**:

- `tests/Acceptance/bin/boot-package.sh:305`
- `tests/Acceptance/bin/upgrade-package.sh:323`

Both compared `DB_VERSION` against the positional `VERSION` / `TO_VERSION` arg — i.e. the cosmetic label. On build_locally the DB reports whatever `version.php` says (say `8.4.0` on master), while the label is `99.99.99` by default (or whatever operator dispatched). Same divergence, same symptom, same failure trace as the original bug:

```
::error::post-install DB version '8.4.0' does not match expected '8.2.0' (see openemr/openemr#13634)
```

@kojiromike's original #13753 report explicitly listed all three assertion sites and suggested using `version.php` for `ACCEPTANCE_EXPECTED_VERSION` **and the two shell guards**. #13761 did the first half; this PR does the second.

## Fix

- **`boot-package.sh` + `upgrade-package.sh`**: read `ACCEPTANCE_EXPECTED_VERSION` env if set, fall back to positional arg. Backward-compat keeps standalone dev-time invocation (no env wiring) working; on the shipped-tarball path where label == actual, the fallback is a no-op.
- **`acceptance-package.yml`**: promote `ACCEPTANCE_EXPECTED_VERSION` from per-step assignments to a **job-level env** (`${{ needs.detect-mode.outputs.expected_version }}`), so every step — including boot/upgrade shell steps — inherits it automatically. Existing per-step assignments still exist for readability/intent; they resolve to the same value so are effectively no-op overrides.

Zero changes to the underlying assertion logic; only its source-of-truth changes.

## How this gap was found

A `workflow_dispatch -f build_locally=true -f to_version=8.2.0` smoke test against master, post-#13761 merge:
- `detect-mode` correctly emitted `expected_version=8.4.0` (reading master's `version.php`)
- All 8 install/upgrade acceptance jobs still failed with the old `post-install DB version '8.4.0' does not match expected '8.2.0'` error from `boot-package.sh:305`

#13761's own CI hadn't caught this because that PR didn't touch `tools/release/**` — so the paths-filter auto-fire never triggered a build_locally run against #13761's changes. The smoke-test caught the gap #13761's self-tests couldn't.

## Test plan

- [x] shellcheck clean on both scripts
- [x] actionlint clean on the workflow
- [x] Pre-commit hook suite clean (via container-routed hook)
- [ ] Re-run the same `workflow_dispatch -f build_locally=true` smoke test on this PR's branch after merge — should now go 8/8 green

## Doc update

`docs/artifact-acceptance-testing-plan.md`'s "TO_VERSION (label) vs EXPECTED_VERSION (actual) split" section now notes this follow-up landed and warns future maintainers that the shell-guard fallback exists for standalone use — do not remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)