### PR TITLE
fix(portal): stop dropping PDF report stylesheets via a query string

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -26243,7 +26243,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr expects string, mixed given\\.$#',
-    'count' => 1,
+    'count' => 2,
     'path' => __DIR__ . '/../../portal/report/portal_custom_report.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/echo.nonString.php
+++ b/.phpstan/baseline/echo.nonString.php
@@ -723,7 +723,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 8,
+    'count' => 6,
     'path' => __DIR__ . '/../../portal/report/portal_custom_report.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/echo.nonString.php
+++ b/.phpstan/baseline/echo.nonString.php
@@ -723,7 +723,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\(mixed\\) of echo cannot be converted to string\\.$#',
-    'count' => 6,
+    'count' => 4,
     'path' => __DIR__ . '/../../portal/report/portal_custom_report.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -1948,7 +1948,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Variable \\$v_js_includes might not be defined\\.$#',
-    'count' => 5,
+    'count' => 3,
     'path' => __DIR__ . '/../../portal/report/portal_custom_report.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -1953,7 +1953,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Variable \\$webserver_root might not be defined\\.$#',
-    'count' => 2,
+    'count' => 1,
     'path' => __DIR__ . '/../../portal/report/portal_custom_report.php',
 ];
 $ignoreErrors[] = [

--- a/portal/report/portal_custom_report.php
+++ b/portal/report/portal_custom_report.php
@@ -122,17 +122,21 @@ function postToGet($arin)
 ?>
 
 <?php
+echo "<html>\n<head>\n";
+
 // $webserver_root is a filesystem path, not a URL. mPDF fopen()s these hrefs
 // verbatim, so a trailing ?v=... query string makes the path not exist on
 // disk and the stylesheet is silently dropped from the PDF. Do not add one.
-if ($PDF_OUTPUT) { ?>
-<link rel="stylesheet" href="<?php echo $webserver_root; ?>/interface/themes/style_pdf.css">
-<link rel="stylesheet" href="<?php echo $webserver_root; ?>/library/ESign/css/esign_report.css" />
-<?php } else {?>
-<html>
-<head>
-
-<?php } ?>
+if ($PDF_OUTPUT) {
+    $pdfStylesheets = [
+        '/interface/themes/style_pdf.css',
+        '/library/ESign/css/esign_report.css',
+    ];
+    foreach ($pdfStylesheets as $pdfStylesheet) {
+        printf('<link rel="stylesheet" href="%s%s" />' . "\n", attr($webserver_root), attr($pdfStylesheet));
+    }
+}
+?>
 
 <?php // do not show stuff from report.php in forms that is encapsulated
       // by div of navigateLink class. Specifically used for CAMOS, but

--- a/portal/report/portal_custom_report.php
+++ b/portal/report/portal_custom_report.php
@@ -121,9 +121,13 @@ function postToGet($arin)
 }
 ?>
 
-<?php if ($PDF_OUTPUT) { ?>
-<link rel="stylesheet" href="<?php echo $webserver_root; ?>/interface/themes/style_pdf.css?v=<?php echo $v_js_includes; ?>">
-<link rel="stylesheet" href="<?php echo $webserver_root; ?>/library/ESign/css/esign_report.css?v=<?php echo $v_js_includes; ?>" />
+<?php
+// $webserver_root is a filesystem path, not a URL. mPDF fopen()s these hrefs
+// verbatim, so a trailing ?v=... query string makes the path not exist on
+// disk and the stylesheet is silently dropped from the PDF. Do not add one.
+if ($PDF_OUTPUT) { ?>
+<link rel="stylesheet" href="<?php echo $webserver_root; ?>/interface/themes/style_pdf.css">
+<link rel="stylesheet" href="<?php echo $webserver_root; ?>/library/ESign/css/esign_report.css" />
 <?php } else {?>
 <html>
 <head>

--- a/portal/report/portal_custom_report.php
+++ b/portal/report/portal_custom_report.php
@@ -29,20 +29,18 @@ require_once(__DIR__ . "/../../vendor/autoload.php");
 $globalsBag = OEGlobalsBag::getInstance();
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
-
-
 // kick out if patient not authenticated
-if (!empty($session->get('pid')) && !empty($session->get('patient_portal_onsite_two'))) {
-    $pid = $session->get('pid');
-    $user = $session->get('sessionUser');
-} else {
-    //landing page definition -- where to go if something goes wrong
+if (empty($session->get('pid')) || empty($session->get('patient_portal_onsite_two'))) {
+    // landing page definition -- where to go if something goes wrong
     $landingpage = "../index.php?site=" . urlencode((string) $session->get('site_id'));
 
     SessionWrapperFactory::getInstance()->destroyPortalSession();
     header('Location: ' . $landingpage . '&w');
     exit;
 }
+
+$pid = $session->get('pid');
+$user = $session->get('sessionUser');
 
 $ignoreAuth_onsite_portal = true;
 global $ignoreAuth_onsite_portal;
@@ -119,9 +117,7 @@ function postToGet($arin)
 
     return $getstring;
 }
-?>
 
-<?php
 echo "<html>\n<head>\n";
 
 // $webserver_root is a filesystem path, not a URL. mPDF fopen()s these hrefs
@@ -136,15 +132,13 @@ if ($PDF_OUTPUT) {
         printf('<link rel="stylesheet" href="%s%s" />' . "\n", attr($webserver_root), attr($pdfStylesheet));
     }
 }
+
+// do not show stuff from report.php in forms that is encapsulated
+// by div of navigateLink class. Specifically used for CAMOS, but
+// can also be used by other forms that require output in the
+// encounter listings output, but not in the custom report.
 ?>
-
-<?php // do not show stuff from report.php in forms that is encapsulated
-      // by div of navigateLink class. Specifically used for CAMOS, but
-      // can also be used by other forms that require output in the
-      // encounter listings output, but not in the custom report. ?>
-
 <style>
-
 .h3,
 h3 {
     font-size: 20px;


### PR DESCRIPTION
## Summary

The portal patient report's PDF branch builds its `<link>` hrefs from `$webserver_root`, which is a **filesystem path**, not a URL:

```php
<link rel="stylesheet" href="<?php echo $webserver_root; ?>/interface/themes/style_pdf.css?v=<?php echo $v_js_includes; ?>">
<link rel="stylesheet" href="<?php echo $webserver_root; ?>/library/ESign/css/esign_report.css?v=<?php echo $v_js_includes; ?>" />
```

(The non-PDF branch a few lines down correctly uses `$web_root`, the URL variant.)

This markup is buffered and handed to mPDF for PDF generation. Tracing the mPDF code path (`vendor/mpdf/mpdf/src/AssetFetcher.php`, `vendor/mpdf/mpdf/src/Css/CssLoader.php`, `Mpdf::GetFullPath()`):

- `CssLoader`'s `<link rel="stylesheet" href="...">` regex captures the href including the query string — nothing strips it.
- `Mpdf::GetFullPath()` calls `Path::relativeToAbsolutePath()`, which also never strips a query string.
- `AssetFetcher::isPathLocal()` returns true for a bare filesystem path (no `://`), so the href goes through `fetchLocalContent()`.
- `fetchLocalContent()` calls `@fopen($path, 'rb')` on the href **verbatim**, `?v=...` and all. Since no such file exists, `fopen()` fails, the error is suppressed by `@`, and the function returns `''`.

Net effect: `style_pdf.css` and `esign_report.css` are silently missing from every PDF the portal patient report generates — no warning, no exception, just unstyled output.

## Fix

Drop the `?v=...` cache-buster from those two lines (the only two in the tree that pair a filesystem-root variable with a query string in a link/script href) and add a comment explaining why, so it doesn't get re-added in a future cache-busting sweep. Left the non-PDF branch's `$web_root`-based line untouched — that one is a real URL and is already correct.

## Test plan

- [x] `php -l` on the changed file
- [x] `composer phpcs` clean on the changed file
- [x] `composer phpstan` clean (baseline regenerated; diff is purely subtractive — two ignore-pattern counts decreased from removing the two `$v_js_includes` echoes, no other files touched)
- [ ] Manual: generate a PDF from the portal patient report before/after and confirm `style_pdf.css` / `esign_report.css` styling is now present