### PR TITLE
feat(changefeed): add drop-in change feed module for incremental resource sync

### DIFF
--- a/interface/modules/custom_modules/oe-module-changefeed/ModuleManagerListener.php
+++ b/interface/modules/custom_modules/oe-module-changefeed/ModuleManagerListener.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * Module Manager lifecycle listener for the Change Feed module.
+ *
+ * The changefeed_log table is created by the install SQL; the change-capture
+ * triggers are (re)installed on enable and dropped on disable/reset, because
+ * CREATE TRIGGER cannot be run through the #If* SQL install parser.
+ *
+ * @package   OpenEMR Modules
+ * @link      https://www.open-emr.org
+ * @author    Ahmed Armaan <arman.ahmaed@carer.ai>
+ * @copyright Copyright (c) 2026 Ahmed Armaan
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Core\AbstractModuleActionListener;
+use OpenEMR\Modules\ChangeFeed\TriggerManager;
+
+class ModuleManagerListener extends AbstractModuleActionListener
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * @param string $methodName
+     * @param string $modId
+     * @param string $currentActionStatus
+     * @return string On success return the action status, otherwise an error string.
+     */
+    public function moduleManagerAction($methodName, $modId, string $currentActionStatus = 'Success'): string
+    {
+        if (method_exists(self::class, $methodName)) {
+            return self::$methodName($modId, $currentActionStatus);
+        }
+
+        return $currentActionStatus;
+    }
+
+    public static function getModuleNamespace(): string
+    {
+        return 'OpenEMR\\Modules\\ChangeFeed\\';
+    }
+
+    public static function initListenerSelf(): ModuleManagerListener
+    {
+        return new self();
+    }
+
+    /**
+     * @param string $modId
+     * @param string $currentActionStatus
+     */
+    private function install($modId, $currentActionStatus): mixed
+    {
+        // Show the config/enable UI before the module is enabled. Triggers are
+        // installed on enable (the log table exists by then).
+        self::setModuleState($modId, '0', '1');
+
+        return $currentActionStatus;
+    }
+
+    /**
+     * @param string $modId
+     * @param string $currentActionStatus
+     */
+    private function enable($modId, $currentActionStatus): mixed
+    {
+        self::setModuleState($modId, '1', '0');
+
+        try {
+            (new TriggerManager())->install();
+        } catch (\Throwable $e) {
+            error_log('ChangeFeed: failed to install change-capture triggers: ' . $e->getMessage());
+            return xl('Change Feed could not install its change-capture triggers; see the server error log.');
+        }
+
+        return $currentActionStatus;
+    }
+
+    /**
+     * @param string $modId
+     * @param string $currentActionStatus
+     */
+    private function disable($modId, $currentActionStatus): mixed
+    {
+        // Keep the config UI available after disable.
+        self::setModuleState($modId, '0', '1');
+
+        try {
+            (new TriggerManager())->uninstall();
+        } catch (\Throwable $e) {
+            error_log('ChangeFeed: failed to drop change-capture triggers: ' . $e->getMessage());
+        }
+
+        return $currentActionStatus;
+    }
+
+    /**
+     * @param string $modId
+     * @param string $currentActionStatus
+     */
+    private function unregister($modId, $currentActionStatus): mixed
+    {
+        return $currentActionStatus;
+    }
+
+    /**
+     * Full teardown: drop the triggers first, then the log table (order matters
+     * - a trigger referencing a dropped table would break writes to the watched
+     * table).
+     *
+     * @param string $modId
+     * @param string $currentActionStatus
+     */
+    private function reset_module($modId, $currentActionStatus): mixed
+    {
+        try {
+            (new TriggerManager())->uninstall();
+            QueryUtils::sqlStatementThrowException(
+                'DROP TABLE IF EXISTS `' . TriggerManager::LOG_TABLE . '`'
+            );
+        } catch (\Throwable $e) {
+            error_log('ChangeFeed: reset failed: ' . $e->getMessage());
+            return xl('Change Feed reset encountered an error; see the server error log.');
+        }
+
+        return $currentActionStatus;
+    }
+
+    /**
+     * @param int|string $modId
+     * @param int|string $flag
+     * @param int|string $flagUi
+     */
+    private static function setModuleState(int|string $modId, int|string $flag, int|string $flagUi): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'UPDATE `modules` SET `mod_active` = ?, `mod_ui_active` = ? WHERE `mod_id` = ? OR `mod_directory` = ?',
+            [$flag, $flagUi, $modId, $modId]
+        );
+    }
+}

--- a/interface/modules/custom_modules/oe-module-changefeed/Readme.md
+++ b/interface/modules/custom_modules/oe-module-changefeed/Readme.md
@@ -1,0 +1,96 @@
+# Change Feed module for OpenEMR
+
+Adds an incremental **change feed** to OpenEMR: ask "what clinical-core rows
+changed since cursor X?" and get back a list of FHIR resource references
+(including deletions), so an integrator can sync incrementally instead of
+repeatedly full-scan polling every resource.
+
+Drop-in module — no core changes. Change capture is done with database triggers,
+so it records **every** write to a watched table, including direct SQL and
+soft-deletes, not just writes that go through the application layer.
+
+## Install
+
+1. Copy `oe-module-changefeed/` into
+   `interface/modules/custom_modules/`.
+2. In OpenEMR: **Modules → Manage Modules**, register/install the module, then
+   **Enable** it.
+   - Install creates the `changefeed_log` table.
+   - Enable installs the capture triggers (this is why enable, not just install,
+     is required).
+   - Disable drops the triggers; the log table is left in place until the module
+     is reset/removed.
+
+The database user OpenEMR connects as needs the MySQL `TRIGGER` privilege
+(standard on the bundled/dev stack).
+
+## Endpoint
+
+```
+GET /api/changefeed?_since=<cursor>&_limit=<n>
+```
+
+- `_since` — cursor from your last poll (default `0` = from the beginning).
+- `_limit` — max changes to return (default `100`, max `1000`).
+
+Requires the same authorization as viewing patient demographics
+(`patients` / `demo`) and a valid API session/token.
+
+### Response
+
+```json
+{
+  "since": 0,
+  "cursor": 1240,
+  "watermark": 1240,
+  "count": 2,
+  "changes": [
+    { "resourceType": "Patient",   "id": "9c2…-uuid", "operation": "update", "cursor": 1239, "changedAt": "2026-09-02 10:15:03" },
+    { "resourceType": "Encounter", "id": "4a1…-uuid", "operation": "delete", "cursor": 1240, "changedAt": "2026-09-02 10:15:07" }
+  ]
+}
+```
+
+Persist `cursor` and pass it as `_since` on the next poll. For `insert`/`update`,
+fetch the current resource via the normal FHIR API (e.g.
+`GET /fhir/Patient/<id>`); `delete` means the resource is gone.
+
+## Watched tables
+
+Out of the box:
+
+| Table | FHIR resource |
+|-------|---------------|
+| `patient_data` | `Patient` |
+| `form_encounter` | `Encounter` |
+
+Extend the set in `TriggerManager::defaultWatched()` — add a `WatchedResource`
+with the table, FHIR resource type, primary-key column, uuid column, and
+(for soft-delete tables) the activity column that going to `0` means "deleted".
+Re-enable the module to (re)install triggers.
+
+## How it works
+
+- One `AFTER INSERT/UPDATE/DELETE` trigger per watched table writes a row into
+  `changefeed_log` (`resource_table`, `resource_type`, `row_pk`, `row_uuid`,
+  `op`, `changed_at`). Each trigger body is a single `INSERT`, so no `DELIMITER`
+  handling is needed.
+- The endpoint serves rows with `id` in `(_since, watermark]`, oldest first.
+
+## Known limitations
+
+- **Watermark lag.** To avoid skipping a change whose auto-increment id becomes
+  visible only after a later id, the feed only serves rows at least a couple of
+  seconds old. A change is therefore visible to consumers up to ~2s after it
+  commits.
+- **uuid at insert time.** If a row is created before its uuid is assigned, the
+  `insert` change may carry no uuid; the feed resolves it from the source row
+  (for insert/update) or, failing that, skips the entry — a later `update`
+  carrying the uuid still reports it. A `delete` with no captured uuid cannot be
+  resolved and is skipped.
+- **Single consumer.** The cursor is a client-side value; there is no per-consumer
+  acknowledgement. `ChangeFeedRepository::pruneUpTo()` can trim acknowledged rows
+  if you run a single consumer.
+- **Mapping scope.** Only the watched tables that map cleanly 1:1 to a FHIR
+  resource are included. Polymorphic tables (e.g. `lists`) are intentionally out
+  of scope for now.

--- a/interface/modules/custom_modules/oe-module-changefeed/info.txt
+++ b/interface/modules/custom_modules/oe-module-changefeed/info.txt
@@ -1,0 +1,1 @@
+Change Feed v1.0.0

--- a/interface/modules/custom_modules/oe-module-changefeed/moduleConfig.php
+++ b/interface/modules/custom_modules/oe-module-changefeed/moduleConfig.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Change Feed module information.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Ahmed Armaan <arman.ahmaed@carer.ai>
+ * @copyright Copyright (c) 2026 Ahmed Armaan
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+return [
+    'name' => 'Change Feed',
+    'description' => 'Adds a resource change feed: serve the clinical-core rows (patient_data, form_encounter) that changed since a cursor - including deletions - through a REST endpoint that returns FHIR resource references, so integrators can sync incrementally instead of full-scan polling.',
+    'version' => '1.0.0',
+    'author' => 'Ahmed Armaan',
+    'email' => 'arman.ahmaed@carer.ai',
+    'license' => 'GPL-3.0',
+    'acl_category' => 'admin',
+    'acl_section' => 'users',
+
+    // Module dependencies
+    'require' => [
+        'openemr' => '>=7.0.0',
+    ],
+
+    // Database tables created by this module
+    'tables' => [
+        'changefeed_log',
+    ],
+
+    // Installation hooks. The changefeed_log table is created here; the
+    // change-capture triggers are installed from ModuleManagerListener on
+    // enable, because CREATE TRIGGER cannot be expressed through the #If* SQL
+    // install parser.
+    'install' => [
+        'sql' => 'sql/install.sql',
+    ],
+
+    // Uninstallation hooks
+    'uninstall' => [
+        'sql' => 'sql/uninstall.sql',
+    ],
+];

--- a/interface/modules/custom_modules/oe-module-changefeed/openemr.bootstrap.php
+++ b/interface/modules/custom_modules/oe-module-changefeed/openemr.bootstrap.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Change Feed module bootstrap.
+ *
+ * Registers the module PSR-4 namespace and wires the Bootstrap class into the
+ * OpenEMR event dispatcher so the change-feed REST route is added to the API.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Ahmed Armaan <arman.ahmaed@carer.ai>
+ * @copyright Copyright (c) 2026 Ahmed Armaan
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+use OpenEMR\Core\ModulesClassLoader;
+use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Modules\ChangeFeed\Bootstrap;
+
+$file = OEGlobalsBag::getInstance()->getProjectDir();
+$classLoader = new ModulesClassLoader($file);
+$classLoader->registerNamespaceIfNotExists(
+    'OpenEMR\\Modules\\ChangeFeed\\',
+    __DIR__ . DIRECTORY_SEPARATOR . 'src'
+);
+
+$eventDispatcher = OEGlobalsBag::getInstance()->getKernel()->getEventDispatcher();
+$bootstrap = new Bootstrap($eventDispatcher);
+$bootstrap->subscribeToEvents();

--- a/interface/modules/custom_modules/oe-module-changefeed/sql/install.sql
+++ b/interface/modules/custom_modules/oe-module-changefeed/sql/install.sql
@@ -1,0 +1,27 @@
+--
+-- Change Feed module - install SQL
+--
+-- Creates the changefeed_log table. The per-table change-capture triggers are
+-- installed separately from ModuleManagerListener (on module enable) because
+-- CREATE TRIGGER cannot be expressed through this #If* install parser.
+--
+-- @package   OpenEMR
+-- @link      https://www.open-emr.org
+-- @author    Ahmed Armaan <arman.ahmaed@carer.ai>
+-- @copyright Copyright (c) 2026 Ahmed Armaan
+-- @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+--
+
+#IfNotTable changefeed_log
+CREATE TABLE IF NOT EXISTS `changefeed_log` (
+    `id` BIGINT(20) NOT NULL AUTO_INCREMENT COMMENT 'Monotonic change cursor',
+    `resource_table` VARCHAR(64) NOT NULL COMMENT 'Source table that changed',
+    `resource_type` VARCHAR(64) NOT NULL COMMENT 'FHIR resourceType the row maps to',
+    `row_pk` VARCHAR(64) NOT NULL COMMENT 'Primary/business key value of the changed row',
+    `row_uuid` VARCHAR(32) DEFAULT NULL COMMENT 'Hex uuid of the row when available (delete-safe id)',
+    `op` ENUM('insert','update','delete') NOT NULL COMMENT 'Change operation',
+    `changed_at` DATETIME NOT NULL COMMENT 'Transaction time the change was recorded',
+    PRIMARY KEY (`id`),
+    KEY `idx_changed_at` (`changed_at`)
+) ENGINE=InnoDB COMMENT='Change Feed - one row per observed clinical-core change';
+#EndIf

--- a/interface/modules/custom_modules/oe-module-changefeed/sql/uninstall.sql
+++ b/interface/modules/custom_modules/oe-module-changefeed/sql/uninstall.sql
@@ -1,0 +1,16 @@
+--
+-- Change Feed module - uninstall SQL
+--
+-- The change-capture triggers are dropped by ModuleManagerListener (on disable
+-- and reset) BEFORE this table is dropped. Dropping changefeed_log while its
+-- triggers still reference it would break writes to the watched tables, so the
+-- ordering matters: disable the module (drops triggers) before removing it.
+--
+-- @package   OpenEMR
+-- @link      https://www.open-emr.org
+-- @author    Ahmed Armaan <arman.ahmaed@carer.ai>
+-- @copyright Copyright (c) 2026 Ahmed Armaan
+-- @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+--
+
+DROP TABLE IF EXISTS `changefeed_log`;

--- a/interface/modules/custom_modules/oe-module-changefeed/src/Bootstrap.php
+++ b/interface/modules/custom_modules/oe-module-changefeed/src/Bootstrap.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Change Feed module bootstrap - registers the REST route.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Ahmed Armaan <arman.ahmaed@carer.ai>
+ * @copyright Copyright (c) 2026 Ahmed Armaan
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\ChangeFeed;
+
+use OpenEMR\Common\Http\HttpRestRequest;
+use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Events\RestApiExtend\RestApiCreateEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class Bootstrap
+{
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher
+    ) {
+    }
+
+    public function subscribeToEvents(): void
+    {
+        $this->eventDispatcher->addListener(
+            RestApiCreateEvent::EVENT_HANDLE,
+            $this->addRestRoutes(...)
+        );
+    }
+
+    public function addRestRoutes(RestApiCreateEvent $event): void
+    {
+        $event->addToRouteMap(
+            'GET /api/changefeed',
+            fn(HttpRestRequest $request, OEGlobalsBag $globalsBag): array =>
+                (new ChangeFeedRestController())->getChanges($request, $globalsBag)
+        );
+    }
+}

--- a/interface/modules/custom_modules/oe-module-changefeed/src/ChangeFeedRepository.php
+++ b/interface/modules/custom_modules/oe-module-changefeed/src/ChangeFeedRepository.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Reads from (and prunes) the changefeed_log table.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Ahmed Armaan <arman.ahmaed@carer.ai>
+ * @copyright Copyright (c) 2026 Ahmed Armaan
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\ChangeFeed;
+
+use OpenEMR\Common\Database\QueryUtils;
+
+final class ChangeFeedRepository
+{
+    /**
+     * Highest cursor safe to serve. Rows are excluded until they are at least
+     * $lagSeconds old, which lets in-flight transactions commit before their
+     * auto-increment id is handed out - closing the window where a consumer
+     * could advance past an id that had not yet become visible. A change is
+     * therefore visible to consumers up to $lagSeconds after it commits.
+     */
+    public function watermark(int $lagSeconds): int
+    {
+        $value = QueryUtils::fetchSingleValue(
+            'SELECT COALESCE(MAX(`id`), 0) AS wm FROM `' . TriggerManager::LOG_TABLE . '` '
+            . 'WHERE `changed_at` <= (NOW() - INTERVAL ? SECOND)',
+            'wm',
+            [$lagSeconds]
+        );
+
+        return (int) $value;
+    }
+
+    /**
+     * Change rows with id in ($sinceCursor, $watermark], oldest first.
+     *
+     * @return list<array<string, ?string>>
+     */
+    public function readSince(int $sinceCursor, int $watermark, int $limit): array
+    {
+        $limit = max(1, $limit);
+        $rows = QueryUtils::fetchRecords(
+            'SELECT `id`, `resource_table`, `resource_type`, `row_pk`, `row_uuid`, `op`, `changed_at` '
+            . 'FROM `' . TriggerManager::LOG_TABLE . '` '
+            . 'WHERE `id` > ? AND `id` <= ? '
+            . 'ORDER BY `id` ASC '
+            . 'LIMIT ' . $limit,
+            [$sinceCursor, $watermark]
+        );
+
+        return array_values($rows);
+    }
+
+    /**
+     * Delete acknowledged rows at or below $cursor to keep the log bounded.
+     */
+    public function pruneUpTo(int $cursor): void
+    {
+        QueryUtils::sqlStatementThrowException(
+            'DELETE FROM `' . TriggerManager::LOG_TABLE . '` WHERE `id` <= ?',
+            [$cursor]
+        );
+    }
+}

--- a/interface/modules/custom_modules/oe-module-changefeed/src/ChangeFeedRestController.php
+++ b/interface/modules/custom_modules/oe-module-changefeed/src/ChangeFeedRestController.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * REST controller for GET /api/changefeed.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Ahmed Armaan <arman.ahmaed@carer.ai>
+ * @copyright Copyright (c) 2026 Ahmed Armaan
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\ChangeFeed;
+
+use OpenEMR\Common\Http\HttpRestRequest;
+use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\RestControllers\Config\RestConfig;
+
+class ChangeFeedRestController
+{
+    public function __construct(
+        private readonly ChangeFeedService $service = new ChangeFeedService()
+    ) {
+    }
+
+    /**
+     * Serve the changes after ?_since=<cursor> (default 0), at most ?_limit=<n>
+     * (default 100, max 1000). The returned array is JSON-encoded by the REST
+     * view subscriber.
+     *
+     * @return array{
+     *     since: int,
+     *     cursor: int,
+     *     watermark: int,
+     *     count: int,
+     *     changes: list<array{resourceType: string, id: string, operation: string, cursor: int, changedAt: string}>
+     * }
+     */
+    public function getChanges(HttpRestRequest $request, OEGlobalsBag $globalsBag): array
+    {
+        // The feed exposes patient and encounter changes; gate it on the same
+        // ACL as viewing patient demographics.
+        RestConfig::request_authorization_check($request, 'patients', 'demo');
+
+        $since = max(0, (int) $request->getQueryParam('_since'));
+
+        $limitParam = $request->getQueryParam('_limit');
+        $limit = is_numeric($limitParam) ? (int) $limitParam : null;
+
+        return $this->service->getChanges($since, $limit);
+    }
+}

--- a/interface/modules/custom_modules/oe-module-changefeed/src/ChangeFeedService.php
+++ b/interface/modules/custom_modules/oe-module-changefeed/src/ChangeFeedService.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * Turns raw changefeed_log rows into a page of FHIR resource references.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Ahmed Armaan <arman.ahmaed@carer.ai>
+ * @copyright Copyright (c) 2026 Ahmed Armaan
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\ChangeFeed;
+
+use DomainException;
+use OpenEMR\Common\Database\QueryUtils;
+
+final class ChangeFeedService
+{
+    private const WATERMARK_LAG_SECONDS = 2;
+    private const DEFAULT_LIMIT = 100;
+    private const MAX_LIMIT = 1000;
+
+    /** @var array<string, WatchedResource> keyed by source table name */
+    private array $watchedByTable;
+
+    public function __construct(
+        private readonly ChangeFeedRepository $repository = new ChangeFeedRepository(),
+        ?TriggerManager $triggerManager = null,
+    ) {
+        $manager = $triggerManager ?? new TriggerManager();
+        $this->watchedByTable = [];
+        foreach ($manager->watchedResources() as $resource) {
+            $this->watchedByTable[$resource->table] = $resource;
+        }
+    }
+
+    /**
+     * @return array{
+     *     since: int,
+     *     cursor: int,
+     *     watermark: int,
+     *     count: int,
+     *     changes: list<array{resourceType: string, id: string, operation: string, cursor: int, changedAt: string}>
+     * }
+     */
+    public function getChanges(int $since, ?int $limit = null): array
+    {
+        if ($since < 0) {
+            throw new DomainException('since cursor must be >= 0');
+        }
+
+        $limit = $this->clampLimit($limit);
+        $watermark = $this->repository->watermark(self::WATERMARK_LAG_SECONDS);
+
+        if ($watermark <= $since) {
+            return $this->page($since, $since, $watermark, []);
+        }
+
+        $rows = $this->repository->readSince($since, $watermark, $limit);
+
+        $changes = [];
+        $cursor = $since;
+        foreach ($rows as $row) {
+            // Advance the cursor for every row read, even ones we cannot map to
+            // a FHIR reference - otherwise an unmappable row would be re-served
+            // forever and the feed would never progress.
+            $cursor = (int) ($row['id'] ?? $cursor);
+            $entry = $this->mapRow($row);
+            if ($entry !== null) {
+                $changes[] = $entry;
+            }
+        }
+
+        return $this->page($since, $cursor, $watermark, $changes);
+    }
+
+    /**
+     * @param array<string, ?string> $row
+     * @return array{resourceType: string, id: string, operation: string, cursor: int, changedAt: string}|null
+     */
+    private function mapRow(array $row): ?array
+    {
+        $uuid = $this->resolveUuid($row);
+        if ($uuid === null) {
+            return null;
+        }
+
+        return [
+            'resourceType' => (string) $row['resource_type'],
+            'id' => $uuid,
+            'operation' => ChangeOperation::from((string) $row['op'])->value,
+            'cursor' => (int) $row['id'],
+            'changedAt' => (string) $row['changed_at'],
+        ];
+    }
+
+    /**
+     * The FHIR logical id (canonical uuid) for a change row. Prefer the uuid the
+     * trigger captured; if it was null at capture time (a row created before its
+     * uuid was assigned), resolve it from the still-present source row. Deletes
+     * cannot be resolved this way, so a delete with no captured uuid is skipped.
+     *
+     * @param array<string, ?string> $row
+     */
+    private function resolveUuid(array $row): ?string
+    {
+        $captured = $row['row_uuid'] ?? null;
+        if (is_string($captured) && $captured !== '') {
+            return Uuid::fromHex($captured);
+        }
+
+        if (($row['op'] ?? null) === ChangeOperation::Delete->value) {
+            return null;
+        }
+
+        $watched = $this->watchedByTable[(string) ($row['resource_table'] ?? '')] ?? null;
+        if ($watched === null) {
+            return null;
+        }
+
+        $hex = QueryUtils::fetchSingleValue(
+            sprintf(
+                'SELECT HEX(`%s`) AS u FROM `%s` WHERE `%s` = ?',
+                $watched->uuidColumn,
+                $watched->table,
+                $watched->primaryKeyColumn
+            ),
+            'u',
+            [$row['row_pk']]
+        );
+
+        return is_string($hex) && $hex !== '' ? Uuid::fromHex($hex) : null;
+    }
+
+    private function clampLimit(?int $limit): int
+    {
+        if ($limit === null || $limit <= 0) {
+            return self::DEFAULT_LIMIT;
+        }
+
+        return min(self::MAX_LIMIT, $limit);
+    }
+
+    /**
+     * @param list<array{resourceType: string, id: string, operation: string, cursor: int, changedAt: string}> $changes
+     * @return array{since: int, cursor: int, watermark: int, count: int, changes: list<array{resourceType: string, id: string, operation: string, cursor: int, changedAt: string}>}
+     */
+    private function page(int $since, int $cursor, int $watermark, array $changes): array
+    {
+        return [
+            'since' => $since,
+            'cursor' => $cursor,
+            'watermark' => $watermark,
+            'count' => count($changes),
+            'changes' => $changes,
+        ];
+    }
+}

--- a/interface/modules/custom_modules/oe-module-changefeed/src/ChangeOperation.php
+++ b/interface/modules/custom_modules/oe-module-changefeed/src/ChangeOperation.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Change operation captured by the feed.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Ahmed Armaan <arman.ahmaed@carer.ai>
+ * @copyright Copyright (c) 2026 Ahmed Armaan
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\ChangeFeed;
+
+enum ChangeOperation: string
+{
+    case Insert = 'insert';
+    case Update = 'update';
+    case Delete = 'delete';
+}

--- a/interface/modules/custom_modules/oe-module-changefeed/src/TriggerManager.php
+++ b/interface/modules/custom_modules/oe-module-changefeed/src/TriggerManager.php
@@ -1,0 +1,208 @@
+<?php
+
+/**
+ * Builds and installs the per-table change-capture triggers.
+ *
+ * One AFTER INSERT / UPDATE / DELETE trigger per watched table, each writing a
+ * single row into changefeed_log. The bodies are single-statement INSERTs (no
+ * BEGIN...END), so they need no DELIMITER handling and install as one statement
+ * each - which is why they are issued here rather than through the SQL install
+ * parser (which splits on ';').
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Ahmed Armaan <arman.ahmaed@carer.ai>
+ * @copyright Copyright (c) 2026 Ahmed Armaan
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\ChangeFeed;
+
+use OpenEMR\Common\Database\QueryUtils;
+use RuntimeException;
+
+final class TriggerManager
+{
+    public const LOG_TABLE = 'changefeed_log';
+
+    private const TRIGGER_PREFIX = 'cf_';
+
+    /** @var array<string, string> SQL event => trigger-name suffix */
+    private const EVENTS = [
+        'INSERT' => 'ai',
+        'UPDATE' => 'au',
+        'DELETE' => 'ad',
+    ];
+
+    /** @var list<WatchedResource> */
+    private array $watched;
+
+    /**
+     * @param list<WatchedResource>|null $watched
+     */
+    public function __construct(?array $watched = null)
+    {
+        $this->watched = $watched ?? self::defaultWatched();
+    }
+
+    /**
+     * The clinical-core tables the feed watches out of the box. Both map 1:1 to
+     * a FHIR resource and carry a uuid column; both are hard-delete tables (no
+     * activity/soft-delete column), so no softDeleteColumn is set.
+     *
+     * @return list<WatchedResource>
+     */
+    public static function defaultWatched(): array
+    {
+        return [
+            new WatchedResource('patient_data', 'Patient', 'pid', 'uuid'),
+            new WatchedResource('form_encounter', 'Encounter', 'id', 'uuid'),
+        ];
+    }
+
+    /**
+     * @return list<WatchedResource>
+     */
+    public function watchedResources(): array
+    {
+        return $this->watched;
+    }
+
+    /**
+     * Install every trigger (dropping any pre-existing one first so re-enabling
+     * the module is idempotent).
+     */
+    public function install(): void
+    {
+        $this->assertLogTableExists();
+        foreach ($this->statements() as $statement) {
+            QueryUtils::sqlStatementThrowException($statement);
+        }
+    }
+
+    /**
+     * Drop every trigger this module owns. Safe to run repeatedly.
+     */
+    public function uninstall(): void
+    {
+        foreach ($this->dropStatements() as $statement) {
+            QueryUtils::sqlStatementThrowException($statement);
+        }
+    }
+
+    /**
+     * Ordered DROP-then-CREATE statements for every watched table. Pure - no
+     * database access - so it can be asserted in a unit test.
+     *
+     * @return list<string>
+     */
+    public function statements(): array
+    {
+        $statements = [];
+        foreach ($this->watched as $resource) {
+            foreach (self::EVENTS as $event => $suffix) {
+                $statements[] = $this->dropStatement($resource, $suffix);
+                $statements[] = $this->createStatement($resource, $event, $suffix);
+            }
+        }
+
+        return $statements;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function dropStatements(): array
+    {
+        $statements = [];
+        foreach ($this->watched as $resource) {
+            foreach (self::EVENTS as $suffix) {
+                $statements[] = $this->dropStatement($resource, $suffix);
+            }
+        }
+
+        return $statements;
+    }
+
+    private function triggerName(WatchedResource $resource, string $suffix): string
+    {
+        return self::TRIGGER_PREFIX . $resource->table . '_' . $suffix;
+    }
+
+    private function dropStatement(WatchedResource $resource, string $suffix): string
+    {
+        return 'DROP TRIGGER IF EXISTS `' . $this->triggerName($resource, $suffix) . '`';
+    }
+
+    private function createStatement(WatchedResource $resource, string $event, string $suffix): string
+    {
+        $rowRef = $event === 'DELETE' ? 'OLD' : 'NEW';
+        $name = $this->triggerName($resource, $suffix);
+        $pkExpr = sprintf('CAST(%s.`%s` AS CHAR)', $rowRef, $resource->primaryKeyColumn);
+        $uuidExpr = sprintf('LOWER(HEX(%s.`%s`))', $rowRef, $resource->uuidColumn);
+        $opExpr = $this->operationExpression($resource, $event);
+
+        return sprintf(
+            'CREATE TRIGGER `%s` AFTER %s ON `%s` FOR EACH ROW '
+            . 'INSERT INTO `%s` '
+            . '(`resource_table`, `resource_type`, `row_pk`, `row_uuid`, `op`, `changed_at`) '
+            . "VALUES ('%s', '%s', %s, %s, %s, NOW())",
+            $name,
+            $event,
+            $resource->table,
+            self::LOG_TABLE,
+            $resource->table,
+            $resource->fhirResourceType,
+            $pkExpr,
+            $uuidExpr,
+            $opExpr
+        );
+    }
+
+    /**
+     * The op value written by a trigger. INSERT/DELETE are fixed; UPDATE is
+     * normally 'update', but for a soft-delete table a transition of the
+     * activity column to 0 is recorded as a delete.
+     */
+    private function operationExpression(WatchedResource $resource, string $event): string
+    {
+        if ($event === 'INSERT') {
+            return "'" . ChangeOperation::Insert->value . "'";
+        }
+        if ($event === 'DELETE') {
+            return "'" . ChangeOperation::Delete->value . "'";
+        }
+
+        // UPDATE
+        if ($resource->softDeleteColumn === null) {
+            return "'" . ChangeOperation::Update->value . "'";
+        }
+
+        return sprintf(
+            "IF(NEW.`%s` = 0 AND (OLD.`%s` IS NULL OR OLD.`%s` <> 0), '%s', '%s')",
+            $resource->softDeleteColumn,
+            $resource->softDeleteColumn,
+            $resource->softDeleteColumn,
+            ChangeOperation::Delete->value,
+            ChangeOperation::Update->value
+        );
+    }
+
+    private function assertLogTableExists(): void
+    {
+        $count = QueryUtils::fetchSingleValue(
+            'SELECT COUNT(*) AS c FROM information_schema.tables '
+            . 'WHERE table_schema = DATABASE() AND table_name = ?',
+            'c',
+            [self::LOG_TABLE]
+        );
+
+        if ((int) $count === 0) {
+            throw new RuntimeException(
+                'changefeed_log table is missing; install the Change Feed module before enabling it.'
+            );
+        }
+    }
+}

--- a/interface/modules/custom_modules/oe-module-changefeed/src/Uuid.php
+++ b/interface/modules/custom_modules/oe-module-changefeed/src/Uuid.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Formats a 32-character hex uuid (as stored by the capture triggers) into the
+ * canonical dashed form used as a FHIR resource logical id.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Ahmed Armaan <arman.ahmaed@carer.ai>
+ * @copyright Copyright (c) 2026 Ahmed Armaan
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\ChangeFeed;
+
+final class Uuid
+{
+    /**
+     * Convert a 32-char hex string to canonical 8-4-4-4-12 form, or null if the
+     * input is not exactly 32 hex characters.
+     */
+    public static function fromHex(string $hex): ?string
+    {
+        $hex = strtolower($hex);
+        if (preg_match('/^[0-9a-f]{32}$/', $hex) !== 1) {
+            return null;
+        }
+
+        return sprintf(
+            '%s-%s-%s-%s-%s',
+            substr($hex, 0, 8),
+            substr($hex, 8, 4),
+            substr($hex, 12, 4),
+            substr($hex, 16, 4),
+            substr($hex, 20, 12)
+        );
+    }
+}

--- a/interface/modules/custom_modules/oe-module-changefeed/src/WatchedResource.php
+++ b/interface/modules/custom_modules/oe-module-changefeed/src/WatchedResource.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * A table the change feed watches, and how its rows map to a FHIR resource.
+ *
+ * Column and table names are validated on construction because they are
+ * interpolated into CREATE TRIGGER / lookup DDL, which cannot be parameterized.
+ * The watched set is defined in code (see TriggerManager::defaultWatched), never
+ * from user input, but the guard keeps that guarantee explicit.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Ahmed Armaan <arman.ahmaed@carer.ai>
+ * @copyright Copyright (c) 2026 Ahmed Armaan
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Modules\ChangeFeed;
+
+use DomainException;
+
+final readonly class WatchedResource
+{
+    public function __construct(
+        public string $table,
+        public string $fhirResourceType,
+        public string $primaryKeyColumn,
+        public string $uuidColumn,
+        public ?string $softDeleteColumn = null,
+    ) {
+        self::assertIdentifier('table', $table);
+        self::assertIdentifier('fhirResourceType', $fhirResourceType);
+        self::assertIdentifier('primaryKeyColumn', $primaryKeyColumn);
+        self::assertIdentifier('uuidColumn', $uuidColumn);
+        if ($softDeleteColumn !== null) {
+            self::assertIdentifier('softDeleteColumn', $softDeleteColumn);
+        }
+    }
+
+    private static function assertIdentifier(string $label, string $value): void
+    {
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $value) !== 1) {
+            throw new DomainException(sprintf('Invalid SQL identifier for %s: "%s"', $label, $value));
+        }
+    }
+}

--- a/interface/modules/custom_modules/oe-module-changefeed/version.php
+++ b/interface/modules/custom_modules/oe-module-changefeed/version.php
@@ -1,0 +1,7 @@
+<?php
+
+$v_major = '1';
+$v_minor = '0';
+$v_patch = '0';
+$v_tag   = '';
+$v_database = 0;


### PR DESCRIPTION
<!--
PR title: feat(changefeed): add drop-in change feed module for incremental resource sync
Trim sections to fit the target repo's template. The AI-assistant section is
required by OpenEMR's PR template.
-->

## Short description

Adds **`oe-module-changefeed`**, a self-contained module that gives OpenEMR an
incremental **change feed** — "which clinical-core rows changed since cursor
X?", including deletions — so integrators can sync incrementally instead of
full-scan polling. **No core changes**; lives entirely under
`interface/modules/custom_modules/oe-module-changefeed/`.

## Motivation

OpenEMR's REST/FHIR APIs expose current state but have no "changed since"
primitive, so a consumer must periodically re-scan and diff each resource type.
That is expensive and — critically — **cannot observe deletions** (a re-scan only
sees a record is gone by its absence). This module supplies the missing
primitive: a cursor a consumer persists, and a feed of `(resource, id, op)` since
that cursor, deletions included.

Capture is done with **database triggers**, deliberately: PHP event hooks miss
direct-SQL writes, and `_lastUpdated` can't represent a delete (and OpenEMR has no
uniform modified-timestamp column). Triggers capture insert/update/**delete** at
the DB layer, including direct SQL.

## Components

- `changefeed_log` — append-only change table; `id` is the monotonic cursor.
- `TriggerManager` — builds/installs/drops the capture triggers; owns the watched set.
- `WatchedResource` — validated table → FHIR type / PK / uuid / optional soft-delete column.
- `ChangeFeedRepository` — log reads (watermark, `readSince`, `pruneUpTo`).
- `ChangeFeedService` — maps rows → FHIR references, resolves uuids, paginates.
- `ChangeFeedRestController` + `Bootstrap` — the `GET /api/changefeed` route (registered via `RestApiCreateEvent`).
- `ModuleManagerListener` — install/enable/disable/reset lifecycle.

## Data model

```sql
CREATE TABLE `changefeed_log` (
    `id`             BIGINT(20)  NOT NULL AUTO_INCREMENT,          -- monotonic cursor
    `resource_table` VARCHAR(64) NOT NULL,
    `resource_type`  VARCHAR(64) NOT NULL,                         -- FHIR resourceType
    `row_pk`         VARCHAR(64) NOT NULL,                         -- always present
    `row_uuid`       VARCHAR(32) DEFAULT NULL,                     -- FHIR id, when assigned (delete-safe)
    `op`             ENUM('insert','update','delete') NOT NULL,
    `changed_at`     DATETIME    NOT NULL,
    PRIMARY KEY (`id`),
    KEY `idx_changed_at` (`changed_at`)
) ENGINE=InnoDB;
```

## Change capture (triggers)

One `AFTER INSERT/UPDATE/DELETE` trigger per watched table. Each body is a
**single `INSERT`** (no `BEGIN…END`), so no `DELIMITER` handling is needed — which
is why they are installed from `ModuleManagerListener` (the `#If*` SQL install
parser splits on `;` and can't express a multi-statement trigger):

```sql
CREATE TRIGGER `cf_patient_data_ai` AFTER INSERT ON `patient_data` FOR EACH ROW
INSERT INTO `changefeed_log`
  (`resource_table`, `resource_type`, `row_pk`, `row_uuid`, `op`, `changed_at`)
VALUES ('patient_data', 'Patient', CAST(NEW.`pid` AS CHAR),
        LOWER(HEX(NEW.`uuid`)), 'insert', NOW());
```

Both identifiers are captured — `row_pk` (always) and `row_uuid` (when assigned) —
so a **delete** stays resolvable via `OLD.uuid` after the row is gone. For
soft-delete tables the UPDATE trigger records a delete when the activity column
goes to 0; the two default tables (`patient_data`, `form_encounter`) are
hard-delete.

## Cursor and watermark

`changefeed_log.id` is the cursor. Auto-increment ids are assigned at statement
time but rows are visible only at commit, so a naive `WHERE id > :cursor` can
advance past an id that committed late and skip it. The feed therefore serves only
up to a **watermark** trailing the newest rows:

```sql
SELECT COALESCE(MAX(id), 0) FROM changefeed_log
WHERE changed_at <= (NOW() - INTERVAL :lag SECOND);   -- lag defaults to 2s
```

Reads are bounded `WHERE id > :since AND id <= :watermark ORDER BY id`. Tradeoff:
a change is visible up to ~`lag` seconds after commit; `lag` should exceed the
longest write transaction on a watched table (sub-second for normal writes).

**FHIR id resolution:** captured uuid → format to canonical; if null on
insert/update → look up from the source row; if null on a delete → skip the entry
but still advance the cursor.

## Endpoint

```
GET /api/changefeed?_since=<cursor>&_limit=<n>     # _since default 0, _limit default 100 (max 1000)
```

Gated on the patient-demographics ACL plus the standard API OAuth2 token. Returns
FHIR resource references (not resource bodies):

```json
{
  "since": 0, "cursor": 3, "watermark": 3, "count": 3,
  "changes": [
    { "resourceType": "Patient", "id": "<uuid>", "operation": "insert", "cursor": 1, "changedAt": "…" },
    { "resourceType": "Patient", "id": "<uuid>", "operation": "update", "cursor": 2, "changedAt": "…" },
    { "resourceType": "Patient", "id": "<uuid>", "operation": "delete", "cursor": 3, "changedAt": "…" }
  ]
}
```

Persist `cursor`, pass as `_since` next poll. For insert/update, fetch via the
normal FHIR API; `delete` means it's gone.

## Lifecycle & safety

Install creates the table; **enable** installs the triggers (idempotent
drop-then-create, so the table exists first); disable drops the triggers; reset
drops triggers **then** the table (order matters). Table/column names reaching
trigger DDL come only from the in-code watched set and are validated against
`^[A-Za-z_][A-Za-z0-9_]*$`; all values use parameterized `QueryUtils` queries.
Extend the watched set via `TriggerManager::defaultWatched()`, then re-enable.

## Testing performed

Verified on `development-easy` (MariaDB 12):

- PSR-12 / PHPStan level 10 / Rector — all clean.
- Enable creates all 6 triggers (`cf_{patient_data,form_encounter}_{ai,au,ad}`).
- insert → update → delete captured as three rows, monotonic cursor, each with a
  resolvable `row_uuid` — including the delete (carries `OLD.uuid`):

  ```
  | id | resource_table | resource_type | row_pk | row_uuid                         | op     |
  |  1 | patient_data   | Patient       | 999    | 9fa640e5a6b111f19847e63b9d82b97f | insert |
  |  2 | patient_data   | Patient       | 999    | 9fa640e5a6b111f19847e63b9d82b97f | update |
  |  3 | patient_data   | Patient       | 999    | 9fa640e5a6b111f19847e63b9d82b97f | delete |
  ```
- Rows above were produced by **raw SQL** (not the UI) — no application-layer blind spot.
- Watermark query returns the expected cursor; `GET /api/changefeed` registered
  and auth-enforced (401 without a token).

## Known limitations / out of scope

- ~2s watermark lag; uuid may be null if a row is created before its uuid is
  assigned (resolved from source for insert/update, skipped for such deletes).
- Single consumer (client-side cursor; `pruneUpTo()` assumes one consumer).
- Only tables mapping 1:1 to a FHIR resource; polymorphic tables (e.g. `lists`) out of scope.
- Not FHIR Subscriptions / `_history`; returns references, not resource bodies.
- Watched set and watermark lag are code constants (future: configurable globals).

## Compatibility

PHP 8.2+; MySQL/MariaDB with the `TRIGGER` privilege for OpenEMR's DB user.

## Was an AI assistant used? Yes

Claude Code (Anthropic) assisted in authoring this module. Each commit carries an
`Assisted-by: Claude Code` trailer.
