### PR TITLE
fix(ci): skip rector AddArrowFunctionReturnTypeRector — master rector-check broken

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -14,6 +14,7 @@ use Rector\CodingStyle\Rector\ArrowFunction\ArrowFunctionDelegatingCallToFirstCl
 use Rector\CodingStyle\Rector\FuncCall\CallUserFuncArrayToVariadicRector;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector;
 use Rector\ValueObject\PhpVersion;
 
 return RectorConfig::configure()
@@ -67,6 +68,19 @@ return RectorConfig::configure()
         // under config/.
         ArrowFunctionDelegatingCallToFirstClassCallableRector::class => [
             __DIR__ . '/config',
+        ],
+        // Rector infers `: int` return types on the two arrow functions in
+        // ObservationController::saveObservation that walk untyped `mixed`
+        // sub-observation arrays: `fn($sub) => $sub['id'] ?? 0`. Adding the
+        // return type would then force the body to also be int-typed, but
+        // the postData / form arrays lack shape typing — so satisfying the
+        // new signature would require a `(int)` cast, which
+        // phpstan-strict-rules `cast.int` forbids ("Cannot cast mixed to
+        // int"). Skip only these sites until ObservationService returns
+        // array-shape-typed sub-observations. Other arrow functions in the
+        // tree should still get inferred return types where safe.
+        AddArrowFunctionReturnTypeRector::class => [
+            __DIR__ . '/src/Controllers/Interface/Forms/Observation/ObservationController.php',
         ],
     ])
     ->withCache(


### PR DESCRIPTION
## Summary

Master's Rector PHP Analysis has been failing since the rector 2.6.4 merge (`f7c9e1b6e0`, PR #13798). Root cause is version-skew between two PRs that landed close together:

- **#13797** bumped phpstan 2.2.9 → 2.2.12 and merged first
- **#13798** bumped rector 2.5.9 → 2.6.4 and applied autofixes with the phpstan 2.2.9 composer.lock

Rector uses phpstan for type inference. Master's rector-check now runs against phpstan 2.2.12, which is more precise than the 2.2.9 the #13798 autofix pass saw — so it unlocks `AddArrowFunctionReturnTypeRector` on call sites where the older phpstan couldn't be certain about the inferred return type.

## The two sites

Both in `src/Controllers/Interface/Forms/Observation/ObservationController.php` (lines 307, 337) — identical arrow functions:

```php
fn($sub) => $sub['id'] ?? 0
```

Rector wants `fn($sub): int => $sub['id'] ?? 0`.

## Why we can't just apply rector's suggestion

Applying `: int` alone triggers phpstan-strict-rules `return.type` — the body `$sub['id'] ?? 0` narrows to `mixed` because `$sub` is an untyped element of `$observation['sub_observations']` (a postData-shaped `array<mixed>`).

Satisfying the new return type would need one of:

- `(int) $sub['id']` — blocked by phpstan-strict-rules `cast.int` ("Cannot cast mixed to int")
- An `is_int` narrow — filters out numeric-string form values these arrows actually walk

Neither is a real improvement over the current bare signature.

## Resolution

Scope `AddArrowFunctionReturnTypeRector` to skip **only ObservationController.php** in rector.php's `withSkip()`, using the rule-to-path form Rector 2.6.4 supports and openemr already uses for `ArrowFunctionDelegatingCallToFirstClassCallableRector` above. The rule stays active for the rest of the tree — any future arrow function elsewhere where phpstan can confidently infer a return type will still get one auto-added.

Updated per CodeRabbit review — narrow scope is more honest and idiomatic than the initial global skip.

## Un-skip path

Once `ObservationService` returns array-shape-typed sub-observations (e.g. `array{id: int, ...}` on `getObservationById` / `getNewObservationTemplate`), `$sub` will no longer be `mixed`, the arrows will type-infer honestly, and rector's rule can apply cleanly. At that point removing the path entry + running `composer rector-fix` will work end-to-end. The comment in rector.php notes this as the un-skip condition.

## Test plan

- [x] `composer rector-check` clean on ObservationController.php at HEAD
- [x] Pre-commit hook suite passes
- [ ] CI rector job green