### PR TITLE
feat(payments): move prepay report to twig 

### DIFF
--- a/interface/reports/prepayment_balance_report.php
+++ b/interface/reports/prepayment_balance_report.php
@@ -6,8 +6,9 @@
  * Lists open pre-payment sessions (ar_session.adjustment_code = 'pre_payment',
  * closed = 0) whose received amount has not been fully applied to charges.
  *
- * The balance arithmetic lives in {@see PrepaymentBalanceService}; this file is
- * the view.
+ * The balance arithmetic lives in {@see PrepaymentBalanceService} and the
+ * markup in templates/reports/prepayment_balance/report.html.twig; this file
+ * reads the filters and wires the two together.
  *
  * @package   OpenEMR
  * @link      https://www.open-emr.org
@@ -20,19 +21,16 @@ declare(strict_types=1);
 
 require_once("../globals.php");
 
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Billing\PrepaymentBalance;
 use OpenEMR\Billing\PrepaymentBalanceService;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Http\CurrentRequest;
-use OpenEMR\Common\Session\SessionWrapperFactory;
-use OpenEMR\Core\Header;
-use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\Utils\DateFormatterUtils;
 
 $request = CurrentRequest::get();
-$session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 if ($request->isMethod('POST')) {
     CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
@@ -57,233 +55,21 @@ $formPatientId = $formPatient === '' ? null : (int) $formPatient;
 $formParkedOnly = $request->request->getBoolean('form_parked_only');
 $isRefresh = $request->request->getBoolean('form_refresh');
 
-// oeFormatShortDate() returns its argument unchanged for inputs shorter than a
-// full date, so its return type is mixed. Narrow once here rather than at each
-// of the five display sites.
-$shortDate = static function (?string $date): string {
-    if ($date === null || $date === '') {
-        return '';
-    }
-    $formatted = DateFormatterUtils::oeFormatShortDate($date);
+$balances = [];
+$totals = PrepaymentBalance::totals([]);
 
-    return is_string($formatted) ? $formatted : '';
-};
-?>
-
-<html>
-
-<head>
-    <title><?php echo xlt('Prepayment Balances'); ?></title>
-
-    <?php Header::setupHeader(["datetime-picker", "report-helper"]); ?>
-
-    <script>
-        // Re-run the report when the edit_payment dialog closes so that fully
-        // applied sessions drop off the list immediately.
-        function refreshReport() {
-            $("#form_refresh").attr("value", "true");
-            $("#theform").submit();
-        }
-
-        $(function () {
-            var win = top.printLogSetup ? top : opener.top;
-            win.printLogSetup(document.getElementById('printbutton'));
-
-            // Open sessions in a dialog rather than navigating away from the
-            // report, matching the pattern in billing/search_payments.php.
-            $(document).on('click', '.medium_modal', function (e) {
-                e.preventDefault();
-                e.stopPropagation();
-                dlgopen('', '', 'modal-full', 800, '', '', {
-                    buttons: [
-                        {text: <?php echo xlj('Close'); ?>, close: true, style: 'default btn-sm'}
-                    ],
-                    sizeHeight: '',
-                    onClosed: 'refreshReport',
-                    type: 'iframe',
-                    url: $(this).attr('href')
-                });
-            });
-
-            $('.datepicker').datetimepicker({
-                <?php $datetimepicker_timepicker = false; ?>
-                <?php $datetimepicker_showseconds = false; ?>
-                <?php $datetimepicker_formatInput = true; ?>
-                <?php require(OEGlobalsBag::getInstance()->getSrcDir() . '/js/xl/jquery-datetimepicker-2-5-4.js.php'); ?>
-            });
-        });
-
-        function setpatient(pid, lname, fname, dob) {
-            document.forms[0].elements['form_patient'].value = pid;
-            document.forms[0].elements['form_patient_name'].value = lname + ', ' + fname;
-        }
-
-        function sel_patient() {
-            dlgopen('../main/calendar/find_patient_popup.php?pflag=0', '_blank', 500, 400);
-        }
-
-        function clear_patient() {
-            document.forms[0].elements['form_patient'].value = '';
-            document.forms[0].elements['form_patient_name'].value = '';
-        }
-    </script>
-
-    <style>
-        /* specifically include & exclude from printing */
-        @media print {
-            #report_parameters {
-                visibility: hidden;
-                display: none;
-            }
-            #report_parameters_daterange {
-                visibility: visible;
-                display: inline;
-            }
-            #report_results table {
-                margin-top: 0px;
-            }
-        }
-
-        /* specifically exclude some from the screen */
-        @media screen {
-            #report_parameters_daterange {
-                visibility: hidden;
-                display: none;
-            }
-        }
-    </style>
-</head>
-
-<body class="body_top">
-
-<!-- Required for the popup date selectors -->
-<div id="overDiv" style="position: absolute; visibility: hidden; z-index: 1000;"></div>
-
-<span class='title'><?php echo xlt('Prepayment Balances'); ?></span>
-
-<div id="report_parameters_daterange"><?php echo text($shortDate($formFromDate)) . " &nbsp; " . xlt('to{{Range}}') . " &nbsp; " . text($shortDate($formToDate)); ?>
-</div>
-
-<form method='post' name='theform' id='theform' action='prepayment_balance_report.php' onsubmit='return top.restoreSession()'>
-<input type="hidden" name="csrf_token_form" value="<?php echo attr(CsrfUtils::collectCsrfToken(session: $session)); ?>" />
-
-<div id="report_parameters">
-
-<table>
-    <tr>
-        <td>
-        <div class='float-left'>
-
-        <table class='text'>
-            <tr>
-                <td class='col-form-label'><?php echo xlt('Check Date From'); ?>:</td>
-                <td><input type='text' name='form_from_date' id='form_from_date' class='datepicker form-control' size='10' value='<?php echo attr($shortDate($formFromDate)); ?>' /></td>
-                <td class='col-form-label'><?php echo xlt('To{{Range}}'); ?>:</td>
-                <td><input type='text' name='form_to_date' id='form_to_date' class='datepicker form-control' size='10' value='<?php echo attr($shortDate($formToDate)); ?>' /></td>
-            </tr>
-            <tr>
-                <td class='col-form-label'><?php echo xlt('Patient'); ?>:</td>
-                <td>
-                    <input type='text' size='20' name='form_patient_name' id='form_patient_name' class='form-control' style='cursor: pointer;' value='<?php echo attr($formPatient); ?>' onclick='sel_patient()' readonly title='<?php echo xla('Click to select patient'); ?>' />
-                    <input type='hidden' name='form_patient' id='form_patient' value='<?php echo attr($formPatient); ?>' />
-                    <a href='#' onclick='clear_patient(); return false;'><?php echo xlt('Clear'); ?></a>
-                </td>
-                <td class='col-form-label'><?php echo xlt('Parked in Global only'); ?>:</td>
-                <td>
-                    <input type='checkbox' name='form_parked_only' id='form_parked_only' value='1'<?php echo $formParkedOnly ? ' checked' : ''; ?> />
-                </td>
-            </tr>
-        </table>
-
-        </div>
-
-        </td>
-        <td class='h-100'>
-        <table class='w-100 h-100' style='border-left: 1px solid;'>
-            <tr>
-                <td>
-                    <div class="text-center">
-                        <div class="btn-group" role="group">
-                            <a href='#' class='btn btn-secondary btn-save' onclick='$("#form_refresh").attr("value","true"); $("#theform").submit();'>
-                                <?php echo xlt('Submit'); ?>
-                            </a>
-                            <?php if ($isRefresh) { ?>
-                                <a href='#' class='btn btn-secondary btn-print' id='printbutton'>
-                                    <?php echo xlt('Print'); ?>
-                                </a>
-                            <?php } ?>
-                        </div>
-                    </div>
-                </td>
-            </tr>
-        </table>
-        </td>
-    </tr>
-</table>
-
-</div>
-<!-- end of search parameters -->
-<?php
 if ($isRefresh) {
-    $service = new PrepaymentBalanceService();
-    $balances = $service->getOpenBalances($formFromDate, $formToDate, $formPatientId, $formParkedOnly);
+    $balances = (new PrepaymentBalanceService())
+        ->getOpenBalances($formFromDate, $formToDate, $formPatientId, $formParkedOnly);
     $totals = PrepaymentBalance::totals($balances);
-    ?>
-<div id="report_results">
-<table class='table'>
+}
 
-    <thead class='thead-light'>
-        <tr>
-            <th><?php echo xlt('Patient'); ?></th>
-            <th><?php echo xlt('PID'); ?></th>
-            <th><?php echo xlt('Session'); ?></th>
-            <th><?php echo xlt('Reference'); ?></th>
-            <th><?php echo xlt('Check Date'); ?></th>
-            <th class="text-right"><?php echo xlt('Days Open'); ?></th>
-            <th class="text-right"><?php echo xlt('Received'); ?></th>
-            <th class="text-right"><?php echo xlt('Applied'); ?></th>
-            <th class="text-right"><?php echo xlt('In Global'); ?></th>
-            <th class="text-right"><?php echo xlt('Unapplied'); ?></th>
-        </tr>
-    </thead>
-    <tbody>
-    <?php foreach ($balances as $balance) { ?>
-        <tr>
-            <td class="detail">&nbsp;<?php echo text($balance->patientName); ?></td>
-            <td class="detail">&nbsp;<?php echo text((string) $balance->patientId); ?></td>
-            <td class="detail">&nbsp;
-                <a class="medium_modal" href='../billing/edit_payment.php?payment_id=<?php echo attr_url((string) $balance->sessionId); ?>'>
-                    <?php echo text((string) $balance->sessionId); ?>
-                </a>
-            </td>
-            <td class="detail">&nbsp;<?php echo text($balance->reference); ?></td>
-            <td class="detail">&nbsp;<?php echo $balance->checkDate === null ? '&nbsp;' : text($shortDate($balance->checkDate)); ?></td>
-            <td class="detail text-right"><?php echo text((string) $balance->daysOpen); ?></td>
-            <td class="detail text-right"><?php echo text(oeFormatMoney($balance->received)); ?></td>
-            <td class="detail text-right"><?php echo text(oeFormatMoney($balance->applied)); ?></td>
-            <td class="detail text-right"><?php echo text(oeFormatMoney($balance->inGlobal)); ?></td>
-            <td class="detail text-right"><?php echo text(oeFormatMoney($balance->unapplied)); ?></td>
-        </tr>
-    <?php } ?>
-    </tbody>
-    <tfoot>
-        <tr class='font-weight-bold'>
-            <td class="detail" colspan="6">&nbsp;<?php echo xlt('Totals'); ?></td>
-            <td class="detail text-right"><?php echo text(oeFormatMoney($totals['received'])); ?></td>
-            <td class="detail text-right"><?php echo text(oeFormatMoney($totals['applied'])); ?></td>
-            <td class="detail text-right"><?php echo text(oeFormatMoney($totals['inGlobal'])); ?></td>
-            <td class="detail text-right"><?php echo text(oeFormatMoney($totals['unapplied'])); ?></td>
-        </tr>
-    </tfoot>
-</table>
-</div>
-<!-- end of search results -->
-<?php } else { ?>
-<div class='text'><?php echo xlt('Click Submit to list all open prepayments with an unapplied balance. Date and patient filters are optional.'); ?>
-</div>
-<?php } ?>
-<input type='hidden' name='form_refresh' id='form_refresh' value='' /></form>
-
-</body>
-
-</html>
+echo ServiceContainer::getTwig()->render('reports/prepayment_balance/report.html.twig', [
+    'formFromDate' => $formFromDate,
+    'formToDate' => $formToDate,
+    'formPatient' => $formPatient,
+    'formParkedOnly' => $formParkedOnly,
+    'isRefresh' => $isRefresh,
+    'balances' => $balances,
+    'totals' => $totals,
+]);

--- a/interface/reports/prepayment_balance_report.php
+++ b/interface/reports/prepayment_balance_report.php
@@ -52,6 +52,9 @@ $formFromDate = is_string($formFromDate) ? $formFromDate : '';
 $formToDate = is_string($formToDate) ? $formToDate : '';
 $formPatient = trim($request->request->getString('form_patient'));
 $formPatientId = $formPatient === '' ? null : (int) $formPatient;
+// Display only. The pid drives the query; this is what the readonly box shows
+// so a submit does not replace the chosen name with its id.
+$formPatientName = trim($request->request->getString('form_patient_name'));
 $formParkedOnly = $request->request->getBoolean('form_parked_only');
 $isRefresh = $request->request->getBoolean('form_refresh');
 
@@ -68,6 +71,7 @@ echo ServiceContainer::getTwig()->render('reports/prepayment_balance/report.html
     'formFromDate' => $formFromDate,
     'formToDate' => $formToDate,
     'formPatient' => $formPatient,
+    'formPatientName' => $formPatientName,
     'formParkedOnly' => $formParkedOnly,
     'isRefresh' => $isRefresh,
     'balances' => $balances,

--- a/templates/reports/prepayment_balance/report.html.twig
+++ b/templates/reports/prepayment_balance/report.html.twig
@@ -1,0 +1,207 @@
+<html>
+
+<head>
+    <title>{{ 'Prepayment Balances'|xlt }}</title>
+
+    {{ setupHeader(['datetime-picker', 'report-helper']) }}
+
+    <script>
+        // Re-run the report when the edit_payment dialog closes so that fully
+        // applied sessions drop off the list immediately.
+        function refreshReport() {
+            $("#form_refresh").attr("value", "true");
+            $("#theform").submit();
+        }
+
+        $(function () {
+            var win = top.printLogSetup ? top : opener.top;
+            win.printLogSetup(document.getElementById('printbutton'));
+
+            // Open sessions in a dialog rather than navigating away from the
+            // report, matching the pattern in billing/search_payments.php.
+            $(document).on('click', '.medium_modal', function (e) {
+                e.preventDefault();
+                e.stopPropagation();
+                dlgopen('', '', 'modal-full', 800, '', '', {
+                    buttons: [
+                        {text: {{ 'Close'|xlj }}, close: true, style: 'default btn-sm'}
+                    ],
+                    sizeHeight: '',
+                    onClosed: 'refreshReport',
+                    type: 'iframe',
+                    url: $(this).attr('href')
+                });
+            });
+
+            {{ jqueryDateTimePicker('.datepicker', false, false, true) }};
+        });
+
+        function setpatient(pid, lname, fname, dob) {
+            document.forms[0].elements['form_patient'].value = pid;
+            document.forms[0].elements['form_patient_name'].value = lname + ', ' + fname;
+        }
+
+        function sel_patient() {
+            dlgopen('../main/calendar/find_patient_popup.php?pflag=0', '_blank', 500, 400);
+        }
+
+        function clear_patient() {
+            document.forms[0].elements['form_patient'].value = '';
+            document.forms[0].elements['form_patient_name'].value = '';
+        }
+    </script>
+
+    <style>
+        /* specifically include & exclude from printing */
+        @media print {
+            #report_parameters {
+                visibility: hidden;
+                display: none;
+            }
+            #report_parameters_daterange {
+                visibility: visible;
+                display: inline;
+            }
+            #report_results table {
+                margin-top: 0px;
+            }
+        }
+
+        /* specifically exclude some from the screen */
+        @media screen {
+            #report_parameters_daterange {
+                visibility: hidden;
+                display: none;
+            }
+        }
+    </style>
+</head>
+
+<body class="body_top">
+
+<!-- Required for the popup date selectors -->
+<div id="overDiv" style="position: absolute; visibility: hidden; z-index: 1000;"></div>
+
+<span class='title'>{{ 'Prepayment Balances'|xlt }}</span>
+
+<div id="report_parameters_daterange">{{ formFromDate|shortDate|text }} &nbsp; {{ 'to{{Range}}'|xlt }} &nbsp; {{ formToDate|shortDate|text }}
+</div>
+
+<form method='post' name='theform' id='theform' action='prepayment_balance_report.php' onsubmit='return top.restoreSession()'>
+{{ csrfToken('default', 'csrf_token_form') }}
+
+<div id="report_parameters">
+
+<table>
+    <tr>
+        <td>
+        <div class='float-left'>
+
+        <table class='text'>
+            <tr>
+                <td class='col-form-label'>{{ 'Check Date From'|xlt }}:</td>
+                <td><input type='text' name='form_from_date' id='form_from_date' class='datepicker form-control' size='10' value='{{ formFromDate|shortDate|attr }}' /></td>
+                <td class='col-form-label'>{{ 'To{{Range}}'|xlt }}:</td>
+                <td><input type='text' name='form_to_date' id='form_to_date' class='datepicker form-control' size='10' value='{{ formToDate|shortDate|attr }}' /></td>
+            </tr>
+            <tr>
+                <td class='col-form-label'>{{ 'Patient'|xlt }}:</td>
+                <td>
+                    <input type='text' size='20' name='form_patient_name' id='form_patient_name' class='form-control' style='cursor: pointer;' value='{{ formPatient|attr }}' onclick='sel_patient()' readonly title='{{ 'Click to select patient'|xla }}' />
+                    <input type='hidden' name='form_patient' id='form_patient' value='{{ formPatient|attr }}' />
+                    <a href='#' onclick='clear_patient(); return false;'>{{ 'Clear'|xlt }}</a>
+                </td>
+                <td class='col-form-label'>{{ 'Parked in Global only'|xlt }}:</td>
+                <td>
+                    <input type='checkbox' name='form_parked_only' id='form_parked_only' value='1'{% if formParkedOnly %} checked{% endif %} />
+                </td>
+            </tr>
+        </table>
+
+        </div>
+
+        </td>
+        <td class='h-100'>
+        <table class='w-100 h-100' style='border-left: 1px solid;'>
+            <tr>
+                <td>
+                    <div class="text-center">
+                        <div class="btn-group" role="group">
+                            <a href='#' class='btn btn-secondary btn-save' onclick='$("#form_refresh").attr("value","true"); $("#theform").submit();'>
+                                {{ 'Submit'|xlt }}
+                            </a>
+                            {% if isRefresh %}
+                                <a href='#' class='btn btn-secondary btn-print' id='printbutton'>
+                                    {{ 'Print'|xlt }}
+                                </a>
+                            {% endif %}
+                        </div>
+                    </div>
+                </td>
+            </tr>
+        </table>
+        </td>
+    </tr>
+</table>
+
+</div>
+<!-- end of search parameters -->
+{% if isRefresh %}
+<div id="report_results">
+<table class='table'>
+
+    <thead class='thead-light'>
+        <tr>
+            <th>{{ 'Patient'|xlt }}</th>
+            <th>{{ 'PID'|xlt }}</th>
+            <th>{{ 'Session'|xlt }}</th>
+            <th>{{ 'Reference'|xlt }}</th>
+            <th>{{ 'Check Date'|xlt }}</th>
+            <th class="text-right">{{ 'Days Open'|xlt }}</th>
+            <th class="text-right">{{ 'Received'|xlt }}</th>
+            <th class="text-right">{{ 'Applied'|xlt }}</th>
+            <th class="text-right">{{ 'In Global'|xlt }}</th>
+            <th class="text-right">{{ 'Unapplied'|xlt }}</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for balance in balances %}
+        <tr>
+            <td class="detail">&nbsp;{{ balance.patientName|text }}</td>
+            <td class="detail">&nbsp;{{ balance.patientId|text }}</td>
+            <td class="detail">&nbsp;
+                <a class="medium_modal" href='../billing/edit_payment.php?payment_id={{ balance.sessionId|attr_url }}'>
+                    {{ balance.sessionId|text }}
+                </a>
+            </td>
+            <td class="detail">&nbsp;{{ balance.reference|text }}</td>
+            <td class="detail">&nbsp;{% if balance.checkDate is null %}&nbsp;{% else %}{{ balance.checkDate|shortDate|text }}{% endif %}</td>
+            <td class="detail text-right">{{ balance.daysOpen|text }}</td>
+            <td class="detail text-right">{{ balance.received|money|text }}</td>
+            <td class="detail text-right">{{ balance.applied|money|text }}</td>
+            <td class="detail text-right">{{ balance.inGlobal|money|text }}</td>
+            <td class="detail text-right">{{ balance.unapplied|money|text }}</td>
+        </tr>
+    {% endfor %}
+    </tbody>
+    <tfoot>
+        <tr class='font-weight-bold'>
+            <td class="detail" colspan="6">&nbsp;{{ 'Totals'|xlt }}</td>
+            <td class="detail text-right">{{ totals.received|money|text }}</td>
+            <td class="detail text-right">{{ totals.applied|money|text }}</td>
+            <td class="detail text-right">{{ totals.inGlobal|money|text }}</td>
+            <td class="detail text-right">{{ totals.unapplied|money|text }}</td>
+        </tr>
+    </tfoot>
+</table>
+</div>
+<!-- end of search results -->
+{% else %}
+<div class='text'>{{ 'Click Submit to list all open prepayments with an unapplied balance. Date and patient filters are optional.'|xlt }}
+</div>
+{% endif %}
+<input type='hidden' name='form_refresh' id='form_refresh' value='' /></form>
+
+</body>
+
+</html>

--- a/templates/reports/prepayment_balance/report.html.twig
+++ b/templates/reports/prepayment_balance/report.html.twig
@@ -117,7 +117,7 @@
             <tr>
                 <td class='col-form-label'>{{ 'Patient'|xlt }}:</td>
                 <td>
-                    <input type='text' size='20' name='form_patient_name' id='form_patient_name' class='form-control' style='cursor: pointer;' value='{{ formPatient|attr }}' onclick='sel_patient()' readonly title='{{ 'Click to select patient'|xla }}' />
+                    <input type='text' size='20' name='form_patient_name' id='form_patient_name' class='form-control' style='cursor: pointer;' value='{{ formPatientName|attr }}' onclick='sel_patient()' readonly title='{{ 'Click to select patient'|xla }}' />
                     <input type='hidden' name='form_patient' id='form_patient' value='{{ formPatient|attr }}' />
                     <a href='#' onclick='clear_patient(); return false;'>{{ 'Clear'|xlt }}</a>
                 </td>

--- a/templates/reports/prepayment_balance/report.html.twig
+++ b/templates/reports/prepayment_balance/report.html.twig
@@ -36,6 +36,16 @@
             {{ jqueryDateTimePicker('.datepicker', false, false, true) }};
         });
 
+        // Opens the chart in the main frame. This leaves the report, and the
+        // filters are POST-only, so coming back lands on the empty form --
+        // same trade-off as collections_report.php and encounters_report.php.
+        function toPatient(newpid) {
+            top.restoreSession();
+            const params = new URLSearchParams({set_pid: newpid});
+            top.RTop.location = {{ webroot|js_escape }}
+                + "/interface/patient_file/summary/demographics.php?" + params;
+        }
+
         function setpatient(pid, lname, fname, dob) {
             document.forms[0].elements['form_patient'].value = pid;
             document.forms[0].elements['form_patient_name'].value = lname + ', ' + fname;
@@ -167,7 +177,11 @@
     <tbody>
     {% for balance in balances %}
         <tr>
-            <td class="detail">&nbsp;{{ balance.patientName|text }}</td>
+            <td class="detail">&nbsp;
+                <a href="#" onclick="toPatient({{ balance.patientId|attr_js }}); return false;" title="{{ 'Open patient chart'|xla }}">
+                    {{ balance.patientName|text }}
+                </a>
+            </td>
             <td class="detail">&nbsp;{{ balance.patientId|text }}</td>
             <td class="detail">&nbsp;
                 <a class="medium_modal" href='../billing/edit_payment.php?payment_id={{ balance.sessionId|attr_url }}'>

--- a/tests/Tests/Services/Billing/PrepaymentBalanceServiceTest.php
+++ b/tests/Tests/Services/Billing/PrepaymentBalanceServiceTest.php
@@ -1,0 +1,316 @@
+<?php
+
+/**
+ * Database-backed coverage for the prepayment balance query.
+ *
+ * The arithmetic on a single row is pinned by the isolated
+ * PrepaymentBalanceTest. What can only be verified against a real database is
+ * the query itself: which sessions it selects, how it aggregates distributions,
+ * and how each filter narrows the result.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (C) 2026 Stephen Waite <stephen.waite@cmsvt.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Services\Billing;
+
+use OpenEMR\Billing\PrepaymentBalance;
+use OpenEMR\Billing\PrepaymentBalanceService;
+use OpenEMR\Common\Database\QueryUtils;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class PrepaymentBalanceServiceTest extends TestCase
+{
+    private PrepaymentBalanceService $service;
+
+    /** @var list<int> Session ids created by a test, torn down afterwards. */
+    private array $sessionIds = [];
+
+    private int $pid;
+
+    protected function setUp(): void
+    {
+        $this->service = new PrepaymentBalanceService();
+        // patient_data.pid is not auto-increment (id is), so pick one above the
+        // current max and insert it explicitly.
+        $this->pid = $this->fetchInt(
+            "SELECT COALESCE(MAX(pid), 0) + 1 AS next FROM patient_data",
+            'next',
+            []
+        );
+        QueryUtils::sqlInsert(
+            "INSERT INTO patient_data (pid, lname, fname, mname) VALUES (?, ?, ?, ?)",
+            [$this->pid, 'Prepay', 'Fixture', '']
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->sessionIds as $sessionId) {
+            QueryUtils::sqlStatementThrowException(
+                "DELETE FROM ar_activity WHERE session_id = ?",
+                [$sessionId]
+            );
+            QueryUtils::sqlStatementThrowException(
+                "DELETE FROM ar_session WHERE session_id = ?",
+                [$sessionId]
+            );
+        }
+        $this->sessionIds = [];
+
+        QueryUtils::sqlStatementThrowException("DELETE FROM patient_data WHERE pid = ?", [$this->pid]);
+    }
+
+    #[Test]
+    public function anUndistributedPrepaymentIsReportedInFull(): void
+    {
+        $sessionId = $this->createPrepayment(500.00);
+
+        $balance = $this->findSession($sessionId);
+
+        $this->assertNotNull($balance, 'an open prepayment with no distributions must be listed');
+        $this->assertSame(500.00, $balance->received);
+        $this->assertSame(0.0, $balance->applied);
+        $this->assertSame(500.00, $balance->unapplied);
+        $this->assertSame('Prepay, Fixture', $balance->patientName);
+    }
+
+    #[Test]
+    public function partialDistributionLeavesTheRemainderUnapplied(): void
+    {
+        $sessionId = $this->createPrepayment(500.00);
+        $this->distribute($sessionId, 200.00);
+
+        $balance = $this->findSession($sessionId);
+
+        $this->assertNotNull($balance);
+        $this->assertSame(200.00, $balance->applied);
+        $this->assertSame(300.00, $balance->unapplied);
+    }
+
+    /**
+     * The applied total is pre-aggregated in a derived table. Joining
+     * ar_activity directly would repeat the ar_session row once per
+     * distribution and multiply pay_total across the copies, so a session with
+     * two distributions is the case that catches a regression there.
+     */
+    #[Test]
+    public function multipleDistributionsDoNotFanOutTheSessionRow(): void
+    {
+        $sessionId = $this->createPrepayment(500.00);
+        $this->distribute($sessionId, 100.00);
+        $this->distribute($sessionId, 150.00);
+
+        $matches = array_filter(
+            $this->service->getOpenBalances(),
+            static fn(PrepaymentBalance $b): bool => $b->sessionId === $sessionId
+        );
+
+        $this->assertCount(1, $matches, 'the session must appear exactly once regardless of distribution count');
+        $balance = array_values($matches)[0];
+        $this->assertSame(250.00, $balance->applied);
+        $this->assertSame(250.00, $balance->unapplied);
+    }
+
+    #[Test]
+    public function fullyDistributedSessionsAreExcluded(): void
+    {
+        $sessionId = $this->createPrepayment(500.00);
+        $this->distribute($sessionId, 500.00);
+
+        $this->assertNull($this->findSession($sessionId));
+    }
+
+    /**
+     * ar_activity.deleted is set when a distribution is voided rather than the
+     * row being removed, so voided money must return to the unapplied total.
+     */
+    #[Test]
+    public function voidedDistributionsReturnToUnapplied(): void
+    {
+        $sessionId = $this->createPrepayment(500.00);
+        $this->distribute($sessionId, 500.00);
+
+        // A fully applied session drops off the report; that is pinned by
+        // fullyDistributedSessionsAreExcluded() rather than re-asserted here.
+        QueryUtils::sqlStatementThrowException(
+            "UPDATE ar_activity SET deleted = NOW() WHERE session_id = ?",
+            [$sessionId]
+        );
+
+        $balance = $this->findSession($sessionId);
+        $this->assertNotNull($balance, 'voiding the distribution must put the session back on the report');
+        $this->assertSame(0.0, $balance->applied);
+        $this->assertSame(500.00, $balance->unapplied);
+    }
+
+    #[Test]
+    public function closedSessionsAreExcluded(): void
+    {
+        $sessionId = $this->createPrepayment(500.00, closed: 1);
+
+        $this->assertNull($this->findSession($sessionId));
+    }
+
+    #[Test]
+    public function nonPrepaymentCategoriesAreExcluded(): void
+    {
+        $sessionId = $this->createPrepayment(500.00, adjustmentCode: 'patient_payment');
+
+        $this->assertNull($this->findSession($sessionId));
+    }
+
+    /**
+     * Sub-cent residue from rounding is not a balance worth chasing; the query
+     * filters on an epsilon rather than on > 0.
+     */
+    #[Test]
+    public function subCentResidueIsBelowTheReportingThreshold(): void
+    {
+        $sessionId = $this->createPrepayment(500.00);
+        $this->distribute($sessionId, 499.999);
+
+        $this->assertNull($this->findSession($sessionId));
+    }
+
+    #[Test]
+    public function moneyParkedInGlobalStillCountsAsUnapplied(): void
+    {
+        $sessionId = $this->createPrepayment(500.00, globalAmount: 120.00);
+
+        $balance = $this->findSession($sessionId);
+
+        $this->assertNotNull($balance);
+        $this->assertSame(120.00, $balance->inGlobal, 'parked credit is reported in its own column');
+        $this->assertSame(500.00, $balance->unapplied, 'and is not subtracted from the unapplied total');
+    }
+
+    #[Test]
+    public function parkedOnlyFilterExcludesSessionsWithNothingInGlobal(): void
+    {
+        $plain = $this->createPrepayment(500.00);
+        $parked = $this->createPrepayment(300.00, globalAmount: 80.00);
+
+        $sessionIds = array_map(
+            static fn(PrepaymentBalance $b): int => $b->sessionId,
+            $this->service->getOpenBalances(parkedOnly: true)
+        );
+
+        $this->assertContains($parked, $sessionIds);
+        $this->assertNotContains($plain, $sessionIds);
+    }
+
+    #[Test]
+    public function checkDateRangeNarrowsTheResultSet(): void
+    {
+        $old = $this->createPrepayment(100.00, checkDate: '2020-01-15');
+        $recent = $this->createPrepayment(200.00, checkDate: '2020-06-15');
+
+        $inRange = array_map(
+            static fn(PrepaymentBalance $b): int => $b->sessionId,
+            $this->service->getOpenBalances('2020-06-01', '2020-06-30')
+        );
+
+        $this->assertContains($recent, $inRange);
+        $this->assertNotContains($old, $inRange);
+    }
+
+    #[Test]
+    public function patientFilterLimitsToOnePatient(): void
+    {
+        $sessionId = $this->createPrepayment(500.00);
+
+        $mine = $this->service->getOpenBalances(patientId: $this->pid);
+        $others = $this->service->getOpenBalances(patientId: $this->pid + 100000);
+
+        $this->assertContains(
+            $sessionId,
+            array_map(static fn(PrepaymentBalance $b): int => $b->sessionId, $mine)
+        );
+        $this->assertSame([], $others, 'a pid with no prepayments returns nothing');
+    }
+
+    #[Test]
+    public function resultsAreOrderedByUnappliedDescending(): void
+    {
+        $this->createPrepayment(100.00, checkDate: '2020-03-01');
+        $this->createPrepayment(900.00, checkDate: '2020-03-02');
+        $this->createPrepayment(400.00, checkDate: '2020-03-03');
+
+        $unapplied = array_map(
+            static fn(PrepaymentBalance $b): float => $b->unapplied,
+            $this->service->getOpenBalances(patientId: $this->pid)
+        );
+
+        $sorted = $unapplied;
+        rsort($sorted);
+        $this->assertSame($sorted, $unapplied);
+    }
+
+    private function createPrepayment(
+        float $payTotal,
+        string $adjustmentCode = 'pre_payment',
+        int $closed = 0,
+        float $globalAmount = 0.0,
+        string $checkDate = '2020-02-01',
+    ): int {
+        $sessionId = (int) QueryUtils::sqlInsert(
+            "INSERT INTO ar_session
+                (payer_id, patient_id, user_id, closed, reference, check_date, deposit_date,
+                 pay_total, modified_time, global_amount, payment_type, description,
+                 adjustment_code, post_to_date, payment_method)
+             VALUES (0, ?, 1, ?, 'TESTFIXTURE', ?, ?, ?, NOW(), ?, 'patient', 'test fixture', ?, ?, 'check')",
+            [$this->pid, $closed, $checkDate, $checkDate, $payTotal, $globalAmount, $adjustmentCode, $checkDate]
+        );
+        $this->sessionIds[] = $sessionId;
+
+        return $sessionId;
+    }
+
+    private function distribute(int $sessionId, float $amount): void
+    {
+        $nextSeq = $this->fetchInt(
+            "SELECT COALESCE(MAX(sequence_no), 0) + 1 AS seq FROM ar_activity WHERE pid = ? AND encounter = 0",
+            'seq',
+            [$this->pid]
+        );
+
+        QueryUtils::sqlStatementThrowException(
+            "INSERT INTO ar_activity
+                (pid, encounter, sequence_no, code_type, code, modifier, payer_type, post_time,
+                 post_user, session_id, memo, pay_amount, adj_amount, modified_time, follow_up,
+                 account_code, deleted)
+             VALUES (?, 0, ?, '', '', '', 0, NOW(), 1, ?, '', ?, 0, NOW(), '', 'PP', NULL)",
+            [$this->pid, $nextSeq, $sessionId, $amount]
+        );
+    }
+
+    /**
+     * fetchSingleValue() is untyped, so narrow rather than cast mixed.
+     *
+     * @param list<mixed> $binds
+     */
+    private function fetchInt(string $sql, string $column, array $binds): int
+    {
+        $value = QueryUtils::fetchSingleValue($sql, $column, $binds);
+
+        return is_numeric($value) ? (int) $value : 0;
+    }
+
+    private function findSession(int $sessionId): ?PrepaymentBalance
+    {
+        foreach ($this->service->getOpenBalances() as $balance) {
+            if ($balance->sessionId === $sessionId) {
+                return $balance;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #13783. Moves the prepayment balance report's markup out of the
PHP entry point and into a Twig template, and adds a link from the patient name
to the patient chart. The templating itself changes no behavior — same filters,
same columns, same query.

## Why

#13783 already split the data layer out into `PrepaymentBalanceService` and
`PrepaymentBalance`, which left the entry point as ~230 lines of interleaved
PHP and HTML sitting behind 30 lines of actual controller logic. Templating it
finishes that separation and drops several workarounds that only existed
because the markup was in PHP.

## Changes

| File | Change |
|---|---|
| `interface/reports/prepayment_balance_report.php` | 289 → 75 lines; reads filters, calls the service, renders |
| `templates/reports/prepayment_balance/report.html.twig` | New; all markup |

Net: 225 added, 232 removed.

## What the templating removes

- **The `$shortDate` closure.** It existed because `oeFormatShortDate()` returns
  `mixed` (it passes short inputs through unchanged), so every display site
  needed narrowing to satisfy PHPStan. The `shortDate` Twig filter handles that
  in the filter layer, so all five call sites become `{{ x|shortDate|text }}`.
- **The `(string)` casts.** `{{ balance.sessionId|text }}` reads the DTO's typed
  `int` property directly.
- **The `SessionWrapperFactory` plumbing.** `{{ csrfToken('default',
  'csrf_token_form') }}` replaces fetching the session to pass to
  `CsrfUtils::collectCsrfToken()`.
- **The inline datepicker `require`.** `{{ jqueryDateTimePicker('.datepicker',
  false, false, true) }}` replaces the four `<?php $datetimepicker_* ?>` lines
  plus the `require` of the xl JS partial.
- **`Header`, `OEGlobalsBag`, and `SessionWrapperFactory` imports**, all now
  unused.

## One behavior change

The patient name is now a link to the patient's chart, following the
`toPatient()` / `top.RTop.location` pattern in `collections_report.php:414` and
`encounters_report.php:212`.

This navigates away from the report, and the filters are POST-only, so returning
lands on the empty form rather than the previous result set. That is the same
trade-off both of those reports already make, and it is noted in a comment above
the function. The session-id link is unaffected — it still opens
`edit_payment.php` in a modal and re-runs the report on close.

Only the name is linked; the PID column stays plain text rather than
duplicating the same destination in an adjacent cell.

## Escaping

Twig runs with `autoescape => false` in `TwigContainer`, so every interpolation
carries an explicit filter: `|text` for element content, `|attr` for attribute
values, `|attr_url` for the `edit_payment.php` link, `|xlt` / `|xla` / `|xlj`
for translated strings in markup, attributes, and JavaScript respectively.

## Testing

`PrepaymentBalanceTest` is untouched and still passes — it covers the DTO, which
this PR does not modify.

Manual: the rendered page should be identical to #13783. Worth confirming
specifically:

1. Column headers, ordering, and the totals footer match.
2. Clicking a session ID opens `edit_payment.php` in the modal, and closing it
   re-runs the report so a fully applied session drops off.
3. Both datepickers open and post a value the report filters on.
4. The patient picker fills the visible name field and the hidden pid field, and
   Clear empties both.
5. `Parked in Global only` still round-trips its checked state.
6. Print button appears only after a submit, and print CSS still hides the
   filter panel while showing the date range.
7. A session with a null `check_date` or a missing `patient_data` row renders
   blank rather than erroring.

Assisted by claude.ai