### PR TITLE
fix(ci): drop stale to_version default from acceptance-package workflow_dispatch

### DIFF
--- a/.github/workflows/acceptance-package.yml
+++ b/.github/workflows/acceptance-package.yml
@@ -56,10 +56,10 @@ on:
         type: string
         default: ''
       to_version:
-        description: 'Target openemr version (release tag suffix, e.g. 8.2.0)'
-        required: true
+        description: 'Target openemr version (release tag suffix, e.g. 8.2.0). Leave empty to use detect-acceptance-mode.sh emit_to_version defaults — 99.99.99 label on build_locally=true, 8.2.0 shipped-tarball fallback otherwise. Explicit value here still wins over both defaults (DISPATCH_TO_VERSION takes precedence). Matches the workflow_call variant''s shape (required: false, default: empty) — the two triggers used to diverge, which caused `-f build_locally=true` dispatches to accidentally test-against-8.2.0-shipped-tarball semantics instead of the 99.99.99 label the build_locally branch was designed for.'
+        required: false
         type: string
-        default: '8.2.0'
+        default: ''
       build_locally:
         description: 'Build target tarball from the PR checkout via PackageAssembler instead of downloading to_version from the GitHub release page (Phase 3.5 PR-tarball validation)'
         type: boolean

--- a/docs/artifact-acceptance-testing-plan.md
+++ b/docs/artifact-acceptance-testing-plan.md
@@ -618,17 +618,25 @@ release-prep sets `$v_tag=''` + `$v_realpatch=0`, so the strip is a
 no-op there; the divergence only shows up on `build_locally=true`
 against a dev-tagged checkout.
 
-**Also flagged for cleanup**: the workflow's `to_version`
-`workflow_dispatch` input is `required: true` with `default: '8.2.0'`.
-On a manual dispatch with `-f build_locally=true` but no
-`-f to_version=`, the input default (`8.2.0`) still overrides
+**Third follow-up (openemr/openemr#13791)** cleaned up a related
+ergonomic bug in the same code path: the workflow's `to_version`
+`workflow_dispatch` input had been `required: true` with
+`default: '8.2.0'`. On a manual dispatch with `-f build_locally=true`
+but no `-f to_version=`, the input default (`8.2.0`) still overrode
 `emit_to_version`'s build_locally branch (which would otherwise
-resolve to `99.99.99`). The stale default also drives downgrade
-failures when the derived `from_version` is >= `8.2.0` (currently
-`8.3.0` on master). Fix is to change the input default from `'8.2.0'`
-to `''` (empty), which `emit_to_version`'s `[[ -n "${DISPATCH_TO_VERSION}" ]]`
-guard already handles — cleanly falling through to the build_locally
-99.99.99 default. Separate PR when convenient; not blocking.
+resolve to `99.99.99`, matching the auto-fire path). The stale
+default also drove downgrade failures when the derived `from_version`
+was >= `8.2.0` (e.g., `8.3.0` on master → 4 of 8 acceptance jobs
+tripped `upgrade-package.sh`'s ordering guard for reasons unrelated
+to what the operator was actually testing). The `workflow_call`
+variant of the same input already had the correct shape
+(`required: false`, `default: ''`); the two triggers had diverged
+and `workflow_dispatch` never got updated. Matched `workflow_call`'s
+shape — `emit_to_version`'s `[[ -n "${DISPATCH_TO_VERSION}" ]]`
+guard already handled empty, so no shell script or downstream
+changes needed. Explicit `-f to_version=X.Y.Z` still wins over the
+empty default. Answer to "why isn't `to_version` required?" for
+future readers.
 
 Exit criterion (met): end-to-end `build_locally=true` demo on a
 real runner produced 6/6 green — `detect-mode`, `build-tarball`


### PR DESCRIPTION
Small 1-line-of-behavior fix flagged during smoke testing of #13786 / #13790.

## Bug

`workflow_dispatch.inputs.to_version` was `required: true` with `default: '8.2.0'`. When an operator dispatches with just `-f build_locally=true` (no explicit `-f to_version=`), the input default of `8.2.0` becomes `DISPATCH_TO_VERSION=8.2.0` in the environment. `detect-acceptance-mode.sh`'s `emit_to_version` precedence is:

```bash
if [[ -n "${DISPATCH_TO_VERSION}" ]]; then
    candidate="${DISPATCH_TO_VERSION}"      # ← catches the '8.2.0' default
elif [[ -n "${preferred}" ]]; then
    candidate="${preferred}"
elif [[ "${build_locally}" == "true" ]]; then
    candidate="99.99.99"                    # ← the intended path, bypassed
else
    candidate="8.2.0"
fi
```

So `-f build_locally=true` with no explicit `to_version` gets `to_version=8.2.0`, not the intended `99.99.99`. On master (currently 8.4.0-dev cycle) this also drives downgrade failures — derived `from_version=8.3.0` > forced `to_version=8.2.0` trips `upgrade-package.sh`'s ordering guard on 4 of 8 acceptance jobs.

The `workflow_call` variant of the same input already has the intended shape (`required: false`, `default: ''`). The two triggers diverged at some point and `workflow_dispatch` never got updated.

## Fix

Match `workflow_call`: `required: false`, `default: ''`. `emit_to_version`'s `[[ -n "${DISPATCH_TO_VERSION}" ]]` guard already handles empty correctly, so the fix is purely at the input-definition layer — no shell script or downstream changes needed.

## Behavior changes

| Invocation | Before | After |
|---|---|---|
| `-f build_locally=true` (no to_version) | `to_version=8.2.0` (default) → tests-against-shipped-8.2.0 semantics + downgrade failures on master | `to_version=99.99.99` (build_locally emit branch) → matches auto-fire path |
| `-f build_locally=true -f to_version=X.Y.Z` | `to_version=X.Y.Z` (explicit wins) | unchanged |
| `-f to_version=X.Y.Z` (no build_locally) | `to_version=X.Y.Z` (explicit wins) | unchanged |
| No inputs at all | `to_version=8.2.0`, build_locally=false → shipped 8.2.0 path | `to_version=8.2.0` (via emit_to_version's else branch) — same effective behavior |

Only the first row's behavior changes. Everything else is either unchanged or ends up with the same effective value via a different code path.

## Test plan

- [x] actionlint clean
- [x] pre-commit clean
- [ ] After merge: `gh workflow run acceptance-package.yml --ref master -f build_locally=true` (no to_version) — detect-mode should now log `resolved to_version=99.99.99` instead of `resolved to_version=8.2.0`; upgrade + wizard-upgrade jobs should no longer hit the downgrade guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)