### PR TITLE
fix(acceptance): strip v_tag/realpatch suffix from About page comparison

### DIFF
--- a/docs/artifact-acceptance-testing-plan.md
+++ b/docs/artifact-acceptance-testing-plan.md
@@ -604,6 +604,32 @@ build_locally=true` smoke test against master post-#13761 merge —
 that PR's own CI hadn't exercised the build_locally path because
 #13761 didn't touch `tools/release/**`.
 
+**Second follow-up (openemr/openemr#13790)** discovered by re-running
+the same smoke test after #13786 landed: the About page displays
+`SoftwareVersion::__toString()` which returns
+`"{base}[{tag}][.{realpatch}]"`, so on master (with `$v_tag='-dev'`)
+it renders `8.4.0-dev` while the DB `version` table only holds `8.4.0`
+(schema has no v_tag column). `ACCEPTANCE_EXPECTED_VERSION` intentionally
+stays at X.Y.Z shape (uniform with the DB + `/api/version` assertions,
+both of which return X.Y.Z), and `VersionDisplayAcceptanceTest` was
+updated to compare against the X.Y.Z prefix of the About page's
+displayed value — dropping the mid-cycle suffix. On shipped tarballs
+release-prep sets `$v_tag=''` + `$v_realpatch=0`, so the strip is a
+no-op there; the divergence only shows up on `build_locally=true`
+against a dev-tagged checkout.
+
+**Also flagged for cleanup**: the workflow's `to_version`
+`workflow_dispatch` input is `required: true` with `default: '8.2.0'`.
+On a manual dispatch with `-f build_locally=true` but no
+`-f to_version=`, the input default (`8.2.0`) still overrides
+`emit_to_version`'s build_locally branch (which would otherwise
+resolve to `99.99.99`). The stale default also drives downgrade
+failures when the derived `from_version` is >= `8.2.0` (currently
+`8.3.0` on master). Fix is to change the input default from `'8.2.0'`
+to `''` (empty), which `emit_to_version`'s `[[ -n "${DISPATCH_TO_VERSION}" ]]`
+guard already handles — cleanly falling through to the build_locally
+99.99.99 default. Separate PR when convenient; not blocking.
+
 Exit criterion (met): end-to-end `build_locally=true` demo on a
 real runner produced 6/6 green — `detect-mode`, `build-tarball`
 (PackageAssembler produced tarball from PR HEAD), `fresh-install`,

--- a/tests/Acceptance/VersionDisplayAcceptanceTest.php
+++ b/tests/Acceptance/VersionDisplayAcceptanceTest.php
@@ -59,15 +59,37 @@ final class VersionDisplayAcceptanceTest extends PantherAcceptanceTestCase
     private const ABOUT_URL = '/interface/main/about_page.php';
 
     /**
-     * Login as admin, GET the About page directly, assert the version
-     * displayed in `.version-info strong` matches
-     * `ACCEPTANCE_EXPECTED_VERSION`.
+     * Login as admin, GET the About page directly, assert the X.Y.Z
+     * prefix of the version displayed in `.version-info strong`
+     * matches `ACCEPTANCE_EXPECTED_VERSION`.
      *
      * Direct navigation (not via the user-menu "About OpenEMR" click)
      * because the goal is to validate the version-render pipe, not the
      * menu wiring — the menu wiring is already covered by
      * `GgUserMenuLinksAcceptanceTest::testUserMenuLink` for the
      * 'About OpenEMR user menu link' data-provider row.
+     *
+     * X.Y.Z prefix comparison, not full displayed string: the About
+     * page renders `SoftwareVersion::__toString()`, which returns
+     * `$full = "{base}[{tag}][.{realpatch}]"` per
+     * SoftwareVersion::__construct's match block. On a shipped
+     * tarball release-prep sets `$v_tag=''` + `$v_realpatch=0`, so
+     * `$full == $base` and comparing the whole string works. On the
+     * build_locally acceptance path (openemr/openemr#13753),
+     * version.php in the checkout is mid-cycle (e.g. `-dev` tagged on
+     * master) so the About page renders `8.4.0-dev` while the DB
+     * `version` table only holds `8.4.0` (schema has no v_tag column;
+     * `boot-package.sh`'s check queries
+     * `CONCAT(v_major,'.',v_minor,'.',v_patch)`) and `/api/version`
+     * likewise returns X.Y.Z as three separate JSON fields.
+     * Keeping `ACCEPTANCE_EXPECTED_VERSION` at X.Y.Z shape (uniform
+     * with the DB + API assertions) means the About page's displayed
+     * value needs its suffix stripped before comparison — the X.Y.Z
+     * prefix is what the file-version pipe (version.php →
+     * OEGlobalsBag → VersionService → SoftwareVersion → About page)
+     * is really carrying across, and that's what this test validates
+     * end-to-end. See openemr/openemr#13786 test-plan for the failure
+     * trace when the suffix wasn't stripped.
      */
     public function testAboutPageShowsExpectedVersion(): void
     {
@@ -94,12 +116,27 @@ final class VersionDisplayAcceptanceTest extends PantherAcceptanceTestCase
         // observed page title + URL in the assertion diagnostic —
         // better signal than a silent version-check bypass.
         $element = $client->findElement(WebDriverBy::cssSelector('.version-info strong'));
-        $actual = trim($element->getText());
+        $displayed = trim($element->getText());
+
+        // Extract the leading X.Y.Z prefix (see docstring). Fail loud
+        // if the displayed value doesn't start with an X.Y.Z shape at
+        // all — that means the version-render pipe is broken in a way
+        // beyond a mere v_tag/realpatch suffix, and the assertSame
+        // below would produce a less-useful diagnostic.
+        if (preg_match('/^\d+\.\d+\.\d+/', $displayed, $match) !== 1) {
+            self::fail(
+                "About page displayed version '{$displayed}' does not start with an X.Y.Z prefix. "
+                . 'The version-render pipe is broken beyond a v_tag/realpatch suffix — check '
+                . 'templates/core/about.html.twig + SoftwareVersion::__toString() + version.php '
+                . 'in the artifact.',
+            );
+        }
+        $actual = $match[0];
 
         self::assertSame(
             $expected,
             $actual,
-            "About page displayed version '{$actual}' does not match expected '{$expected}'. "
+            "About page displayed version '{$displayed}' (X.Y.Z prefix '{$actual}') does not match expected '{$expected}'. "
             . 'Landing URL: ' . $client->getCurrentURL() . '. '
             . 'Title: ' . $client->getTitle() . '. '
             . 'This most likely means the artifact ships a version.php that does not match '


### PR DESCRIPTION
Second follow-up to #13761 / #13786. Closes remainder of #13753.

## The gap

After #13786 landed and I re-ran the same `workflow_dispatch -f build_locally=true` smoke test against master, the acceptance jobs failed with:

```
About page displayed version '8.4.0-dev' does not match expected '8.4.0'
```

The About page renders `SoftwareVersion::__toString()` which returns `$full = "{base}[{tag}][.{realpatch}]"` per `SoftwareVersion::__construct`. On a shipped tarball release-prep sets `$v_tag=''` + `$v_realpatch=0`, so `$full == $base` and asserting the whole string worked. On the build_locally path with master mid-cycle (`$v_tag='-dev'`) the About page renders `8.4.0-dev` while:

- **DB `version` table** holds `8.4.0` (schema has no v_tag column; `boot-package.sh`'s assertion queries `CONCAT(v_major,'.',v_minor,'.',v_patch)`)
- **`/api/version`** returns `8.4.0` (`VersionApiAcceptanceTest` concats the three JSON fields, matching DB shape)

## Fix

`ACCEPTANCE_EXPECTED_VERSION` intentionally kept at X.Y.Z shape (uniform with DB + API). `VersionDisplayAcceptanceTest` now extracts the X.Y.Z prefix from the About page's displayed value before comparing. On shipped tarballs the strip is a no-op since `$full == $base` already. On build_locally against a dev-tagged checkout, the strip drops `-dev` (or `.1`, or `-dev.1` for combos) so the assertion works.

Fail-loud regex validator confirms the displayed value starts with an X.Y.Z shape — if the render pipe is broken beyond a mere suffix, the diagnostic still points at the right file.

## Alternative rejected

Adding a second env `ACCEPTANCE_EXPECTED_DISPLAY_VERSION` (full X.Y.Z-tag.realpatch string) would preserve the test's original strict-string assertion. Rejected because release-prep enforces `v_tag=''` on shipped tarballs — the strictness has no real-world payoff, and the two-env plumbing (new `read_tree_display_version` in `detect-acceptance-mode.sh`, new detect-mode output, new workflow env, new test env override) is 4x the surgery.

## Discovery pattern

Third dispatch in a row surfacing a distinct gap in the same #13753 bug family — one gap deeper each time:

1. **#13761** — label (TO_VERSION) vs version.php divergence, 6 workflow-level assertions
2. **#13786** — same divergence, missed in boot-package.sh + upgrade-package.sh shell guards
3. **This PR** — About page assertion's shape (`$full`) diverges from DB/API (`$base`) on dev-tagged checkouts

Each was caught by the same manual smoke-test-after-merge cycle. Suggests two things worth flagging (both captured in the doc):

- Consider adding a `tools/release/README.md` touch (or similar) as a self-test in the next fix so the auto-fire path exercises the change in-PR
- The workflow's `to_version` `workflow_dispatch` input has a stale `default: '8.2.0'` that overrides `emit_to_version`'s build_locally 99.99.99 default when the dispatcher just passes `-f build_locally=true`. Change to `default: ''`. Separate PR when convenient; not blocking this one.

## Test plan

- [x] PHP syntax check (via pre-commit)
- [x] shellcheck (n/a — no shell changes)
- [x] actionlint (n/a — no workflow changes)
- [x] PHPStan (via pre-commit)
- [ ] End-to-end: another `gh workflow run acceptance-package.yml --ref master -f build_locally=true` after merge, this time with the `to_version` default noted above so no downgrade fallout. Should go 4-of-4 green on the install-side legs (fresh-install / wizard-install × tar / zip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)