### PR TITLE
fix(calendar): allow double-click edit of IN/OUT/LUNCH events

### DIFF
--- a/interface/main/calendar/modules/PostCalendar/pnuserapi.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuserapi.php
@@ -13,6 +13,7 @@
 */
 
 use OpenEMR\Common\Calendar\Month;
+use OpenEMR\Common\Calendar\ProviderCategoryType;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\OEGlobalsBag;
@@ -1329,7 +1330,7 @@ function &postcalendar_userapi_pcQueryEvents($args)
         // Provider categories (IN/OUT/LUNCH/etc. use pc_cattype=1) must open
         // add_edit_event with prov=true — legacy templates set this as the
         // third segment of the event DOM id after a per-event category lookup.
-        $events[$i]['pccattype']   = (is_numeric($tmp['cattype']) && (int) $tmp['cattype'] === 1) ? 'true' : '';
+        $events[$i]['pccattype']   = ProviderCategoryType::toDomMarker($tmp['cattype']);
         $events[$i]['pid']         = $tmp['pid'];
         $events[$i]['apptstatus']  = $tmp['apptstatus'];
         $events[$i]['pubpid']      = $tmp['pubpid'];

--- a/interface/main/calendar/modules/PostCalendar/pnuserapi.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuserapi.php
@@ -1329,7 +1329,7 @@ function &postcalendar_userapi_pcQueryEvents($args)
         // Provider categories (IN/OUT/LUNCH/etc. use pc_cattype=1) must open
         // add_edit_event with prov=true — legacy templates set this as the
         // third segment of the event DOM id after a per-event category lookup.
-        $events[$i]['pccattype']   = ((int) $tmp['cattype'] === 1) ? 'true' : '';
+        $events[$i]['pccattype']   = (is_numeric($tmp['cattype']) && (int) $tmp['cattype'] === 1) ? 'true' : '';
         $events[$i]['pid']         = $tmp['pid'];
         $events[$i]['apptstatus']  = $tmp['apptstatus'];
         $events[$i]['pubpid']      = $tmp['pubpid'];

--- a/interface/main/calendar/modules/PostCalendar/pnuserapi.php
+++ b/interface/main/calendar/modules/PostCalendar/pnuserapi.php
@@ -1104,7 +1104,7 @@ function &postcalendar_userapi_pcQueryEvents($args)
     "a.pc_recurrspec, a.pc_topic, a.pc_alldayevent, a.pc_location, " .
     "a.pc_conttel, a.pc_contname, a.pc_contemail, a.pc_website, a.pc_fee, " .
     "a.pc_sharing, a.pc_prefcatid, b.pc_catcolor, b.pc_catname, " .
-    "b.pc_catdesc, a.pc_pid, a.pc_apptstatus, a.pc_aid, " .
+    "b.pc_catdesc, b.pc_cattype, a.pc_pid, a.pc_apptstatus, a.pc_aid, " .
     "concat(u.fname,' ',u.lname) as provider_name, " .
     "concat(pd.lname,', ',pd.fname) as patient_name, " .
     "concat(u.fname, ' ', u.lname) as owner_name, " .
@@ -1273,6 +1273,7 @@ function &postcalendar_userapi_pcQueryEvents($args)
             $tmp['catcolor'],
             $tmp['catname'],
             $tmp['catdesc'],
+            $tmp['cattype'],
             $tmp['pid'],
             $tmp['apptstatus'],
             $tmp['aid'],
@@ -1325,6 +1326,10 @@ function &postcalendar_userapi_pcQueryEvents($args)
         // Modified 06-2009 by BM to translate the category if applicable
         $events[$i]['catname']     = xl_appt_category($tmp['catname']);
         $events[$i]['catdesc']     = $tmp['catdesc'];
+        // Provider categories (IN/OUT/LUNCH/etc. use pc_cattype=1) must open
+        // add_edit_event with prov=true — legacy templates set this as the
+        // third segment of the event DOM id after a per-event category lookup.
+        $events[$i]['pccattype']   = ((int) $tmp['cattype'] === 1) ? 'true' : '';
         $events[$i]['pid']         = $tmp['pid'];
         $events[$i]['apptstatus']  = $tmp['apptstatus'];
         $events[$i]['pubpid']      = $tmp['pubpid'];

--- a/interface/themes/ajax_calendar_sass.scss
+++ b/interface/themes/ajax_calendar_sass.scss
@@ -540,6 +540,14 @@ $side-calendar-date-padding: 0.3rem !default;
     z-index: 2;
   }
 
+  /* Create-slot marker is not .event (avoids EditEvent bindings) but still needs
+     absolute layout inside .calendar_day or it pins to the column top-left. */
+  a.apptMarker {
+    position: absolute;
+    width: 100%;
+    z-index: 1;
+  }
+
   .event_out.event_highlight,
   .in_start.event_highlight {
     background-color: $yellow;

--- a/interface/themes/ajax_calendar_sass.scss
+++ b/interface/themes/ajax_calendar_sass.scss
@@ -465,21 +465,22 @@ $side-calendar-date-padding: 0.3rem !default;
       text-overflow: ellipsis;
       white-space: nowrap;
       width: 100%;
-      z-index: 2;
+      /* Above OUT/IN labels so appointments remain the pointer target. */
+      z-index: 3;
     }
 
     &_noshow {
       @extend %highlight;
       border-radius: 0.25rem;
       overflow: hidden;
-      z-index: 2;
+      z-index: 3;
     }
 
     &_reserved {
       @extend %highlight;
       border-radius: 0.25rem;
       overflow: hidden;
-      z-index: 2;
+      z-index: 3;
     }
 
     &_holiday {
@@ -487,7 +488,7 @@ $side-calendar-date-padding: 0.3rem !default;
       border-radius: 0.25rem;
       overflow: hidden;
       width: 100% !important;
-      z-index: 2;
+      z-index: 3;
     }
 
     &_time {
@@ -546,7 +547,7 @@ $side-calendar-date-padding: 0.3rem !default;
     font-weight: bold;
     margin: 0;
     opacity: 1;
-    z-index: 2;
+    z-index: 4;
   }
 
   .pop-up img {

--- a/interface/themes/ajax_calendar_sass.scss
+++ b/interface/themes/ajax_calendar_sass.scss
@@ -450,7 +450,10 @@ $side-calendar-date-padding: 0.3rem !default;
 
     &_out {
       @extend %highlight;
-      z-index: 3;
+      /* Above create-slot marker, editable on double-click. */
+      cursor: pointer;
+      pointer-events: auto;
+      z-index: 2;
     }
 
     &_appointment {
@@ -531,6 +534,8 @@ $side-calendar-date-padding: 0.3rem !default;
 
   .in_start {
     background: transparent;
+    cursor: pointer;
+    pointer-events: auto;
     z-index: 2;
   }
 

--- a/library/js/calendarDirectSelect.js
+++ b/library/js/calendarDirectSelect.js
@@ -46,10 +46,13 @@ function displayApptTime(evt) {
     }
     let marker = $(this).find("a.apptMarker");
     if (marker.length == 0) {
+        // Do not add class "event" — that class is bound to EditEvent dblclick
+        // and would intercept double-clicks meant for IN/OUT/LUNCH blocks.
         style = "style='height:" + tsHeight + ";'";
-        $(this).find("div.calendar_day").append("<a class='apptMarker event event_appointment'" + style + "></a>");
+        $(this).find("div.calendar_day").append("<a class='apptMarker event_appointment'" + style + "></a>");
         marker = $(this).find("a.apptMarker");
-        marker.css("z-index", 1);
+        // Stay under real schedule events (OUT/LUNCH/appointments) so they remain clickable.
+        marker.css("z-index", 0);
     }
     y = evt.pageY - $(this).offset().top;
     rem = y % tsHeightNum;
@@ -63,6 +66,26 @@ function displayApptTime(evt) {
             return;
         }
     }
+
+    // If the cursor is over a real calendar event (IN label, OUT, LUNCH,
+    // appointment), hide the create-slot marker so click/dblclick reach it.
+    // Temporarily disable marker hit-testing so elementFromPoint sees below.
+    marker.css("pointer-events", "none");
+    let under = document.elementFromPoint(evt.clientX, evt.clientY);
+    marker.css("pointer-events", "");
+    let $under = $(under);
+    let $realEvent = $under.closest("div.event").not(".apptMarker");
+    if ($realEvent.length) {
+        // IN body fill is pointer-events:none; only the in_start label is editable.
+        // Over bare IN fill, keep the marker so empty office hours stay creatable.
+        if ($realEvent.hasClass("event_in") && !$realEvent.hasClass("in_start") && !$under.closest(".in_start").length) {
+            // fall through — show marker for new appointment in open IN hours
+        } else {
+            marker.hide();
+            return;
+        }
+    }
+
     marker.css("top", y);
     date = $(this).attr("date");
     updateApptTime(marker, index, y, date, $(this).attr("provider"));

--- a/library/js/calendarDirectSelect.js
+++ b/library/js/calendarDirectSelect.js
@@ -51,8 +51,9 @@ function displayApptTime(evt) {
         style = "style='height:" + tsHeight + ";'";
         $(this).find("div.calendar_day").append("<a class='apptMarker event_appointment'" + style + "></a>");
         marker = $(this).find("a.apptMarker");
-        // Stay under real schedule events (OUT/LUNCH/appointments) so they remain clickable.
-        marker.css("z-index", 0);
+        // Above IN fill (z-index 1 body is pointer-events:none); under OUT/LUNCH/
+        // appointments (z-index 2+) so those remain clickable.
+        marker.css("z-index", 1);
     }
     y = evt.pageY - $(this).offset().top;
     rem = y % tsHeightNum;

--- a/src/Common/Calendar/ProviderCategoryType.php
+++ b/src/Common/Calendar/ProviderCategoryType.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Map openemr_postcalendar_categories.pc_cattype to the legacy DOM pccattype
+ * marker used in calendar event element ids.
+ *
+ * Provider-status categories (IN/OUT/LUNCH/etc.) use pc_cattype=1 and must open
+ * add_edit_event with prov=true. Legacy templates put that flag in the third
+ * segment of the event DOM id after a per-event category lookup.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Common\Calendar;
+
+final class ProviderCategoryType
+{
+    /**
+     * Value stored in openemr_postcalendar_categories.pc_cattype for provider
+     * status categories (IN / OUT / LUNCH / etc.).
+     */
+    public const PROVIDER_STATUS = 1;
+
+    /**
+     * Return the legacy pccattype DOM segment for a category type value.
+     *
+     * @param mixed $cattype Raw pc_cattype from the database row
+     */
+    public static function toDomMarker(mixed $cattype): string
+    {
+        return (is_numeric($cattype) && (int) $cattype === self::PROVIDER_STATUS) ? 'true' : '';
+    }
+
+    /**
+     * Whether the category type is a provider-status category.
+     *
+     * @param mixed $cattype Raw pc_cattype from the database row
+     */
+    public static function isProviderStatus(mixed $cattype): bool
+    {
+        return self::toDomMarker($cattype) === 'true';
+    }
+}

--- a/templates/calendar/default/views/_calendar_screen_js.html.twig
+++ b/templates/calendar/default/views/_calendar_screen_js.html.twig
@@ -215,8 +215,14 @@
         cursor: pointer;
         z-index: 3;
     }
+    /* apptMarker deliberately omits the generic .event class (so EditEvent
+       dblclick does not fire on it). Re-apply the absolute layout that .event
+       would have provided, or top/height stay in normal flow and the marker
+       pins to the top-left of the column. */
     #bigCal .calendar_day a.apptMarker {
-        z-index: 0;
+        position: absolute;
+        width: 100%;
+        z-index: 1;
     }
     #bigCal .calendar_day .event_out.event_highlight,
     #bigCal .calendar_day .in_start.event_highlight {

--- a/templates/calendar/default/views/_calendar_screen_js.html.twig
+++ b/templates/calendar/default/views/_calendar_screen_js.html.twig
@@ -113,9 +113,14 @@
           $(this).toggleClass("tdDatePickerHighlightCurrent");
         });
         $("#printview").click(function() { PrintView(this); });
-        $(".event").dblclick(function() { EditEvent(this); });
-        $(".event").mouseover(function() { $(this).toggleClass("event_highlight"); });
-        $(".event").mouseout(function() { $(this).toggleClass("event_highlight"); });
+        // Exclude the direct-select create marker (.apptMarker) — it is not an editable event.
+        $(".event").not(".apptMarker").dblclick(function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            EditEvent(this);
+        });
+        $(".event").not(".apptMarker").mouseover(function() { $(this).toggleClass("event_highlight"); });
+        $(".event").not(".apptMarker").mouseout(function() { $(this).toggleClass("event_highlight"); });
         $(".tdMonthName-small").click(function() {
             dpCal = $("#datePicker > table");
             mp = $("#monthPicker");
@@ -128,15 +133,29 @@
 
     /* edit an existing event */
     var EditEvent = function(eObj) {
-        objID = eObj.id;
-        var parts = new Array();
-        parts = objID.split("-");
-        editing_group = $(eObj).hasClass("groups");
-        if(editing_group){
-            oldGroupEvt(parts[0], parts[1], parts[2]);
+        if (!eObj || $(eObj).hasClass('apptMarker')) {
+            return false;
+        }
+        // Prefer data-eid when present; fall back to legacy id="date-eid-prov".
+        var objID = eObj.id || '';
+        var parts = objID.split("-");
+        // IDs are YYYYMMDD-eid-pccattype; eid is numeric but keep join-safe parse:
+        // date (8 digits), eid (middle), pccattype ("true" or empty).
+        var eventDate = parts[0] || '';
+        var eventId = parts.length >= 2 ? parts[1] : '';
+        var pccattype = parts.length >= 3 ? parts.slice(2).join('-') : '';
+        if (!eventId && eObj.getAttribute) {
+            eventId = eObj.getAttribute('data-eid') || '';
+        }
+        if (!eventId) {
+            return false;
+        }
+        var editing_group = $(eObj).hasClass("groups");
+        if (editing_group) {
+            oldGroupEvt(eventDate, eventId, pccattype);
             return true;
         }
-        oldEvt(parts[0], parts[1], parts[2]);
+        oldEvt(eventDate, eventId, pccattype);
         return true;
     }
 
@@ -169,6 +188,41 @@
         $("#wrapper").toggleClass("toggled");
     });
 </script>
+
+{# Stacking for editable provider-status blocks vs create-slot marker. #}
+<style>
+    /* IN body fill stays under appointments and does not capture clicks so
+       open hours remain creatable. The in_start label is the edit target. */
+    #bigCal .calendar_day .event_in {
+        pointer-events: none;
+        z-index: 1;
+    }
+    /* OUT/IN-label above the create-slot marker (z-index 0), below appointments. */
+    #bigCal .calendar_day .event_out {
+        cursor: pointer;
+        pointer-events: auto;
+        z-index: 2;
+    }
+    #bigCal .calendar_day .in_start {
+        cursor: pointer;
+        pointer-events: auto;
+        z-index: 2;
+    }
+    #bigCal .calendar_day .event_appointment,
+    #bigCal .calendar_day .event_reserved,
+    #bigCal .calendar_day .event_noshow,
+    #bigCal .calendar_day .event_holiday {
+        cursor: pointer;
+        z-index: 3;
+    }
+    #bigCal .calendar_day a.apptMarker {
+        z-index: 0;
+    }
+    #bigCal .calendar_day .event_out.event_highlight,
+    #bigCal .calendar_day .in_start.event_highlight {
+        z-index: 4;
+    }
+</style>
 
 {# Fixed-width times gutter that does not depend on a theme rebuild. #}
 <style>

--- a/tests/Tests/Isolated/Common/Calendar/ProviderCategoryTypeTest.php
+++ b/tests/Tests/Isolated/Common/Calendar/ProviderCategoryTypeTest.php
@@ -66,9 +66,4 @@ final class ProviderCategoryTypeTest extends TestCase
     {
         $this->assertSame($expected, ProviderCategoryType::isProviderStatus($cattype));
     }
-
-    public function testProviderStatusConstant(): void
-    {
-        $this->assertSame(1, ProviderCategoryType::PROVIDER_STATUS);
-    }
 }

--- a/tests/Tests/Isolated/Common/Calendar/ProviderCategoryTypeTest.php
+++ b/tests/Tests/Isolated/Common/Calendar/ProviderCategoryTypeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Isolated tests for ProviderCategoryType.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Calendar;
+
+use OpenEMR\Common\Calendar\ProviderCategoryType;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ProviderCategoryTypeTest extends TestCase
+{
+    /**
+     * @return array<string, array{mixed, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function toDomMarkerProvider(): array
+    {
+        return [
+            'int provider status' => [1, 'true'],
+            'string provider status' => ['1', 'true'],
+            'float-ish provider status' => [1.0, 'true'],
+            'patient category zero' => [0, ''],
+            'string zero' => ['0', ''],
+            'other category' => [2, ''],
+            'null' => [null, ''],
+            'empty string' => ['', ''],
+            'non-numeric' => ['provider', ''],
+            'bool true is not numeric' => [true, ''],
+            'bool false' => [false, ''],
+        ];
+    }
+
+    #[DataProvider('toDomMarkerProvider')]
+    public function testToDomMarker(mixed $cattype, string $expected): void
+    {
+        $this->assertSame($expected, ProviderCategoryType::toDomMarker($cattype));
+    }
+
+    /**
+     * @return array<string, array{mixed, bool}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function isProviderStatusProvider(): array
+    {
+        return [
+            'provider' => [1, true],
+            'patient' => [0, false],
+            'null' => [null, false],
+            'string one' => ['1', true],
+        ];
+    }
+
+    #[DataProvider('isProviderStatusProvider')]
+    public function testIsProviderStatus(mixed $cattype, bool $expected): void
+    {
+        $this->assertSame($expected, ProviderCategoryType::isProviderStatus($cattype));
+    }
+
+    public function testProviderStatusConstant(): void
+    {
+        $this->assertSame(1, ProviderCategoryType::PROVIDER_STATUS);
+    }
+}

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-day-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-day-screen-empty.html
@@ -311,8 +311,14 @@
         cursor: pointer;
         z-index: 3;
     }
+    /* apptMarker deliberately omits the generic .event class (so EditEvent
+       dblclick does not fire on it). Re-apply the absolute layout that .event
+       would have provided, or top/height stay in normal flow and the marker
+       pins to the top-left of the column. */
     #bigCal .calendar_day a.apptMarker {
-        z-index: 0;
+        position: absolute;
+        width: 100%;
+        z-index: 1;
     }
     #bigCal .calendar_day .event_out.event_highlight,
     #bigCal .calendar_day .in_start.event_highlight {

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-day-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-day-screen-empty.html
@@ -287,11 +287,6 @@
 </script>
 
 <style>
-<script>
-    $(function () { if (typeof setupDirectTime === 'function') { setupDirectTime(); } });
-</script>
-
-<style>
     /* IN body fill stays under appointments and does not capture clicks so
        open hours remain creatable. The in_start label is the edit target. */
     #bigCal .calendar_day .event_in {

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-day-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-day-screen-empty.html
@@ -210,9 +210,14 @@
           $(this).toggleClass("tdDatePickerHighlightCurrent");
         });
         $("#printview").click(function() { PrintView(this); });
-        $(".event").dblclick(function() { EditEvent(this); });
-        $(".event").mouseover(function() { $(this).toggleClass("event_highlight"); });
-        $(".event").mouseout(function() { $(this).toggleClass("event_highlight"); });
+        // Exclude the direct-select create marker (.apptMarker) — it is not an editable event.
+        $(".event").not(".apptMarker").dblclick(function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            EditEvent(this);
+        });
+        $(".event").not(".apptMarker").mouseover(function() { $(this).toggleClass("event_highlight"); });
+        $(".event").not(".apptMarker").mouseout(function() { $(this).toggleClass("event_highlight"); });
         $(".tdMonthName-small").click(function() {
             dpCal = $("#datePicker > table");
             mp = $("#monthPicker");
@@ -225,15 +230,29 @@
 
     /* edit an existing event */
     var EditEvent = function(eObj) {
-        objID = eObj.id;
-        var parts = new Array();
-        parts = objID.split("-");
-        editing_group = $(eObj).hasClass("groups");
-        if(editing_group){
-            oldGroupEvt(parts[0], parts[1], parts[2]);
+        if (!eObj || $(eObj).hasClass('apptMarker')) {
+            return false;
+        }
+        // Prefer data-eid when present; fall back to legacy id="date-eid-prov".
+        var objID = eObj.id || '';
+        var parts = objID.split("-");
+        // IDs are YYYYMMDD-eid-pccattype; eid is numeric but keep join-safe parse:
+        // date (8 digits), eid (middle), pccattype ("true" or empty).
+        var eventDate = parts[0] || '';
+        var eventId = parts.length >= 2 ? parts[1] : '';
+        var pccattype = parts.length >= 3 ? parts.slice(2).join('-') : '';
+        if (!eventId && eObj.getAttribute) {
+            eventId = eObj.getAttribute('data-eid') || '';
+        }
+        if (!eventId) {
+            return false;
+        }
+        var editing_group = $(eObj).hasClass("groups");
+        if (editing_group) {
+            oldGroupEvt(eventDate, eventId, pccattype);
             return true;
         }
-        oldEvt(parts[0], parts[1], parts[2]);
+        oldEvt(eventDate, eventId, pccattype);
         return true;
     }
 
@@ -266,6 +285,45 @@
         $("#wrapper").toggleClass("toggled");
     });
 </script>
+
+<style>
+<script>
+    $(function () { if (typeof setupDirectTime === 'function') { setupDirectTime(); } });
+</script>
+
+<style>
+    /* IN body fill stays under appointments and does not capture clicks so
+       open hours remain creatable. The in_start label is the edit target. */
+    #bigCal .calendar_day .event_in {
+        pointer-events: none;
+        z-index: 1;
+    }
+    /* OUT/IN-label above the create-slot marker (z-index 0), below appointments. */
+    #bigCal .calendar_day .event_out {
+        cursor: pointer;
+        pointer-events: auto;
+        z-index: 2;
+    }
+    #bigCal .calendar_day .in_start {
+        cursor: pointer;
+        pointer-events: auto;
+        z-index: 2;
+    }
+    #bigCal .calendar_day .event_appointment,
+    #bigCal .calendar_day .event_reserved,
+    #bigCal .calendar_day .event_noshow,
+    #bigCal .calendar_day .event_holiday {
+        cursor: pointer;
+        z-index: 3;
+    }
+    #bigCal .calendar_day a.apptMarker {
+        z-index: 0;
+    }
+    #bigCal .calendar_day .event_out.event_highlight,
+    #bigCal .calendar_day .in_start.event_highlight {
+        z-index: 4;
+    }
+</style>
 
 <style>
     #bigCal td#times,

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-month-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-month-screen-empty.html
@@ -276,7 +276,40 @@
 </script>
 
 <style>
-<<<<<<< HEAD
+    /* IN body fill stays under appointments and does not capture clicks so
+       open hours remain creatable. The in_start label is the edit target. */
+    #bigCal .calendar_day .event_in {
+        pointer-events: none;
+        z-index: 1;
+    }
+    /* OUT/IN-label above the create-slot marker (z-index 0), below appointments. */
+    #bigCal .calendar_day .event_out {
+        cursor: pointer;
+        pointer-events: auto;
+        z-index: 2;
+    }
+    #bigCal .calendar_day .in_start {
+        cursor: pointer;
+        pointer-events: auto;
+        z-index: 2;
+    }
+    #bigCal .calendar_day .event_appointment,
+    #bigCal .calendar_day .event_reserved,
+    #bigCal .calendar_day .event_noshow,
+    #bigCal .calendar_day .event_holiday {
+        cursor: pointer;
+        z-index: 3;
+    }
+    #bigCal .calendar_day a.apptMarker {
+        z-index: 0;
+    }
+    #bigCal .calendar_day .event_out.event_highlight,
+    #bigCal .calendar_day .in_start.event_highlight {
+        z-index: 4;
+    }
+</style>
+
+<style>
     #bigCal td#times,
     #bigCal td.calendar-times-col {
         box-sizing: border-box;
@@ -319,37 +352,5 @@
         opacity: 0.75;
         text-decoration: none;
         user-select: none;
-=======
-    /* IN body fill stays under appointments and does not capture clicks so
-       open hours remain creatable. The in_start label is the edit target. */
-    #bigCal .calendar_day .event_in {
-        pointer-events: none;
-        z-index: 1;
-    }
-    /* OUT/IN-label above the create-slot marker (z-index 0), below appointments. */
-    #bigCal .calendar_day .event_out {
-        cursor: pointer;
-        pointer-events: auto;
-        z-index: 2;
-    }
-    #bigCal .calendar_day .in_start {
-        cursor: pointer;
-        pointer-events: auto;
-        z-index: 2;
-    }
-    #bigCal .calendar_day .event_appointment,
-    #bigCal .calendar_day .event_reserved,
-    #bigCal .calendar_day .event_noshow,
-    #bigCal .calendar_day .event_holiday {
-        cursor: pointer;
-        z-index: 3;
-    }
-    #bigCal .calendar_day a.apptMarker {
-        z-index: 0;
-    }
-    #bigCal .calendar_day .event_out.event_highlight,
-    #bigCal .calendar_day .in_start.event_highlight {
-        z-index: 4;
->>>>>>> 0865c30b96 (fix(calendar): allow double-click edit of IN/OUT/LUNCH events)
     }
 </style>

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-month-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-month-screen-empty.html
@@ -300,8 +300,14 @@
         cursor: pointer;
         z-index: 3;
     }
+    /* apptMarker deliberately omits the generic .event class (so EditEvent
+       dblclick does not fire on it). Re-apply the absolute layout that .event
+       would have provided, or top/height stay in normal flow and the marker
+       pins to the top-left of the column. */
     #bigCal .calendar_day a.apptMarker {
-        z-index: 0;
+        position: absolute;
+        width: 100%;
+        z-index: 1;
     }
     #bigCal .calendar_day .event_out.event_highlight,
     #bigCal .calendar_day .in_start.event_highlight {

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-month-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-month-screen-empty.html
@@ -199,9 +199,14 @@
           $(this).toggleClass("tdDatePickerHighlightCurrent");
         });
         $("#printview").click(function() { PrintView(this); });
-        $(".event").dblclick(function() { EditEvent(this); });
-        $(".event").mouseover(function() { $(this).toggleClass("event_highlight"); });
-        $(".event").mouseout(function() { $(this).toggleClass("event_highlight"); });
+        // Exclude the direct-select create marker (.apptMarker) — it is not an editable event.
+        $(".event").not(".apptMarker").dblclick(function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            EditEvent(this);
+        });
+        $(".event").not(".apptMarker").mouseover(function() { $(this).toggleClass("event_highlight"); });
+        $(".event").not(".apptMarker").mouseout(function() { $(this).toggleClass("event_highlight"); });
         $(".tdMonthName-small").click(function() {
             dpCal = $("#datePicker > table");
             mp = $("#monthPicker");
@@ -214,15 +219,29 @@
 
     /* edit an existing event */
     var EditEvent = function(eObj) {
-        objID = eObj.id;
-        var parts = new Array();
-        parts = objID.split("-");
-        editing_group = $(eObj).hasClass("groups");
-        if(editing_group){
-            oldGroupEvt(parts[0], parts[1], parts[2]);
+        if (!eObj || $(eObj).hasClass('apptMarker')) {
+            return false;
+        }
+        // Prefer data-eid when present; fall back to legacy id="date-eid-prov".
+        var objID = eObj.id || '';
+        var parts = objID.split("-");
+        // IDs are YYYYMMDD-eid-pccattype; eid is numeric but keep join-safe parse:
+        // date (8 digits), eid (middle), pccattype ("true" or empty).
+        var eventDate = parts[0] || '';
+        var eventId = parts.length >= 2 ? parts[1] : '';
+        var pccattype = parts.length >= 3 ? parts.slice(2).join('-') : '';
+        if (!eventId && eObj.getAttribute) {
+            eventId = eObj.getAttribute('data-eid') || '';
+        }
+        if (!eventId) {
+            return false;
+        }
+        var editing_group = $(eObj).hasClass("groups");
+        if (editing_group) {
+            oldGroupEvt(eventDate, eventId, pccattype);
             return true;
         }
-        oldEvt(parts[0], parts[1], parts[2]);
+        oldEvt(eventDate, eventId, pccattype);
         return true;
     }
 
@@ -257,6 +276,7 @@
 </script>
 
 <style>
+<<<<<<< HEAD
     #bigCal td#times,
     #bigCal td.calendar-times-col {
         box-sizing: border-box;
@@ -299,5 +319,37 @@
         opacity: 0.75;
         text-decoration: none;
         user-select: none;
+=======
+    /* IN body fill stays under appointments and does not capture clicks so
+       open hours remain creatable. The in_start label is the edit target. */
+    #bigCal .calendar_day .event_in {
+        pointer-events: none;
+        z-index: 1;
+    }
+    /* OUT/IN-label above the create-slot marker (z-index 0), below appointments. */
+    #bigCal .calendar_day .event_out {
+        cursor: pointer;
+        pointer-events: auto;
+        z-index: 2;
+    }
+    #bigCal .calendar_day .in_start {
+        cursor: pointer;
+        pointer-events: auto;
+        z-index: 2;
+    }
+    #bigCal .calendar_day .event_appointment,
+    #bigCal .calendar_day .event_reserved,
+    #bigCal .calendar_day .event_noshow,
+    #bigCal .calendar_day .event_holiday {
+        cursor: pointer;
+        z-index: 3;
+    }
+    #bigCal .calendar_day a.apptMarker {
+        z-index: 0;
+    }
+    #bigCal .calendar_day .event_out.event_highlight,
+    #bigCal .calendar_day .in_start.event_highlight {
+        z-index: 4;
+>>>>>>> 0865c30b96 (fix(calendar): allow double-click edit of IN/OUT/LUNCH events)
     }
 </style>

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-week-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-week-screen-empty.html
@@ -297,8 +297,14 @@
         cursor: pointer;
         z-index: 3;
     }
+    /* apptMarker deliberately omits the generic .event class (so EditEvent
+       dblclick does not fire on it). Re-apply the absolute layout that .event
+       would have provided, or top/height stay in normal flow and the marker
+       pins to the top-left of the column. */
     #bigCal .calendar_day a.apptMarker {
-        z-index: 0;
+        position: absolute;
+        width: 100%;
+        z-index: 1;
     }
     #bigCal .calendar_day .event_out.event_highlight,
     #bigCal .calendar_day .in_start.event_highlight {

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-week-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-week-screen-empty.html
@@ -273,7 +273,40 @@
 </script>
 
 <style>
-<<<<<<< HEAD
+    /* IN body fill stays under appointments and does not capture clicks so
+       open hours remain creatable. The in_start label is the edit target. */
+    #bigCal .calendar_day .event_in {
+        pointer-events: none;
+        z-index: 1;
+    }
+    /* OUT/IN-label above the create-slot marker (z-index 0), below appointments. */
+    #bigCal .calendar_day .event_out {
+        cursor: pointer;
+        pointer-events: auto;
+        z-index: 2;
+    }
+    #bigCal .calendar_day .in_start {
+        cursor: pointer;
+        pointer-events: auto;
+        z-index: 2;
+    }
+    #bigCal .calendar_day .event_appointment,
+    #bigCal .calendar_day .event_reserved,
+    #bigCal .calendar_day .event_noshow,
+    #bigCal .calendar_day .event_holiday {
+        cursor: pointer;
+        z-index: 3;
+    }
+    #bigCal .calendar_day a.apptMarker {
+        z-index: 0;
+    }
+    #bigCal .calendar_day .event_out.event_highlight,
+    #bigCal .calendar_day .in_start.event_highlight {
+        z-index: 4;
+    }
+</style>
+
+<style>
     #bigCal td#times,
     #bigCal td.calendar-times-col {
         box-sizing: border-box;
@@ -316,38 +349,6 @@
         opacity: 0.75;
         text-decoration: none;
         user-select: none;
-=======
-    /* IN body fill stays under appointments and does not capture clicks so
-       open hours remain creatable. The in_start label is the edit target. */
-    #bigCal .calendar_day .event_in {
-        pointer-events: none;
-        z-index: 1;
-    }
-    /* OUT/IN-label above the create-slot marker (z-index 0), below appointments. */
-    #bigCal .calendar_day .event_out {
-        cursor: pointer;
-        pointer-events: auto;
-        z-index: 2;
-    }
-    #bigCal .calendar_day .in_start {
-        cursor: pointer;
-        pointer-events: auto;
-        z-index: 2;
-    }
-    #bigCal .calendar_day .event_appointment,
-    #bigCal .calendar_day .event_reserved,
-    #bigCal .calendar_day .event_noshow,
-    #bigCal .calendar_day .event_holiday {
-        cursor: pointer;
-        z-index: 3;
-    }
-    #bigCal .calendar_day a.apptMarker {
-        z-index: 0;
-    }
-    #bigCal .calendar_day .event_out.event_highlight,
-    #bigCal .calendar_day .in_start.event_highlight {
-        z-index: 4;
->>>>>>> 0865c30b96 (fix(calendar): allow double-click edit of IN/OUT/LUNCH events)
     }
 </style>
 

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-week-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-week-screen-empty.html
@@ -196,9 +196,14 @@
           $(this).toggleClass("tdDatePickerHighlightCurrent");
         });
         $("#printview").click(function() { PrintView(this); });
-        $(".event").dblclick(function() { EditEvent(this); });
-        $(".event").mouseover(function() { $(this).toggleClass("event_highlight"); });
-        $(".event").mouseout(function() { $(this).toggleClass("event_highlight"); });
+        // Exclude the direct-select create marker (.apptMarker) — it is not an editable event.
+        $(".event").not(".apptMarker").dblclick(function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            EditEvent(this);
+        });
+        $(".event").not(".apptMarker").mouseover(function() { $(this).toggleClass("event_highlight"); });
+        $(".event").not(".apptMarker").mouseout(function() { $(this).toggleClass("event_highlight"); });
         $(".tdMonthName-small").click(function() {
             dpCal = $("#datePicker > table");
             mp = $("#monthPicker");
@@ -211,15 +216,29 @@
 
     /* edit an existing event */
     var EditEvent = function(eObj) {
-        objID = eObj.id;
-        var parts = new Array();
-        parts = objID.split("-");
-        editing_group = $(eObj).hasClass("groups");
-        if(editing_group){
-            oldGroupEvt(parts[0], parts[1], parts[2]);
+        if (!eObj || $(eObj).hasClass('apptMarker')) {
+            return false;
+        }
+        // Prefer data-eid when present; fall back to legacy id="date-eid-prov".
+        var objID = eObj.id || '';
+        var parts = objID.split("-");
+        // IDs are YYYYMMDD-eid-pccattype; eid is numeric but keep join-safe parse:
+        // date (8 digits), eid (middle), pccattype ("true" or empty).
+        var eventDate = parts[0] || '';
+        var eventId = parts.length >= 2 ? parts[1] : '';
+        var pccattype = parts.length >= 3 ? parts.slice(2).join('-') : '';
+        if (!eventId && eObj.getAttribute) {
+            eventId = eObj.getAttribute('data-eid') || '';
+        }
+        if (!eventId) {
+            return false;
+        }
+        var editing_group = $(eObj).hasClass("groups");
+        if (editing_group) {
+            oldGroupEvt(eventDate, eventId, pccattype);
             return true;
         }
-        oldEvt(parts[0], parts[1], parts[2]);
+        oldEvt(eventDate, eventId, pccattype);
         return true;
     }
 
@@ -254,6 +273,7 @@
 </script>
 
 <style>
+<<<<<<< HEAD
     #bigCal td#times,
     #bigCal td.calendar-times-col {
         box-sizing: border-box;
@@ -296,6 +316,38 @@
         opacity: 0.75;
         text-decoration: none;
         user-select: none;
+=======
+    /* IN body fill stays under appointments and does not capture clicks so
+       open hours remain creatable. The in_start label is the edit target. */
+    #bigCal .calendar_day .event_in {
+        pointer-events: none;
+        z-index: 1;
+    }
+    /* OUT/IN-label above the create-slot marker (z-index 0), below appointments. */
+    #bigCal .calendar_day .event_out {
+        cursor: pointer;
+        pointer-events: auto;
+        z-index: 2;
+    }
+    #bigCal .calendar_day .in_start {
+        cursor: pointer;
+        pointer-events: auto;
+        z-index: 2;
+    }
+    #bigCal .calendar_day .event_appointment,
+    #bigCal .calendar_day .event_reserved,
+    #bigCal .calendar_day .event_noshow,
+    #bigCal .calendar_day .event_holiday {
+        cursor: pointer;
+        z-index: 3;
+    }
+    #bigCal .calendar_day a.apptMarker {
+        z-index: 0;
+    }
+    #bigCal .calendar_day .event_out.event_highlight,
+    #bigCal .calendar_day .in_start.event_highlight {
+        z-index: 4;
+>>>>>>> 0865c30b96 (fix(calendar): allow double-click edit of IN/OUT/LUNCH events)
     }
 </style>
 


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Double-clicking IN, OUT, or LUNCH (provider-status) blocks on the calendar day/week views now reliably opens the event editor.

Fixes #13805

#### Changes proposed in this pull request:

- Select `b.pc_cattype` and set `pccattype` to `'true'` for provider categories so edit opens with `prov=true`
- Remove the `event` class from the create-slot appt marker and keep it under real events (`z-index: 0`)
- Hide the create marker when the cursor is over a real editable event so double-click is not intercepted
- Bind dblclick/highlight only to `.event:not(.apptMarker)` and harden `EditEvent` id/`data-eid` parsing
- Raise OUT / `in_start` stacking and pointer cursor so those blocks remain clickable
- Update Twig screen fixtures

#### Was an AI assistant used? Yes / No

Yes

<!-- warp-managed-pr-artifacts
### References
- [Warp conversation](https://app.warp.dev/conversation/bf996c7e-ce5e-4b49-ba15-ebb043f164b1)
- [Plan: Upstream Skok calendar fixes](https://app.warp.dev/drive/notebook/d9fCCH7Kj3CqmF45jY0NHL)
-->