### PR TITLE
fix(calendar): scale day view horizontally with many providers

### DIFF
--- a/interface/themes/ajax_calendar_sass.scss
+++ b/interface/themes/ajax_calendar_sass.scss
@@ -109,14 +109,19 @@ $side-calendar-date-padding: 0.3rem !default;
 
   #bigCal {
     background-color: $light;
-    overflow: hidden;
+    /* Horizontal scroll when many providers; times column is sticky. */
+    overflow-x: auto;
+    overflow-y: hidden;
 
     table {
       border: 0;
-      border-collapse: collapse;
+      border-collapse: separate;
+      border-spacing: 0;
       margin-top: 0;
+      min-width: 100%;
+      table-layout: auto;
       vertical-align: middle;
-      width: 100%;
+      width: max-content;
     }
 
     td {
@@ -235,11 +240,16 @@ $side-calendar-date-padding: 0.3rem !default;
     }
   }
 
-  /* the DIV of times */
+  /* Sticky time gutter — provider columns scroll underneath. */
   #times {
     background-color: $white;
+    max-width: 3.5rem;
+    min-width: 3.25rem;
     padding: 0.3125rem !important;
-    width: 1%;
+    position: sticky;
+    width: 3.25rem;
+    z-index: 8;
+    #{$left}: 0;
 
     table {
       background-color: $white;
@@ -255,6 +265,7 @@ $side-calendar-date-padding: 0.3rem !default;
       }
     }
     border-#{$right}: 1px solid $gray-300;
+    box-shadow: 2px 0 4px rgba(0, 0, 0, 0.08);
   }
 
   .timeslot {
@@ -275,30 +286,51 @@ $side-calendar-date-padding: 0.3rem !default;
     background-color: $white;
     border: 1px solid $gray-300;
     margin: 0;
+    /* Readable floor width; extra providers extend the table and scroll. */
+    min-width: 11.5rem;
     padding: 0;
+    position: relative;
     vertical-align: top;
-    width: 25rem;
+    width: 11.5rem;
   }
 
   /* for the header row with provider names */
   .providerheader {
+    align-items: center;
     background-color: $primary;
     border-bottom: 1px solid $gray-300;
     color: $white;
+    display: flex;
+    gap: 0.25rem;
+    justify-content: space-between;
     overflow: hidden;
-    text-align: center;
+    padding: 0 0.35rem;
+    /* Sit above IN/OUT fills that may extend under this row so office-hours
+       blocks never paint over the provider name bar. */
+    position: relative;
     white-space: nowrap;
     width: 100%;
+    z-index: 5;
+
+    .provider-name {
+      flex: 1 1 auto;
+      min-width: 0;
+      overflow: hidden;
+      text-align: center;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
   }
 
   // Based off of BS4's close class
   .providerXbtn {
     color: $white;
-    float: $right;
-    margin-left: 0.25rem;
-    margin-right: 0.25rem;
-    opacity: 0.5;
-    padding: 0;
+    flex: 0 0 auto;
+    float: none;
+    margin-left: 0;
+    margin-right: 0;
+    opacity: 0.9;
+    padding: 0 0.15rem;
     text-shadow: $close-text-shadow;
 
     @include hover() {
@@ -424,6 +456,8 @@ $side-calendar-date-padding: 0.3rem !default;
     &_in {
       border: 1px solid $gray-300;
       overflow: hidden;
+      /* Long IN fill stays under appointments and the provider header. */
+      pointer-events: none;
       text-overflow: ellipsis;
       white-space: nowrap;
       width: 100%;
@@ -432,7 +466,8 @@ $side-calendar-date-padding: 0.3rem !default;
 
     &_out {
       @extend %highlight;
-      z-index: 3;
+      /* Behind appointments (was 3 and covered first-slot appts). */
+      z-index: 1;
     }
 
     &_appointment {
@@ -442,23 +477,23 @@ $side-calendar-date-padding: 0.3rem !default;
       border-radius: 0.25rem;
       overflow: hidden;
       text-overflow: ellipsis;
-      white-space: nowrap;
+      white-space: normal;
       width: 100%;
-      z-index: 2;
+      z-index: 3;
     }
 
     &_noshow {
       @extend %highlight;
       border-radius: 0.25rem;
       overflow: hidden;
-      z-index: 2;
+      z-index: 3;
     }
 
     &_reserved {
       @extend %highlight;
       border-radius: 0.25rem;
       overflow: hidden;
-      z-index: 2;
+      z-index: 3;
     }
 
     &_holiday {
@@ -466,7 +501,7 @@ $side-calendar-date-padding: 0.3rem !default;
       border-radius: 0.25rem;
       overflow: hidden;
       width: 100% !important;
-      z-index: 2;
+      z-index: 3;
     }
 
     &_time {
@@ -513,7 +548,10 @@ $side-calendar-date-padding: 0.3rem !default;
 
   .in_start {
     background: transparent;
-    z-index: 2;
+    /* Label stays on the start slot but under appointments; still
+       receives clicks so the IN event can be edited. */
+    pointer-events: auto;
+    z-index: 1;
   }
 
   .event_out.event_highlight,
@@ -523,7 +561,7 @@ $side-calendar-date-padding: 0.3rem !default;
     font-weight: bold;
     margin: 0;
     opacity: 1;
-    z-index: 2;
+    z-index: 4;
   }
 
   .pop-up img {

--- a/templates/calendar/default/views/_calendar_screen_js.html.twig
+++ b/templates/calendar/default/views/_calendar_screen_js.html.twig
@@ -158,3 +158,119 @@
         $("#wrapper").toggleClass("toggled");
     });
 </script>
+
+{# Day/week layout that does not depend on a theme rebuild:
+   - horizontal scroll with readable provider columns
+   - sticky time column so providers scroll underneath it
+   - IN/OUT under appointments + provider header #}
+<style>
+    /* Scroll container: providers overflow to the right; times stay pinned. */
+    #bigCal {
+        overflow-x: auto !important;
+        overflow-y: hidden;
+        -webkit-overflow-scrolling: touch;
+        width: 100%;
+    }
+    #bigCal > .table-responsive {
+        overflow: visible !important;
+    }
+    #bigCal > .table-responsive > table.table {
+        border-collapse: separate;
+        border-spacing: 0;
+        margin-bottom: 0;
+        min-width: 100%;
+        table-layout: auto;
+        width: max-content;
+    }
+
+    /* Sticky time gutter — schedule columns slide under this while scrolling. */
+    #bigCal td#times {
+        background-color: var(--white, #fff);
+        border-right: 1px solid var(--gray300, #dee2e6);
+        box-shadow: 2px 0 4px rgba(0, 0, 0, 0.08);
+        left: 0;
+        padding: 0.3125rem !important;
+        position: sticky;
+        vertical-align: top;
+        width: 3.25rem;
+        min-width: 3.25rem;
+        max-width: 3.5rem;
+        z-index: 8;
+    }
+    #bigCal td#times .table-responsive {
+        overflow: visible !important;
+    }
+    #bigCal td#times table {
+        width: 100%;
+    }
+    #bigCal td.timeslot {
+        box-sizing: border-box;
+        white-space: nowrap;
+    }
+
+    /* Each provider keeps a readable min width; more columns => horizontal scroll. */
+    #bigCal td.schedule {
+        min-width: 11.5rem;
+        padding: 0 !important;
+        position: relative;
+        vertical-align: top;
+        width: 11.5rem;
+    }
+
+    /* Header: name truncates, close (X) always visible. */
+    #bigCal .providerheader {
+        align-items: center;
+        box-sizing: border-box;
+        display: flex;
+        gap: 0.25rem;
+        justify-content: space-between;
+        overflow: hidden;
+        padding: 0 0.35rem;
+        position: relative;
+        white-space: nowrap;
+        z-index: 5;
+    }
+    #bigCal .providerheader .provider-name {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-align: center;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    #bigCal .providerheader .providerXbtn {
+        flex: 0 0 auto;
+        float: none;
+        line-height: 1;
+        margin: 0;
+        opacity: 0.9;
+        padding: 0 0.15rem;
+    }
+
+    #bigCal .calendar_day .event_in {
+        pointer-events: none;
+        z-index: 1;
+    }
+    #bigCal .calendar_day .event_out {
+        z-index: 1;
+    }
+    #bigCal .calendar_day .in_start {
+        pointer-events: auto;
+        z-index: 1;
+    }
+    #bigCal .calendar_day .event_appointment,
+    #bigCal .calendar_day .event_reserved,
+    #bigCal .calendar_day .event_noshow,
+    #bigCal .calendar_day .event_holiday {
+        box-sizing: border-box;
+        line-height: 1.15;
+        overflow: hidden;
+        padding: 0 0.25rem;
+        white-space: normal;
+        z-index: 3;
+    }
+    #bigCal .calendar_day .event_out.event_highlight,
+    #bigCal .calendar_day .in_start.event_highlight {
+        z-index: 4;
+    }
+</style>

--- a/templates/calendar/default/views/day/ajax_template.html.twig
+++ b/templates/calendar/default/views/day/ajax_template.html.twig
@@ -171,8 +171,8 @@
                 {% for provider in providers %}
                     <td class="schedule {{ provider.classForWeekend|attr }}" title="{{ provider.fname|attr }} {{ provider.lname|attr }}" date="{{ Date|attr }}" provider="{{ provider.id|attr }}">
                         <div class="providerheader providerday">
-                            {{ provider.fname|text }} {{ provider.lname|text }}
-                            <a class="providerXbtn userClose" data-username="{{ provider.username|attr }}"></a>
+                            <span class="provider-name" title="{{ provider.fname|attr }} {{ provider.lname|attr }}">{{ provider.fname|text }} {{ provider.lname|text }}</span>
+                            <a class="providerXbtn userClose" data-username="{{ provider.username|attr }}" title="{{ 'Remove provider'|xla }}"></a>
                         </div>
                         <div class="calendar_day">
                             {% for event in provider.events %}

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-day-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-day-screen-empty.html
@@ -256,6 +256,118 @@
     });
 </script>
 
+<style>
+    /* Scroll container: providers overflow to the right; times stay pinned. */
+    #bigCal {
+        overflow-x: auto !important;
+        overflow-y: hidden;
+        -webkit-overflow-scrolling: touch;
+        width: 100%;
+    }
+    #bigCal > .table-responsive {
+        overflow: visible !important;
+    }
+    #bigCal > .table-responsive > table.table {
+        border-collapse: separate;
+        border-spacing: 0;
+        margin-bottom: 0;
+        min-width: 100%;
+        table-layout: auto;
+        width: max-content;
+    }
+
+    /* Sticky time gutter — schedule columns slide under this while scrolling. */
+    #bigCal td#times {
+        background-color: var(--white, #fff);
+        border-right: 1px solid var(--gray300, #dee2e6);
+        box-shadow: 2px 0 4px rgba(0, 0, 0, 0.08);
+        left: 0;
+        padding: 0.3125rem !important;
+        position: sticky;
+        vertical-align: top;
+        width: 3.25rem;
+        min-width: 3.25rem;
+        max-width: 3.5rem;
+        z-index: 8;
+    }
+    #bigCal td#times .table-responsive {
+        overflow: visible !important;
+    }
+    #bigCal td#times table {
+        width: 100%;
+    }
+    #bigCal td.timeslot {
+        box-sizing: border-box;
+        white-space: nowrap;
+    }
+
+    /* Each provider keeps a readable min width; more columns => horizontal scroll. */
+    #bigCal td.schedule {
+        min-width: 11.5rem;
+        padding: 0 !important;
+        position: relative;
+        vertical-align: top;
+        width: 11.5rem;
+    }
+
+    /* Header: name truncates, close (X) always visible. */
+    #bigCal .providerheader {
+        align-items: center;
+        box-sizing: border-box;
+        display: flex;
+        gap: 0.25rem;
+        justify-content: space-between;
+        overflow: hidden;
+        padding: 0 0.35rem;
+        position: relative;
+        white-space: nowrap;
+        z-index: 5;
+    }
+    #bigCal .providerheader .provider-name {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-align: center;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    #bigCal .providerheader .providerXbtn {
+        flex: 0 0 auto;
+        float: none;
+        line-height: 1;
+        margin: 0;
+        opacity: 0.9;
+        padding: 0 0.15rem;
+    }
+
+    #bigCal .calendar_day .event_in {
+        pointer-events: none;
+        z-index: 1;
+    }
+    #bigCal .calendar_day .event_out {
+        z-index: 1;
+    }
+    #bigCal .calendar_day .in_start {
+        pointer-events: auto;
+        z-index: 1;
+    }
+    #bigCal .calendar_day .event_appointment,
+    #bigCal .calendar_day .event_reserved,
+    #bigCal .calendar_day .event_noshow,
+    #bigCal .calendar_day .event_holiday {
+        box-sizing: border-box;
+        line-height: 1.15;
+        overflow: hidden;
+        padding: 0 0.25rem;
+        white-space: normal;
+        z-index: 3;
+    }
+    #bigCal .calendar_day .event_out.event_highlight,
+    #bigCal .calendar_day .in_start.event_highlight {
+        z-index: 4;
+    }
+</style>
+
 <script>
     $(function () { if (typeof setupDirectTime === 'function') { setupDirectTime(); } });
 </script>

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-month-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-month-screen-empty.html
@@ -244,3 +244,115 @@
         $("#wrapper").toggleClass("toggled");
     });
 </script>
+
+<style>
+    /* Scroll container: providers overflow to the right; times stay pinned. */
+    #bigCal {
+        overflow-x: auto !important;
+        overflow-y: hidden;
+        -webkit-overflow-scrolling: touch;
+        width: 100%;
+    }
+    #bigCal > .table-responsive {
+        overflow: visible !important;
+    }
+    #bigCal > .table-responsive > table.table {
+        border-collapse: separate;
+        border-spacing: 0;
+        margin-bottom: 0;
+        min-width: 100%;
+        table-layout: auto;
+        width: max-content;
+    }
+
+    /* Sticky time gutter — schedule columns slide under this while scrolling. */
+    #bigCal td#times {
+        background-color: var(--white, #fff);
+        border-right: 1px solid var(--gray300, #dee2e6);
+        box-shadow: 2px 0 4px rgba(0, 0, 0, 0.08);
+        left: 0;
+        padding: 0.3125rem !important;
+        position: sticky;
+        vertical-align: top;
+        width: 3.25rem;
+        min-width: 3.25rem;
+        max-width: 3.5rem;
+        z-index: 8;
+    }
+    #bigCal td#times .table-responsive {
+        overflow: visible !important;
+    }
+    #bigCal td#times table {
+        width: 100%;
+    }
+    #bigCal td.timeslot {
+        box-sizing: border-box;
+        white-space: nowrap;
+    }
+
+    /* Each provider keeps a readable min width; more columns => horizontal scroll. */
+    #bigCal td.schedule {
+        min-width: 11.5rem;
+        padding: 0 !important;
+        position: relative;
+        vertical-align: top;
+        width: 11.5rem;
+    }
+
+    /* Header: name truncates, close (X) always visible. */
+    #bigCal .providerheader {
+        align-items: center;
+        box-sizing: border-box;
+        display: flex;
+        gap: 0.25rem;
+        justify-content: space-between;
+        overflow: hidden;
+        padding: 0 0.35rem;
+        position: relative;
+        white-space: nowrap;
+        z-index: 5;
+    }
+    #bigCal .providerheader .provider-name {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-align: center;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    #bigCal .providerheader .providerXbtn {
+        flex: 0 0 auto;
+        float: none;
+        line-height: 1;
+        margin: 0;
+        opacity: 0.9;
+        padding: 0 0.15rem;
+    }
+
+    #bigCal .calendar_day .event_in {
+        pointer-events: none;
+        z-index: 1;
+    }
+    #bigCal .calendar_day .event_out {
+        z-index: 1;
+    }
+    #bigCal .calendar_day .in_start {
+        pointer-events: auto;
+        z-index: 1;
+    }
+    #bigCal .calendar_day .event_appointment,
+    #bigCal .calendar_day .event_reserved,
+    #bigCal .calendar_day .event_noshow,
+    #bigCal .calendar_day .event_holiday {
+        box-sizing: border-box;
+        line-height: 1.15;
+        overflow: hidden;
+        padding: 0 0.25rem;
+        white-space: normal;
+        z-index: 3;
+    }
+    #bigCal .calendar_day .event_out.event_highlight,
+    #bigCal .calendar_day .in_start.event_highlight {
+        z-index: 4;
+    }
+</style>

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-week-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-week-screen-empty.html
@@ -242,6 +242,118 @@
     });
 </script>
 
+<style>
+    /* Scroll container: providers overflow to the right; times stay pinned. */
+    #bigCal {
+        overflow-x: auto !important;
+        overflow-y: hidden;
+        -webkit-overflow-scrolling: touch;
+        width: 100%;
+    }
+    #bigCal > .table-responsive {
+        overflow: visible !important;
+    }
+    #bigCal > .table-responsive > table.table {
+        border-collapse: separate;
+        border-spacing: 0;
+        margin-bottom: 0;
+        min-width: 100%;
+        table-layout: auto;
+        width: max-content;
+    }
+
+    /* Sticky time gutter — schedule columns slide under this while scrolling. */
+    #bigCal td#times {
+        background-color: var(--white, #fff);
+        border-right: 1px solid var(--gray300, #dee2e6);
+        box-shadow: 2px 0 4px rgba(0, 0, 0, 0.08);
+        left: 0;
+        padding: 0.3125rem !important;
+        position: sticky;
+        vertical-align: top;
+        width: 3.25rem;
+        min-width: 3.25rem;
+        max-width: 3.5rem;
+        z-index: 8;
+    }
+    #bigCal td#times .table-responsive {
+        overflow: visible !important;
+    }
+    #bigCal td#times table {
+        width: 100%;
+    }
+    #bigCal td.timeslot {
+        box-sizing: border-box;
+        white-space: nowrap;
+    }
+
+    /* Each provider keeps a readable min width; more columns => horizontal scroll. */
+    #bigCal td.schedule {
+        min-width: 11.5rem;
+        padding: 0 !important;
+        position: relative;
+        vertical-align: top;
+        width: 11.5rem;
+    }
+
+    /* Header: name truncates, close (X) always visible. */
+    #bigCal .providerheader {
+        align-items: center;
+        box-sizing: border-box;
+        display: flex;
+        gap: 0.25rem;
+        justify-content: space-between;
+        overflow: hidden;
+        padding: 0 0.35rem;
+        position: relative;
+        white-space: nowrap;
+        z-index: 5;
+    }
+    #bigCal .providerheader .provider-name {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-align: center;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    #bigCal .providerheader .providerXbtn {
+        flex: 0 0 auto;
+        float: none;
+        line-height: 1;
+        margin: 0;
+        opacity: 0.9;
+        padding: 0 0.15rem;
+    }
+
+    #bigCal .calendar_day .event_in {
+        pointer-events: none;
+        z-index: 1;
+    }
+    #bigCal .calendar_day .event_out {
+        z-index: 1;
+    }
+    #bigCal .calendar_day .in_start {
+        pointer-events: auto;
+        z-index: 1;
+    }
+    #bigCal .calendar_day .event_appointment,
+    #bigCal .calendar_day .event_reserved,
+    #bigCal .calendar_day .event_noshow,
+    #bigCal .calendar_day .event_holiday {
+        box-sizing: border-box;
+        line-height: 1.15;
+        overflow: hidden;
+        padding: 0 0.25rem;
+        white-space: normal;
+        z-index: 3;
+    }
+    #bigCal .calendar_day .event_out.event_highlight,
+    #bigCal .calendar_day .in_start.event_highlight {
+        z-index: 4;
+    }
+</style>
+
 <script>
     $(function () { if (typeof setupDirectTime === 'function') { setupDirectTime(); } });
 </script>


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Fixes calendar day view layout when many providers are selected: provider columns no longer compress into the viewport. The grid scrolls horizontally, the time column stays sticky, and provider headers keep a usable name + close control.

Fixes #13794

#### Changes proposed in this pull request:

- Give each provider column a readable minimum width (~11.5rem) and let `#bigCal` scroll horizontally when providers exceed the viewport
- Make the times column sticky so it remains visible while provider columns scroll
- Flex the provider header so the name can ellipsis and the close (X) control stays on the right
- Restack IN/OUT under appointments/header so office-hours fills do not cover the header or first-slot appointments
- Include matching runtime CSS in the calendar screen Twig so the layout works without a theme rebuild
- Update day/week/month screen Twig render fixtures

#### Was an AI assistant used? Yes / No

Yes

<!-- warp-managed-pr-artifacts
### References
- [Warp conversation](https://app.warp.dev/conversation/bf996c7e-ce5e-4b49-ba15-ebb043f164b1)
- [Plan: Upstream Skok calendar fixes](https://app.warp.dev/drive/notebook/d9fCCH7Kj3CqmF45jY0NHL)
-->