### PR TITLE
fix(calendar): block time-column create on holiday/closed days

### DIFF
--- a/library/js/calendarDirectSelect.js
+++ b/library/js/calendarDirectSelect.js
@@ -38,6 +38,12 @@ function updateApptTime(marker, index, y, date, provider) {
 }
 
 function displayApptTime(evt) {
+    // Holidays / clinic-closed days block new appointments the same way
+    // full-column holiday overlays do on the provider schedule.
+    if ($(this).hasClass("schedule-holiday") || $(this).attr("data-holiday") === "1") {
+        $(this).find("a.apptMarker").hide();
+        return;
+    }
     let marker = $(this).find("a.apptMarker");
     if (marker.length == 0) {
         style = "style='height:" + tsHeight + ";'";

--- a/src/PostCalendar/ViewModel/CalendarRenderDataBuilder.php
+++ b/src/PostCalendar/ViewModel/CalendarRenderDataBuilder.php
@@ -829,6 +829,11 @@ final readonly class CalendarRenderDataBuilder
             ? substr($eventDate, 0, 4) . substr($eventDate, 5, 2) . substr($eventDate, 8, 2)
             : '';
 
+        // Clinic-wide holiday (catid 6) or closed (catid 7) blocks new appointments
+        // in provider columns via full-height event overlays. Surface the same
+        // flag so the time gutter can refuse newEvt / direct-select create.
+        $isHolidayDay = $this->dayHasHolidayOrClosed($aEvents[$eventDate] ?? []);
+
         $providersGrid = [];
         foreach ($providers as $provider) {
             $providerIdRaw = $provider['id'] ?? null;
@@ -897,6 +902,8 @@ final readonly class CalendarRenderDataBuilder
             'selectedUsernames'       => $selectedUsernames,
             'timeRows'                => $timeRows,
             'timeslotCss'             => $timeslotCss,
+            'timeslotHeightVal'       => $timeslotHeightVal,
+            'isHolidayDay'            => $isHolidayDay,
             'providers'               => $providersGrid,
             'webroot'                 => $webroot,
         ];
@@ -967,6 +974,19 @@ final readonly class CalendarRenderDataBuilder
         $timeslotCss = $timeslotHeightVal . $timeslotHeightUnit;
         $timeRows = $this->buildTimeRows($times, $isTwelveHourFormat);
 
+        // Week time gutter uses the focused Date for newEvt(); block when that day is a holiday.
+        $focusDateKey = null;
+        foreach (array_keys($aEvents) as $columnDate) {
+            $columnYmd = substr($columnDate, 0, 4) . substr($columnDate, 5, 2) . substr($columnDate, 8, 2);
+            if ($columnYmd === $dateYmd) {
+                $focusDateKey = $columnDate;
+                break;
+            }
+        }
+        $isHolidayDay = $focusDateKey !== null
+            ? $this->dayHasHolidayOrClosed($aEvents[$focusDateKey] ?? [])
+            : false;
+
         $providersGrid = [];
         foreach ($providers as $provider) {
             $providerIdRaw = $provider['id'] ?? null;
@@ -1019,6 +1039,7 @@ final readonly class CalendarRenderDataBuilder
                     'dayHeaderLabel'  => date('D m/d', $columnTs),
                     'classForWeekend' => $isWeekend ? 'weekend-day' : 'work-day',
                     'isCurrentDay'    => $columnYmd === $dateYmd,
+                    'isHolidayDay'    => $this->dayHasHolidayOrClosed($dateEvents),
                     'events'          => $columnEvents,
                 ];
             }
@@ -1057,6 +1078,8 @@ final readonly class CalendarRenderDataBuilder
             'selectedUsernames'       => $selectedUsernames,
             'timeRows'                => $timeRows,
             'timeslotCss'             => $timeslotCss,
+            'timeslotHeightVal'       => $timeslotHeightVal,
+            'isHolidayDay'            => $isHolidayDay,
             'providers'               => $providersGrid,
             'webroot'                 => $webroot,
         ];
@@ -1509,6 +1532,26 @@ final readonly class CalendarRenderDataBuilder
         }
 
         return $event;
+    }
+
+    /**
+     * True when the day carries a clinic holiday (catid 6) or closed (catid 7)
+     * event. Those categories paint full-column overlays that block creating
+     * appointments on provider schedules; the time gutter needs the same signal.
+     *
+     * @param  list<array<string, mixed>> $events
+     */
+    private function dayHasHolidayOrClosed(array $events): bool
+    {
+        foreach ($events as $event) {
+            $catidRaw = $event['catid'] ?? 0;
+            $catid = is_int($catidRaw) || is_string($catidRaw) ? (int) $catidRaw : 0;
+            if ($catid === 6 || $catid === 7) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/templates/calendar/default/views/_calendar_screen_js.html.twig
+++ b/templates/calendar/default/views/_calendar_screen_js.html.twig
@@ -20,6 +20,16 @@
  }
 
  function newEvt(startampm, starttimeh, starttimem, eventdate, providerid, catid) {
+  // Guard: holiday / clinic-closed days must not open create dialog from the time gutter.
+  var holidayDate = String(eventdate || '');
+  var $holidayCell = $('#bigCal td.schedule[data-holiday="1"][date="' + holidayDate + '"]');
+  if (!$holidayCell.length && typeof pcIsHolidayDay !== 'undefined' && pcIsHolidayDay) {
+    // Day view: single Date applies to the whole grid.
+    $holidayCell = $('#bigCal td.schedule.schedule-holiday');
+  }
+  if ($holidayCell.length) {
+    return false;
+  }
   dlgopen('add_edit_event.php?startampm=' + encodeURIComponent(startampm) +
    '&starttimeh=' + encodeURIComponent(starttimeh) + '&userid=' + encodeURIComponent(providerid) + '&starttimem=' + encodeURIComponent(starttimem) +
    '&date=' + encodeURIComponent(eventdate) + '&catid=' + encodeURIComponent(catid)
@@ -74,6 +84,7 @@
        each value is escaped exactly once for its sink. #}
     var tsHeight={{ timeslotCss|default('20px')|js_escape }};
     var tsHeightNum={{ timeslotHeightVal|default(20) }};
+    var pcIsHolidayDay = {{ isHolidayDay|default(false) ? 'true' : 'false' }};
     var pcWebroot={{ webroot|js_escape }};
     var pcViewtype={{ viewtype|default('day')|js_escape }};
     var pcDate={{ Date|default('')|js_escape }};
@@ -158,3 +169,15 @@
         $("#wrapper").toggleClass("toggled");
     });
 </script>
+
+<style>
+    /* Time gutter on holidays: show labels but do not offer new-appointment links. */
+    #bigCal td.timeslot.timeslot-holiday .timeslot-holiday-label {
+        color: var(--gray600, #6c757d);
+        cursor: not-allowed;
+        display: block;
+        opacity: 0.75;
+        text-decoration: none;
+        user-select: none;
+    }
+</style>

--- a/templates/calendar/default/views/day/ajax_template.html.twig
+++ b/templates/calendar/default/views/day/ajax_template.html.twig
@@ -157,10 +157,16 @@
                             <tr><td class="timeslot providerXbtn" data-username="__PC_ALL__"><i class="fa fa-lg fa-user-md"></i></td></tr>
                             {% for slot in timeRows %}
                                 <tr>
-                                    <td class="timeslot">
-                                        <a href="javascript:newEvt({{ slot.startampm|attr_js }},{{ slot.hour|attr_js }},{{ slot.minute|attr_js }},{{ Date|attr_js }},0,0)" title="{{ 'New Appointment'|xla }}" alt="{{ 'New Appointment'|xla }}">
-                                            {{ slot.displayLabel|text }}
-                                        </a>
+                                    <td class="timeslot{% if isHolidayDay %} timeslot-holiday{% endif %}">
+                                        {% if isHolidayDay %}
+                                            <span class="timeslot-label timeslot-holiday-label" title="{{ 'Clinic closed for holiday — new appointments are blocked'|xla }}">
+                                                {{ slot.displayLabel|text }}
+                                            </span>
+                                        {% else %}
+                                            <a href="javascript:newEvt({{ slot.startampm|attr_js }},{{ slot.hour|attr_js }},{{ slot.minute|attr_js }},{{ Date|attr_js }},0,0)" title="{{ 'New Appointment'|xla }}" alt="{{ 'New Appointment'|xla }}">
+                                                {{ slot.displayLabel|text }}
+                                            </a>
+                                        {% endif %}
                                     </td>
                                 </tr>
                             {% endfor %}
@@ -169,7 +175,7 @@
                 </td>
 
                 {% for provider in providers %}
-                    <td class="schedule {{ provider.classForWeekend|attr }}" title="{{ provider.fname|attr }} {{ provider.lname|attr }}" date="{{ Date|attr }}" provider="{{ provider.id|attr }}">
+                    <td class="schedule {{ provider.classForWeekend|attr }}{% if isHolidayDay %} schedule-holiday{% endif %}" title="{{ provider.fname|attr }} {{ provider.lname|attr }}" date="{{ Date|attr }}" provider="{{ provider.id|attr }}"{% if isHolidayDay %} data-holiday="1"{% endif %}>
                         <div class="providerheader providerday">
                             {{ provider.fname|text }} {{ provider.lname|text }}
                             <a class="providerXbtn userClose" data-username="{{ provider.username|attr }}"></a>

--- a/templates/calendar/default/views/week/ajax_template.html.twig
+++ b/templates/calendar/default/views/week/ajax_template.html.twig
@@ -184,10 +184,16 @@
                             <tr><td class="timeslot providerXbtn" data-username="__PC_ALL__"><i class="fa fa-lg fa-user-md"></i></td></tr>
                             {% for slot in timeRows %}
                                 <tr>
-                                    <td class="timeslot">
-                                        <a href="javascript:newEvt({{ slot.startampm|attr_js }},{{ slot.hour|attr_js }},{{ slot.minute|attr_js }},{{ Date|attr_js }},0,0)" title="{{ 'New Appointment'|xla }}" alt="{{ 'New Appointment'|xla }}">
-                                            {{ slot.displayLabel|text }}
-                                        </a>
+                                    <td class="timeslot{% if isHolidayDay %} timeslot-holiday{% endif %}">
+                                        {% if isHolidayDay %}
+                                            <span class="timeslot-label timeslot-holiday-label" title="{{ 'Clinic closed for holiday — new appointments are blocked'|xla }}">
+                                                {{ slot.displayLabel|text }}
+                                            </span>
+                                        {% else %}
+                                            <a href="javascript:newEvt({{ slot.startampm|attr_js }},{{ slot.hour|attr_js }},{{ slot.minute|attr_js }},{{ Date|attr_js }},0,0)" title="{{ 'New Appointment'|xla }}" alt="{{ 'New Appointment'|xla }}">
+                                                {{ slot.displayLabel|text }}
+                                            </a>
+                                        {% endif %}
                                     </td>
                                 </tr>
                             {% endfor %}
@@ -197,7 +203,8 @@
 
                 {% for column in provider.dayColumns %}
                     {% set columnClass = 'schedule ' ~ column.classForWeekend %}
-                    <td class="{{ columnClass|attr }}" date="{{ column.dateYmd|attr }}" provider="{{ provider.id|attr }}">
+                    {% if column.isHolidayDay %}{% set columnClass = columnClass ~ ' schedule-holiday' %}{% endif %}
+                    <td class="{{ columnClass|attr }}" date="{{ column.dateYmd|attr }}" provider="{{ provider.id|attr }}"{% if column.isHolidayDay %} data-holiday="1"{% endif %}>
                         <div class="calendar_day">
                             {% for event in column.events %}
                                 {% if event.catid == 2 %}

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-day-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-day-screen-empty.html
@@ -123,6 +123,16 @@
  }
 
  function newEvt(startampm, starttimeh, starttimem, eventdate, providerid, catid) {
+  // Guard: holiday / clinic-closed days must not open create dialog from the time gutter.
+  var holidayDate = String(eventdate || '');
+  var $holidayCell = $('#bigCal td.schedule[data-holiday="1"][date="' + holidayDate + '"]');
+  if (!$holidayCell.length && typeof pcIsHolidayDay !== 'undefined' && pcIsHolidayDay) {
+    // Day view: single Date applies to the whole grid.
+    $holidayCell = $('#bigCal td.schedule.schedule-holiday');
+  }
+  if ($holidayCell.length) {
+    return false;
+  }
   dlgopen('add_edit_event.php?startampm=' + encodeURIComponent(startampm) +
    '&starttimeh=' + encodeURIComponent(starttimeh) + '&userid=' + encodeURIComponent(providerid) + '&starttimem=' + encodeURIComponent(starttimem) +
    '&date=' + encodeURIComponent(eventdate) + '&catid=' + encodeURIComponent(catid)
@@ -171,6 +181,7 @@
 <script>
         var tsHeight="20px";
     var tsHeightNum=20;
+    var pcIsHolidayDay = false;
     var pcWebroot="";
     var pcViewtype="day";
     var pcDate="20260315";
@@ -255,6 +266,18 @@
         $("#wrapper").toggleClass("toggled");
     });
 </script>
+
+<style>
+    /* Time gutter on holidays: show labels but do not offer new-appointment links. */
+    #bigCal td.timeslot.timeslot-holiday .timeslot-holiday-label {
+        color: var(--gray600, #6c757d);
+        cursor: not-allowed;
+        display: block;
+        opacity: 0.75;
+        text-decoration: none;
+        user-select: none;
+    }
+</style>
 
 <script>
     $(function () { if (typeof setupDirectTime === 'function') { setupDirectTime(); } });

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-month-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-month-screen-empty.html
@@ -112,6 +112,16 @@
  }
 
  function newEvt(startampm, starttimeh, starttimem, eventdate, providerid, catid) {
+  // Guard: holiday / clinic-closed days must not open create dialog from the time gutter.
+  var holidayDate = String(eventdate || '');
+  var $holidayCell = $('#bigCal td.schedule[data-holiday="1"][date="' + holidayDate + '"]');
+  if (!$holidayCell.length && typeof pcIsHolidayDay !== 'undefined' && pcIsHolidayDay) {
+    // Day view: single Date applies to the whole grid.
+    $holidayCell = $('#bigCal td.schedule.schedule-holiday');
+  }
+  if ($holidayCell.length) {
+    return false;
+  }
   dlgopen('add_edit_event.php?startampm=' + encodeURIComponent(startampm) +
    '&starttimeh=' + encodeURIComponent(starttimeh) + '&userid=' + encodeURIComponent(providerid) + '&starttimem=' + encodeURIComponent(starttimem) +
    '&date=' + encodeURIComponent(eventdate) + '&catid=' + encodeURIComponent(catid)
@@ -160,6 +170,7 @@
 <script>
         var tsHeight="20px";
     var tsHeightNum=20;
+    var pcIsHolidayDay = false;
     var pcWebroot="";
     var pcViewtype="month";
     var pcDate="20260315";
@@ -244,3 +255,15 @@
         $("#wrapper").toggleClass("toggled");
     });
 </script>
+
+<style>
+    /* Time gutter on holidays: show labels but do not offer new-appointment links. */
+    #bigCal td.timeslot.timeslot-holiday .timeslot-holiday-label {
+        color: var(--gray600, #6c757d);
+        cursor: not-allowed;
+        display: block;
+        opacity: 0.75;
+        text-decoration: none;
+        user-select: none;
+    }
+</style>

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-week-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-week-screen-empty.html
@@ -109,6 +109,16 @@
  }
 
  function newEvt(startampm, starttimeh, starttimem, eventdate, providerid, catid) {
+  // Guard: holiday / clinic-closed days must not open create dialog from the time gutter.
+  var holidayDate = String(eventdate || '');
+  var $holidayCell = $('#bigCal td.schedule[data-holiday="1"][date="' + holidayDate + '"]');
+  if (!$holidayCell.length && typeof pcIsHolidayDay !== 'undefined' && pcIsHolidayDay) {
+    // Day view: single Date applies to the whole grid.
+    $holidayCell = $('#bigCal td.schedule.schedule-holiday');
+  }
+  if ($holidayCell.length) {
+    return false;
+  }
   dlgopen('add_edit_event.php?startampm=' + encodeURIComponent(startampm) +
    '&starttimeh=' + encodeURIComponent(starttimeh) + '&userid=' + encodeURIComponent(providerid) + '&starttimem=' + encodeURIComponent(starttimem) +
    '&date=' + encodeURIComponent(eventdate) + '&catid=' + encodeURIComponent(catid)
@@ -157,6 +167,7 @@
 <script>
         var tsHeight="20px";
     var tsHeightNum=20;
+    var pcIsHolidayDay = false;
     var pcWebroot="";
     var pcViewtype="week";
     var pcDate="20260315";
@@ -241,6 +252,18 @@
         $("#wrapper").toggleClass("toggled");
     });
 </script>
+
+<style>
+    /* Time gutter on holidays: show labels but do not offer new-appointment links. */
+    #bigCal td.timeslot.timeslot-holiday .timeslot-holiday-label {
+        color: var(--gray600, #6c757d);
+        cursor: not-allowed;
+        display: block;
+        opacity: 0.75;
+        text-decoration: none;
+        user-select: none;
+    }
+</style>
 
 <script>
     $(function () { if (typeof setupDirectTime === 'function') { setupDirectTime(); } });

--- a/tests/Tests/Isolated/PostCalendar/ViewModel/CalendarRenderDataBuilderTest.php
+++ b/tests/Tests/Isolated/PostCalendar/ViewModel/CalendarRenderDataBuilderTest.php
@@ -523,4 +523,191 @@ final class CalendarRenderDataBuilderTest extends TestCase
 
         self::assertSame([], $result['providers']);
     }
+
+    /**
+     * Holiday/closed markers (catid 6/7) must surface as isHolidayDay so the
+     * time gutter can refuse newEvt / direct-select create. Use aid that does
+     * not match the provider so decorate* skips the event (avoids DB-backed
+     * dateformat() in addI18nDateDecoration) while dayHasHolidayOrClosed still
+     * sees the category on the day's event list.
+     *
+     * @param  list<array<string, mixed>> $dayEvents
+     * @return array<string, mixed>
+     */
+    private function buildDayScreenWithEvents(array $dayEvents): array
+    {
+        $builder = $this->builder(ViewType::Day);
+
+        /** @var array<string, list<array<string, mixed>>> $aEvents */
+        $aEvents = ['2026-03-15' => $dayEvents];
+
+        return $builder->buildDayScreenRenderData(
+            $aEvents,
+            [$this->makeProvider()],
+            [$this->makeProvider()],
+            [['id' => 1, 'name' => 'Main']],
+            $this->makeTimes(),
+            30,
+            '20260315',
+            $this->shortDayNames(),
+            1,
+            0,
+            '/img',
+            '/openemr',
+            '?prev',
+            '?next',
+            'fa-chevron-left',
+            'fa-chevron-right',
+            '<select id="monthPicker"></select>',
+            true,
+            'Sunday, March 15, 2026',
+            true
+        );
+    }
+
+    /**
+     * @param  array<string, list<array<string, mixed>>> $events
+     * @return array<string, mixed>
+     */
+    private function buildWeekScreenWithEvents(array $events, string $dateYmd = '20260315'): array
+    {
+        $builder = $this->builder(ViewType::Week);
+
+        return $builder->buildWeekScreenRenderData(
+            $events,
+            [$this->makeProvider()],
+            [$this->makeProvider()],
+            [['id' => 1, 'name' => 'Main']],
+            $this->makeTimes(),
+            30,
+            $dateYmd,
+            $this->shortDayNames(),
+            1,
+            0,
+            '/img',
+            '/openemr',
+            '?prev',
+            '?next',
+            'fa-chevron-left',
+            'fa-chevron-right',
+            '',
+            true,
+            'Mar 15 - Mar 16 2026',
+            true
+        );
+    }
+
+    /**
+     * @param  array<int|string, mixed> $dayColumns
+     * @return array<int|string, mixed>
+     */
+    private function dayColumnAt(array $dayColumns, int $index): array
+    {
+        self::assertArrayHasKey($index, $dayColumns);
+        $column = $dayColumns[$index];
+        self::assertIsArray($column);
+
+        return $column;
+    }
+
+    public function testBuildDayScreenIsHolidayDayFalseWithoutHolidayOrClosed(): void
+    {
+        $result = $this->buildDayScreenWithEvents([
+            $this->makeEvent(catid: 5, eid: 1, aid: 999),
+        ]);
+
+        self::assertFalse($result['isHolidayDay']);
+        self::assertSame(20, $result['timeslotHeightVal']);
+    }
+
+    public function testBuildDayScreenIsHolidayDayTrueForHolidayCatid6(): void
+    {
+        $result = $this->buildDayScreenWithEvents([
+            $this->makeEvent(catid: 6, eid: 60, aid: 999),
+            $this->makeEvent(catid: 5, eid: 61, aid: 999),
+        ]);
+
+        self::assertTrue($result['isHolidayDay']);
+    }
+
+    public function testBuildDayScreenIsHolidayDayTrueForClosedCatid7(): void
+    {
+        $result = $this->buildDayScreenWithEvents([
+            $this->makeEvent(catid: 7, eid: 70, aid: 999),
+        ]);
+
+        self::assertTrue($result['isHolidayDay']);
+    }
+
+    public function testBuildDayScreenIsHolidayDayTrueWhenCatidIsStringSix(): void
+    {
+        // Production event rows often carry string catids from SQL.
+        $holiday = $this->makeEvent(catid: 6, eid: 66, aid: 999);
+        $holiday['catid'] = '6';
+
+        $result = $this->buildDayScreenWithEvents([$holiday]);
+
+        self::assertTrue($result['isHolidayDay']);
+    }
+
+    public function testBuildDayScreenIsHolidayDayFalseForEmptyDay(): void
+    {
+        $result = $this->buildDayScreenWithEvents([]);
+
+        self::assertFalse($result['isHolidayDay']);
+    }
+
+    public function testBuildWeekScreenIsHolidayDayTrueWhenFocusDateIsHoliday(): void
+    {
+        $result = $this->buildWeekScreenWithEvents([
+            '2026-03-15' => [$this->makeEvent(catid: 6, eid: 1, aid: 999)],
+            '2026-03-16' => [$this->makeEvent(catid: 5, eid: 2, aid: 999)],
+        ], '20260315');
+
+        self::assertTrue($result['isHolidayDay']);
+        self::assertSame(20, $result['timeslotHeightVal']);
+
+        $providers = $this->arrayAt($result, 'providers');
+        self::assertIsArray($providers[0]);
+        $dayColumns = $providers[0]['dayColumns'];
+        self::assertIsArray($dayColumns);
+        self::assertCount(2, $dayColumns);
+
+        $firstColumn = $this->dayColumnAt($dayColumns, 0);
+        $secondColumn = $this->dayColumnAt($dayColumns, 1);
+        self::assertTrue($firstColumn['isHolidayDay']);
+        self::assertFalse($secondColumn['isHolidayDay']);
+    }
+
+    public function testBuildWeekScreenIsHolidayDayFalseWhenFocusDateIsOpen(): void
+    {
+        $result = $this->buildWeekScreenWithEvents([
+            '2026-03-15' => [$this->makeEvent(catid: 5, eid: 1, aid: 999)],
+            '2026-03-16' => [$this->makeEvent(catid: 7, eid: 2, aid: 999)],
+        ], '20260315');
+
+        // Top-level flag follows the focused Date column only.
+        self::assertFalse($result['isHolidayDay']);
+
+        $providers = $this->arrayAt($result, 'providers');
+        self::assertIsArray($providers[0]);
+        $dayColumns = $providers[0]['dayColumns'];
+        self::assertIsArray($dayColumns);
+
+        $firstColumn = $this->dayColumnAt($dayColumns, 0);
+        $secondColumn = $this->dayColumnAt($dayColumns, 1);
+        self::assertFalse($firstColumn['isHolidayDay']);
+        self::assertTrue($secondColumn['isHolidayDay']);
+    }
+
+    public function testBuildWeekScreenIsHolidayDayFalseWhenFocusDateNotInEvents(): void
+    {
+        // Focus Date has no matching column key → gutter stays open.
+        $result = $this->buildWeekScreenWithEvents([
+            '2026-03-16' => [$this->makeEvent(catid: 6, eid: 1, aid: 999)],
+            '2026-03-17' => [],
+        ], '20260315');
+
+        self::assertFalse($result['isHolidayDay']);
+    }
 }


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Block creating appointments from the calendar time column (and direct-select marker) on holiday/closed days, matching the clinic-closed expectation already implied by holiday overlays.

Fixes #13807

#### Changes proposed in this pull request:

- Detect holiday (`catid` 6) / closed (`catid` 7) days in day and week render data (`isHolidayDay`)
- Render time gutter labels without `newEvt` links on holiday days
- Mark provider schedule columns with `schedule-holiday` / `data-holiday=\"1\"`
- Guard `newEvt()` against holiday dates
- Hide the direct-select create marker on holiday columns
- Update Twig screen fixtures

#### Was an AI assistant used? Yes / No

Yes

<!-- warp-managed-pr-artifacts
### References
- [Warp conversation](https://app.warp.dev/conversation/bf996c7e-ce5e-4b49-ba15-ebb043f164b1)
- [Plan: Upstream Skok calendar fixes](https://app.warp.dev/drive/notebook/d9fCCH7Kj3CqmF45jY0NHL)
-->