### PR TITLE
fix(assets): append the cache-buster to inline asset includes

### DIFF
--- a/interface/billing/era_payments.php
+++ b/interface/billing/era_payments.php
@@ -429,7 +429,7 @@ if ($confirm_overwrite === 'yes' && $validEraName) {
         </div>
     </div><!-- End of Container Div-->
     <?php $oemr_ui->oeBelowContainerDiv();?>
-    <script src = '<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/library/js/oeUI/oeFileUploads.js'></script>
+    <script src = '<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/library/js/oeUI/oeFileUploads.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>'></script>
 
     <!-- Overwrite Confirmation Modal -->
     <div class="modal fade" id="overwriteConfirmModal" tabindex="-1" role="dialog" aria-labelledby="overwriteConfirmModalLabel" aria-hidden="true" data-backdrop="static" data-keyboard="false">

--- a/interface/billing/new_payment.php
+++ b/interface/billing/new_payment.php
@@ -436,7 +436,7 @@ $payment_id = $payment_id * 1 > 0 ? $payment_id + 0 : $request_payment_id + 0;
         <div class="clearfix">.</div>
     </div><!-- end of container div -->
     <?php $oemr_ui->oeBelowContainerDiv();?>
-<script src = '<?php echo OEGlobalsBag::getInstance()->getString('webroot');?>/library/js/oeUI/oeFileUploads.js'></script>
+<script src = '<?php echo OEGlobalsBag::getInstance()->getString('webroot');?>/library/js/oeUI/oeFileUploads.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>'></script>
 <script>
 $(function () {
     $('select').removeClass('class1 text');

--- a/interface/clickmap/template/general_new.html
+++ b/interface/clickmap/template/general_new.html
@@ -3,8 +3,8 @@
     <head>
     {headerTemplate}
 {/if}
-<script src="{$GLOBALS.webroot}/library/js/clickmap.js"></script>
-<link rel="stylesheet" href="{$form->template_dir}/css/clickmap.css" />
+<script src="{$GLOBALS.webroot}/library/js/clickmap.js?v={assetVersionNumber}"></script>
+<link rel="stylesheet" href="{$form->template_dir}/css/clickmap.css?v={assetVersionNumber}" />
 {if !$reportMode}
 	</head>
 	<body>

--- a/interface/drugs/dispense_drug.php
+++ b/interface/drugs/dispense_drug.php
@@ -203,7 +203,7 @@ sprintf("\n%s %s %s %s\n%s %s %s", xl('Lot'), $row['lot_number'], xl('Exp'), $ro
 
 ?>
 <html>
-    <script src="<?php echo $webroot ?>/interface/main/tabs/js/include_opener.js"></script>
+    <script src="<?php echo $webroot ?>/interface/main/tabs/js/include_opener.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 <head>
 <style>
 body {

--- a/interface/forms/CAMOS/rx_print.php
+++ b/interface/forms/CAMOS/rx_print.php
@@ -19,6 +19,7 @@ require_once('../../globals.php');
 use OpenEMR\Common\Csrf\CsrfUtils;
 use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Core\OEGlobalsBag;
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
@@ -172,7 +173,7 @@ if (filter_input(INPUT_POST, 'print_pdf') || filter_input(INPUT_POST, 'print_htm
 <title>
         <?php echo xlt('CAMOS'); ?>
 </title>
-<link rel="stylesheet" href="./rx.css" />
+<link rel="stylesheet" href="./rx.css?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>" />
 </head>
 <body onload='init()'>
 <img src='./hline.jpg' id='hline'>
@@ -492,7 +493,7 @@ return count_turnoff;
 }
 
 </script>
-<link rel="stylesheet" href="./rx.css" />
+<link rel="stylesheet" href="./rx.css?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>" />
 </head>
 <h1><?php echo xlt('Select CAMOS Entries for Printing'); ?></h1>
 <form method=POST name='pick_items' target=_new>

--- a/interface/forms/eye_mag/SpectacleRx.php
+++ b/interface/forms/eye_mag/SpectacleRx.php
@@ -375,7 +375,7 @@ if ($_REQUEST['dispensed'] ?? '') {
 
         <?php Header::setupHeader(['opener', 'pure', 'jscolor']); ?>
 
-        <link rel="stylesheet" href="../../forms/<?php echo $form_folder; ?>/css/style.css" type="text/css">
+        <link rel="stylesheet" href="../../forms/<?php echo $form_folder; ?>/css/style.css?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>" type="text/css">
 
         <style>
             .title {
@@ -757,7 +757,7 @@ if ($_REQUEST['dispensed'] ?? '') {
 <html>
 <head>
     <?php Header::setupHeader([ 'opener', 'jquery-ui', 'jquery-ui-redmond', 'pure', 'jscolor' ]); ?>
-    <link rel="stylesheet" href="../../forms/<?php echo $form_folder; ?>/css/style.css">
+    <link rel="stylesheet" href="../../forms/<?php echo $form_folder; ?>/css/style.css?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>">
 
     <style>
         .title {

--- a/interface/forms/eye_mag/a_issue.php
+++ b/interface/forms/eye_mag/a_issue.php
@@ -561,7 +561,7 @@ $ROSCOMMENTS   = $rres['ROSCOMMENTS']   ?? '';
 
     <?php Header::setupHeader(['datetime-picker', 'purecss', 'shortcut', 'opener', 'dialog'  ]); ?>
 
-    <link rel="stylesheet" href="<?php echo OEGlobalsBag::getInstance()->getKernel()->getRootDir(); ?>/forms/<?php echo $form_folder; ?>/css/style.css">
+    <link rel="stylesheet" href="<?php echo OEGlobalsBag::getInstance()->getKernel()->getRootDir(); ?>/forms/<?php echo $form_folder; ?>/css/style.css?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>">
     <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/forms/<?php echo $form_folder; ?>/js/eye_base.php?enc=<?php echo attr($encounter); ?>&providerID=<?php echo attr($providerID); ?>"></script>
 </head>
 

--- a/interface/forms/eye_mag/report.php
+++ b/interface/forms/eye_mag/report.php
@@ -307,7 +307,7 @@ function narrative($pid, $encounter, $cols, $form_id, $choice = 'full'): void
     ?>
 
     <?php Header::setupHeader(['no_dialog', 'no_jquery', 'fontawesome']); ?>
-    <link rel="stylesheet" href="../../forms/eye_mag/css/report.css">
+    <link rel="stylesheet" href="../../forms/eye_mag/css/report.css?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>">
     <style>
         <?php if ($PDF_OUTPUT) { ?>
         .mot {

--- a/interface/forms/eye_mag/view.php
+++ b/interface/forms/eye_mag/view.php
@@ -4417,7 +4417,7 @@ if ($refresh !== null && $refresh !== 'fullscreen') {
         menu_overhaul_bottom($pid, $encounter);
     }
     ?>
-  <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/forms/<?php echo $form_folder; ?>/js/jquery-panelslider/jquery.panelslider.min.js"></script>
+  <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/forms/<?php echo $form_folder; ?>/js/jquery-panelslider/jquery.panelslider.min.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
   <script>
         function openNewForm(sel, label) {
             top.restoreSession();
@@ -4544,10 +4544,10 @@ if ($refresh !== null && $refresh !== 'fullscreen') {
 
         var base = '<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>';
     </script>
-    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/forms/<?php echo $form_folder; ?>/js/shorthand_eye.js"></script>
-    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/forms/<?php echo $form_folder; ?>/js/shortcut.js-2-01-B/shortcut.js"></script>
+    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/forms/<?php echo $form_folder; ?>/js/shorthand_eye.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
+    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/forms/<?php echo $form_folder; ?>/js/shortcut.js-2-01-B/shortcut.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
     <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/forms/<?php echo $form_folder; ?>/js/eye_base.php?enc=<?php echo attr($encounter); ?>&providerID=<?php echo attr($provider_id); ?>"></script>
-    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/forms/<?php echo $form_folder; ?>/js/canvasdraw.js"></script>
+    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/interface/forms/<?php echo $form_folder; ?>/js/canvasdraw.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
     <div id="right-panel" name="right-panel" class="panel_side" >
       <div class="text-center" style="margin-top: 10px;">
         <span class="fa fa-file-alt" id="PANEL_TEXT" name="PANEL_TEXT"></span>

--- a/interface/forms/fee_sheet/code_choice/initialize_code_choice.php
+++ b/interface/forms/fee_sheet/code_choice/initialize_code_choice.php
@@ -18,5 +18,5 @@ require_once("templates/code_choices.php");
 $web_root = \OpenEMR\Core\OEGlobalsBag::getInstance()->getWebRoot();
 ?>
 
-<script src="<?php echo $web_root;?>/interface/forms/fee_sheet/code_choice/js/view_model.js"></script>
-<link rel="stylesheet" href="<?php echo $web_root;?>/interface/forms/fee_sheet/code_choice/css/code_choices.css">
+<script src="<?php echo $web_root;?>/interface/forms/fee_sheet/code_choice/js/view_model.js?v=<?php echo attr_url(\OpenEMR\Core\OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
+<link rel="stylesheet" href="<?php echo $web_root;?>/interface/forms/fee_sheet/code_choice/css/code_choices.css?v=<?php echo attr_url(\OpenEMR\Core\OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>">

--- a/interface/forms/fee_sheet/contraception_products/initialize_contraception_products.php
+++ b/interface/forms/fee_sheet/contraception_products/initialize_contraception_products.php
@@ -3,10 +3,11 @@
 require_once("templates/contraception_products.php");
 
 use OpenEMR\Common\Utils\CacheUtils;
+use OpenEMR\Core\OEGlobalsBag;
 
 // Hoist legacy `globals.php` locals so PHPStan can see them (#11792 Phase 5).
 $web_root = \OpenEMR\Core\OEGlobalsBag::getInstance()->getWebRoot();
 ?>
 
 <script type="text/javascript" src='<?php echo CacheUtils::addAssetCacheParamToPath("$web_root/interface/forms/fee_sheet/contraception_products/js/view_model.js"); ?>'></script>
-<link rel="stylesheet" href="<?php echo $web_root;?>/interface/forms/fee_sheet/contraception_products/css/contraception_products.css" type="text/css">
+<link rel="stylesheet" href="<?php echo $web_root;?>/interface/forms/fee_sheet/contraception_products/css/contraception_products.css?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>" type="text/css">

--- a/interface/forms/fee_sheet/review/views/review.php
+++ b/interface/forms/fee_sheet/review/views/review.php
@@ -19,7 +19,7 @@ $web_root = \OpenEMR\Core\OEGlobalsBag::getInstance()->getWebRoot();
 
 ?>
 <script type="text/html" id="review-display">
-    <link rel="stylesheet" href="<?php echo $web_root;?>/interface/forms/fee_sheet/review/views/review.css">
+    <link rel="stylesheet" href="<?php echo $web_root;?>/interface/forms/fee_sheet/review/views/review.css?v=<?php echo attr_url(\OpenEMR\Core\OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>">
     <div data-bind="visible: $data.show">
     <div data-bind="visible: encounters().length==0"><?php echo xlt("No prior encounters."); ?></div>
     <select data-bind="options:encounters, optionsText: 'date', value: selectedEncounter, event: {change: choose_encounter}, visible: encounters().length>0"></select>

--- a/interface/forms/gad7/new.php
+++ b/interface/forms/gad7/new.php
@@ -17,6 +17,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;    // security module
 use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
+use OpenEMR\Core\OEGlobalsBag;
 
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
 ?>
@@ -34,7 +35,7 @@ var changes_made = false;
 </script>
 
 <SCRIPT
-  src="<?php echo $rootdir;?>/forms/gad7/gad7_javasrc.js">
+  src="<?php echo $rootdir;?>/forms/gad7/gad7_javasrc.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>">
  </script>
 
  <script>

--- a/interface/forms/gad7/view.php
+++ b/interface/forms/gad7/view.php
@@ -18,6 +18,7 @@ use OpenEMR\Common\Csrf\CsrfUtils;    // security module
 use OpenEMR\Common\Forms\FormActionBarSettings;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
+use OpenEMR\Core\OEGlobalsBag;
 
 $form_folder = "gad7";
 $session = SessionWrapperFactory::getInstance()->getActiveSession();
@@ -36,7 +37,7 @@ var gad7_score = 0;
 
 </script>
 <SCRIPT
-  src="<?php echo $rootdir;?>/forms/gad7/gad7_javasrc.js">
+  src="<?php echo $rootdir;?>/forms/gad7/gad7_javasrc.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>">
  </script>
 
 <SCRIPT>

--- a/interface/forms/misc_billing_options/save.php
+++ b/interface/forms/misc_billing_options/save.php
@@ -42,7 +42,7 @@ CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
 if ($session->has('billencounter')) {
     $pid = $session->get('billpid');
     $encounter = $session->get('billencounter');
-    echo "<script src='" . $webroot . "/interface/main/tabs/js/include_opener.js'></script>";
+    echo "<script src='" . $webroot . "/interface/main/tabs/js/include_opener.js?v=" . attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')) . "'></script>";
 }
 if (!$encounter) { // comes from globals.php
     die(xlt("Internal error: we do not seem to be in an encounter!"));

--- a/interface/forms/newpatient/templates/newpatient/partials/common/_body-scripts.html.twig
+++ b/interface/forms/newpatient/templates/newpatient/partials/common/_body-scripts.html.twig
@@ -22,10 +22,10 @@
 </script>
 
 {# Load Bootstrap bundle to enable dismissible alerts and other JS components #}
-<script src="{{ webroot }}/public/assets/bootstrap/dist/js/bootstrap.bundle.min.js?v={{ v_js_includes }}"></script>
+<script src="{{ webroot }}/public/assets/bootstrap/dist/js/bootstrap.bundle.min.js?v={{ assetVersion|attr_url }}"></script>
 
 {# TODO: It seems like this should be put in a module for this form #}
 {% if textTemplatesEnabled %}
     {# NOTE this is the Nation Notes integration / implementation to launch the templates when double clicking on the encounter reason textfield #}
-    <script src="{{ webroot }}/library/js/CustomTemplateLoader.js"></script>
+    <script src="{{ webroot }}/library/js/CustomTemplateLoader.js?v={{ assetVersion|attr_url }}"></script>
 {% endif %}

--- a/interface/forms/phq9/common.php
+++ b/interface/forms/phq9/common.php
@@ -58,7 +58,7 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
     </script>
     <?php $qno = 0; ?>
 
-    <script src="<?php echo $rootdir; ?>/forms/phq9/phq9_javasrc.js"></script>
+    <script src="<?php echo $rootdir; ?>/forms/phq9/phq9_javasrc.js?v=<?php echo attr_url(\OpenEMR\Core\OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 
     <script>
         // stuff that uses embedded php must go here, not in the include javascript file -

--- a/interface/forms/track_anything/history.php
+++ b/interface/forms/track_anything/history.php
@@ -83,7 +83,7 @@ echo "<html><head>";
 <title><?php echo xlt('Tracker')?></title>
 
 
-<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="style.css?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>">
 
 <script>
 //-------------- checkboxes checked checker --------------------

--- a/interface/forms/vitals/growthchart/chart.php
+++ b/interface/forms/vitals/growthchart/chart.php
@@ -333,8 +333,8 @@ function cssHeader(): void
     ?>
     <html>
     <head>
-    <link rel="stylesheet" title="page1" href="page1.css">
-    <link rel="stylesheet" title="page2" href="page2.css">
+    <link rel="stylesheet" title="page1" href="page1.css?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>">
+    <link rel="stylesheet" title="page2" href="page2.css?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>">
     <style>
         html {
             padding: 0;

--- a/interface/main/calendar/modules/PostCalendar/common.api.php
+++ b/interface/main/calendar/modules/PostCalendar/common.api.php
@@ -30,6 +30,7 @@
 //  define constants used to make the code more readable
 //=================================================================
 use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Core\OEGlobalsBag;
 
 define('_IS_SUNDAY', 0);
 define('_IS_MONDAY', 1);
@@ -318,6 +319,7 @@ function postcalendar_userapi_loadPopups()
     unset($modinfo);
     $capicon = '';
     $close = _PC_OL_CLOSE;
+    $assetVersion = attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes'));
 
     $output = <<<EOF
 
@@ -356,7 +358,7 @@ ol_hauto = 1;
 ol_vauto = 1;
 </script>
 <div id="overDiv" style="position:absolute; top:0px; left:0px; visibility:hidden; z-index:1000;"></div>
-<script src="modules/$pcDir/pnincludes/overlib_mini.js">
+<script src="modules/$pcDir/pnincludes/overlib_mini.js?v=$assetVersion">
 <!-- overLIB (c) Erik Bosrup -->
 </script>
 

--- a/interface/main/main_screen.php
+++ b/interface/main/main_screen.php
@@ -69,7 +69,7 @@ function generate_html_u2f(): void
 {
     global $appId;
     ?>
-    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/u2f-api.js"></script>
+    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/u2f-api.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
     <script>
         function doAuth() {
             var f = document.getElementById("u2fform");

--- a/interface/main/messages/trusted-messages.php
+++ b/interface/main/messages/trusted-messages.php
@@ -70,7 +70,7 @@ $verifyMessageReceivedChecked = OEGlobalsBag::getInstance()->getBoolean('phimail
 
     echo "<title>" .  xlt('Messages, Reminders, Recalls') . "</title>";
     ?>
-    <script src="js/trusted-messages.js" type="text/javascript"></script>
+    <script src="js/trusted-messages.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>" type="text/javascript"></script>
 </head>
 <body class='body_top'>
     <div id="container_div" class="<?php echo attr($oemr_ui->oeContainer()); ?>">

--- a/interface/modules/custom_modules/oe-module-faxsms/contact.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/contact.php
@@ -86,7 +86,7 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
     echo "<script>var pid=" . js_escape($interface_pid ?: $pid) . ";var isFax=" . js_escape($isFax) . ";var isOnetime=" . js_escape($isOnetime) . ";var isEmail=" . js_escape($isEmail) . ";var isSms=" . js_escape($isSMS) . ";var isForward=" . js_escape($isForward) . ";var recipient=" . js_escape($recipient_phone) . ";var isUniversal=" . js_escape($isUniversal) . ";</script>";
     ?>
     <?php if (OEGlobalsBag::getInstance()->getBoolean('text_templates_enabled')) { ?>
-        <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/CustomTemplateLoader.js"></script>
+        <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/CustomTemplateLoader.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
     <?php } ?>
     <script>
         const serviceType = <?php echo js_escape($serviceType); ?>;

--- a/interface/modules/custom_modules/oe-module-faxsms/messageUI.php
+++ b/interface/modules/custom_modules/oe-module-faxsms/messageUI.php
@@ -56,8 +56,8 @@ $site_id = $session->get('site_id');
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><?php echo $tabTitle ?? ''; ?></title>
-    <link rel="stylesheet" href="<?php echo OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative(); ?>/dropzone/dist/dropzone.css">
-    <script src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative(); ?>/utif2/UTIF.js"></script>
+    <link rel="stylesheet" href="<?php echo OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative(); ?>/dropzone/dist/dropzone.css?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>">
+    <script src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative(); ?>/utif2/UTIF.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
     <?php
     if (!$clientApp->verifyAcl()) {
         die("<h3>" . xlt("Not Authorised!") . "</h3>");
@@ -67,8 +67,8 @@ $site_id = $session->get('site_id');
         ";let currentService=" . js_escape($service) . ";let serviceType=" . js_escape($serviceType) . ";let csrfToken=" . js_escape(CsrfUtils::collectCsrfToken($session, 'contact-form')) . "</script>";
     echo ServiceType::renderJsConstants();
     ?>
-    <script type="text/javascript" src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative(); ?>/dropzone/dist/dropzone.js"></script>
-    <script type="text/javascript" src="<?php echo $assetBase; ?>/js/messageUI.js"></script>
+    <script type="text/javascript" src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative(); ?>/dropzone/dist/dropzone.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
+    <script type="text/javascript" src="<?php echo $assetBase; ?>/js/messageUI.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 
     <script>
         $(function () {

--- a/interface/modules/custom_modules/oe-module-weno/templates/weno_fragment.php
+++ b/interface/modules/custom_modules/oe-module-weno/templates/weno_fragment.php
@@ -139,7 +139,7 @@ $resDrugs = sqlStatement("SELECT * FROM prescriptions WHERE patient_id = ? AND i
 
 ?>
 <script
-    src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/interface/modules/custom_modules/oe-module-weno/public/assets/js/synch.js"></script>
+    src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/interface/modules/custom_modules/oe-module-weno/public/assets/js/synch.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 <style>
     .dialog-alert {
         font-size: 14px;

--- a/interface/modules/custom_modules/oe-module-weno/templates/weno_users.php
+++ b/interface/modules/custom_modules/oe-module-weno/templates/weno_users.php
@@ -117,7 +117,7 @@ if (($_POST['save'] ?? false) == 'true') {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?php echo xlt("Prescriber Weno Ids"); ?></title>
     <?php Header::setupHeader(); ?>
-    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/interface/modules/custom_modules/oe-module-weno/public/assets/js/synch.js"></script>
+    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/interface/modules/custom_modules/oe-module-weno/public/assets/js/synch.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
     <script>
         $(function () {
             const persistChange = document.querySelectorAll('.persist-uid');

--- a/interface/modules/zend_modules/module/PatientFilter/acl/acl_setup.php
+++ b/interface/modules/zend_modules/module/PatientFilter/acl/acl_setup.php
@@ -7,6 +7,7 @@ if ($aclSetupFlag !== true) {
 }
 
 use OpenEMR\Common\Acl\AclExtended;
+use OpenEMR\Core\OEGlobalsBag;
 
 AclExtended::addObjectSectionAcl('pfeh', 'PatientFilter');
 
@@ -23,7 +24,7 @@ AclExtended::updateAcl($physicians_write, 'Physicians', 'pfeh', 'Parameters', 'p
 <html>
 <head>
     <title>PatientFilter ACL Setup</title>
-    <link rel=STYLESHEET href="interface/themes/style_blue.css">
+    <link rel=STYLESHEET href="interface/themes/style_blue.css?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>">
 </head>
 <body>
 <b>OpenEMR[PatientFilter] ACL Setup</b>

--- a/interface/orders/find_order_popup.php
+++ b/interface/orders/find_order_popup.php
@@ -16,6 +16,7 @@
 require_once("../globals.php");
 
 use OpenEMR\Core\Header;
+use OpenEMR\Core\OEGlobalsBag;
 
 $order = (int) ($_GET['order'] ?? null);
 $labid = (int) ($_GET['labid'] ?? null);
@@ -48,7 +49,7 @@ if (isset($_GET['typeid'])) {
         }
     }
     ?>
-    <script src="<?php echo \OpenEMR\Core\OEGlobalsBag::getInstance()->getWebRoot() ?>/interface/main/tabs/js/include_opener.js"></script>
+    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/interface/main/tabs/js/include_opener.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
     <script>
         if (opener.closed) {
             alert(<?php echo xlj('The destination form was closed; I cannot act on your selection.'); ?>);

--- a/interface/orders/single_order_results.inc.php
+++ b/interface/orders/single_order_results.inc.php
@@ -409,7 +409,7 @@ function generate_order_report($orderid, $input_form = false, $genstyles = true,
 <?php } ?>
 
     <?php if ($input_form) { ?>
-        <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/library/textformat.js"></script>
+        <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot(); ?>/library/textformat.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
     <?php } // end if input form
     ?>
 

--- a/interface/orders/single_order_results.php
+++ b/interface/orders/single_order_results.php
@@ -67,7 +67,7 @@ body {
 }
 </style>
 
-<script src="../../library/topdialog.js"></script>
+<script src="../../library/topdialog.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 <script>
     <?php require(OEGlobalsBag::getInstance()->getSrcDir() . "/restoreSession.php"); ?>
 </script>

--- a/interface/orders/types.php
+++ b/interface/orders/types.php
@@ -43,7 +43,7 @@ if ($popup && $_POST['form_save'] ?? '') {
     $ptrow = sqlQuery("SELECT name FROM procedure_type WHERE procedure_type_id = ?", [$form_order]);
     $name = $ptrow['name'];
     ?>
-    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/interface/main/tabs/js/include_opener.js"></script>
+    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/interface/main/tabs/js/include_opener.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
     <script>
     if (opener.closed || ! opener.set_proc_type) {
         alert(<?php echo xlj('The destination form was closed; I cannot act on your selection.'); ?>);

--- a/interface/patient_file/encounter/forms.php
+++ b/interface/patient_file/encounter/forms.php
@@ -85,8 +85,8 @@ if (file_exists(__DIR__ . "/../../forms/track_anything/style.css")) { ?>
     <script>
         var csrf_token_js = <?php echo js_escape(CsrfUtils::collectCsrfToken(session: $session)); ?>;
     </script>
-    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/interface/forms/track_anything/report.js"></script>
-    <link rel="stylesheet" href="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/interface/forms/track_anything/style.css">
+    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/interface/forms/track_anything/report.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
+    <link rel="stylesheet" href="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/interface/forms/track_anything/style.css?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>">
 <?php } ?>
 
 <?php
@@ -120,7 +120,7 @@ if (!empty($_GET['attachid'])) {
 // If google sign-in enable then add scripts.
 if (OEGlobalsBag::getInstance()->getBoolean('google_signin_enabled') && !empty(OEGlobalsBag::getInstance()->getString('google_signin_client_id'))) { ?>
     <script src="https://accounts.google.com/gsi/client" async defer></script>
-    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/gSignIn.js"></script>
+    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/gSignIn.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 <?php } ?>
 
 <script>

--- a/interface/patient_file/encounter/load_form.php
+++ b/interface/patient_file/encounter/load_form.php
@@ -89,5 +89,5 @@ if ($telemetryService->isTelemetryEnabled()) {
 }
 
 if (OEGlobalsBag::getInstance()->getBoolean('text_templates_enabled') && !($_GET['formname'] == 'fee_sheet')) { ?>
-    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/CustomTemplateLoader.js"></script>
+    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/CustomTemplateLoader.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 <?php } ?>

--- a/interface/patient_file/encounter/view_form.php
+++ b/interface/patient_file/encounter/view_form.php
@@ -84,5 +84,5 @@ require_once($file);
 
 $id = $clean_id;
 if (OEGlobalsBag::getInstance()->getBoolean('text_templates_enabled')) { ?>
-    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/CustomTemplateLoader.js"></script>
+    <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/CustomTemplateLoader.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 <?php } ?>

--- a/interface/patient_file/front_payment.php
+++ b/interface/patient_file/front_payment.php
@@ -692,7 +692,7 @@ function toencounter(enc, datestr, topframe) {
 
     <?php echo Header::setupAssets(['topdialog']); ?>
 
-<script src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative(); ?>/jquery-creditcardvalidator/jquery.creditCardValidator.js"></script>
+<script src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative(); ?>/jquery-creditcardvalidator/jquery.creditCardValidator.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 
 <script>
     var chargeMsg = <?php echo xlj('Payment was successfully authorized and charged. Thank You.'); ?>;

--- a/interface/patient_file/history/encounters.php
+++ b/interface/patient_file/history/encounters.php
@@ -203,7 +203,7 @@ function generatePageElement($start, $pagesize, $billing, $issue, $text): void
 <!-- Not sure why we don't want this ui to be B.S responsive. -->
 <?php Header::setupHeader(['no_textformat']); ?>
 
-<script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/ajtooltip.js"></script>
+<script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/ajtooltip.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 
 <script>
 

--- a/interface/super/edit_globals.php
+++ b/interface/super/edit_globals.php
@@ -373,7 +373,7 @@ function checkBackgroundServices(): void
     $serverConfig = new ServerConfig();
     $apiUrl = $serverConfig->getInternalBaseApiUrl();
     ?>
-    <script src="edit_globals.js" type="text/javascript"></script>
+    <script src="edit_globals.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>" type="text/javascript"></script>
     <script>
         window.oeUI.api.setApiUrlAndCsrfToken(<?php echo js_escape($apiUrl); ?>, <?php echo js_escape(CsrfUtils::collectCsrfToken($session, 'api')); ?>);
     </script>

--- a/interface/usergroup/mfa_u2f.php
+++ b/interface/usergroup/mfa_u2f.php
@@ -36,7 +36,7 @@ $user_full_name = $user_name['fname'] . " " . $user_name['lname'];
 <head>
 <?php Header::setupHeader(); ?>
 <title><?php echo xlt('U2F Registration'); ?></title>
-<script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/u2f-api.js"></script>
+<script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/u2f-api.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 <script>
 
 function doregister() {

--- a/interface/usergroup/user_admin.php
+++ b/interface/usergroup/user_admin.php
@@ -62,7 +62,7 @@ $iter = $result[0];
 
 <?php Header::setupHeader(['common','opener', 'erx']); ?>
 
-<script src="checkpwd_validation.js"></script>
+<script src="checkpwd_validation.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 
 <!-- validation library -->
 <!--//Not lbf forms use the new validation, please make sure you have the corresponding values in the list Page validation-->

--- a/interface/usergroup/user_info.php
+++ b/interface/usergroup/user_info.php
@@ -38,7 +38,7 @@ $user_full_name = $user_name['fname'] . " " . $user_name['lname'];
 <?php Header::setupHeader(); ?>
 <title><?php echo xlt('Change Password'); ?></title>
 
-<script src="checkpwd_validation.js"></script>
+<script src="checkpwd_validation.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 
 <script>
 //Validating password and display message if password field is empty - starts

--- a/interface/usergroup/usergroup_admin_add.php
+++ b/interface/usergroup/usergroup_admin_add.php
@@ -42,7 +42,7 @@ $session = SessionWrapperFactory::getInstance()->getActiveSession();
 
 <?php Header::setupHeader(['common','opener', 'erx']); ?>
 
-<script src="checkpwd_validation.js"></script>
+<script src="checkpwd_validation.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 
 <!-- validation library -->
 <!--//Not lbf forms use the new validation, please make sure you have the corresponding values in the list Page validation-->

--- a/library/custom_template/custom_template.php
+++ b/library/custom_template/custom_template.php
@@ -89,7 +89,7 @@ if ($isNN) {
 }
     Header::setupHeader(['common', 'opener', 'select2', 'ckeditor', $ckeditorConfig]);
 ?>
-<script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/ajax_functions_writer.js"></script>
+<script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/ajax_functions_writer.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 
 <script>
     // note these variables are set on backend server side, leaving comment for server side readers

--- a/library/custom_template/delete_category.php
+++ b/library/custom_template/delete_category.php
@@ -39,7 +39,7 @@ $res = sqlStatement("SELECT * FROM customlists as cl left outer join users as u 
     <head>
         <title><!-- Insert your title here --></title>
         <?php Header::setupHeader('opener'); ?>
-        <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/ajax_functions_writer.js"></script>
+        <script src="<?php echo OEGlobalsBag::getInstance()->getWebRoot() ?>/library/js/ajax_functions_writer.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 
         <script>
         function delete_full_category(id){

--- a/library/smarty/plugins/function.assetVersionNumber.php
+++ b/library/smarty/plugins/function.assetVersionNumber.php
@@ -33,10 +33,12 @@ use OpenEMR\Core\OEGlobalsBag;
 function smarty_function_assetVersionNumber($params, &$smarty): string
 {
     // version.php sets v_js_includes to an int for a release and to an md5
-    // string in dev, but interface/globals.php stores null when version.php was
-    // already included in another scope. Narrow the raw value rather than
-    // calling getString(): the key is present-but-null in that case, so
-    // getString() would skip its default and throw UnexpectedValueException.
+    // string in dev. interface/globals.php publishes it through VersionFile,
+    // whose $jsIncludes is int|string and which throws rather than yielding
+    // null, so a bootstrapped request always has a usable value here.
+    //
+    // Narrow the raw value anyway: Smarty templates can render before
+    // globals.php has run, and an absent key reads back as null.
     $configured = OEGlobalsBag::getInstance()->get('v_js_includes');
 
     // Any unusable value falls back to the current timestamp. A constant

--- a/library/validation/validation_script.js.php
+++ b/library/validation/validation_script.js.php
@@ -32,9 +32,9 @@ require_once(OEGlobalsBag::getInstance()->getSrcDir() . "/validation/LBF_Validat
 /*Other pages depend if the page in the lists options (page validation)is active and exists)*/
 if ($use_validate_js) {
     ?>
-    <script src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative() ?>/moment/moment.js"></script>
-    <script src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getRootDir() ?>/../library/js/vendors/validate/validate_modified.js"></script>
-    <script src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getRootDir() ?>/../library/js/vendors/validate/validate_extend.js"></script>
+    <script src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getAssetsRelative() ?>/moment/moment.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
+    <script src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getRootDir() ?>/../library/js/vendors/validate/validate_modified.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
+    <script src="<?php echo OEGlobalsBag::getInstance()->getKernel()->getRootDir() ?>/../library/js/vendors/validate/validate_extend.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 
     <style type="text/css">
     .error-message {

--- a/portal/patient/templates/OnsiteDocumentListView.tpl.php
+++ b/portal/patient/templates/OnsiteDocumentListView.tpl.php
@@ -115,7 +115,7 @@ $templateService = new DocumentTemplateService();
     <script src="<?php echo $assets_static_relative; ?>/dropzone/dist/dropzone.js?v=<?php echo $v_js_includes; ?>"></script>
     <script src="<?php echo $webroot; ?>/portal/sign/assets/signature_pad.umd.js?v=<?php echo $v_js_includes; ?>"></script>
     <script src="<?php echo $webroot; ?>/portal/sign/assets/signer_api.js?v=<?php echo $v_js_includes; ?>"></script>
-    <script src="<?php echo $webroot; ?>/portal/patient/scripts/libs/LAB.min.js"></script>
+    <script src="<?php echo $webroot; ?>/portal/patient/scripts/libs/LAB.min.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
     <script>
         $LAB.setGlobalDefaults({
             BasePath: "<?php $this->eprint($this->ROOT_URL); ?>"

--- a/portal/patient/templates/ProviderHome.tpl.php
+++ b/portal/patient/templates/ProviderHome.tpl.php
@@ -42,7 +42,7 @@ $v_js_includes = $globalsBag->get('v_js_includes');
     <script src="<?php echo $web_root; ?>/portal/sign/assets/signature_pad.umd.js?v=<?php echo $v_js_includes; ?>"></script>
     <script src="<?php echo $web_root; ?>/portal/sign/assets/signer_api.js?v=<?php echo $v_js_includes; ?>"></script>
 
-    <script src="<?php echo $web_root; ?>/portal/patient/scripts/libs/LAB.min.js"></script>
+    <script src="<?php echo $web_root; ?>/portal/patient/scripts/libs/LAB.min.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
     <script>
         $LAB.script("<?php echo $assets_static_relative; ?>/underscore/underscore-min.js")
         .script("<?php echo $assets_static_relative; ?>/moment/moment.js")

--- a/portal/patient/templates/_FormsHeader.tpl.php
+++ b/portal/patient/templates/_FormsHeader.tpl.php
@@ -41,7 +41,7 @@ if ($session->get('patient_portal_onsite_two', 0)) {
 }
 ?>
 
-<script src="<?php echo $web_root; ?>/portal/patient/scripts/libs/LAB.min.js"></script>
+<script src="<?php echo $web_root; ?>/portal/patient/scripts/libs/LAB.min.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 <script>
     $LAB.script("<?php echo $assets_static_relative; ?>/underscore/underscore-min.js").wait()
         .script("<?php echo $assets_static_relative; ?>/backbone/backbone-min.js")

--- a/portal/patient/templates/_Header.tpl.php
+++ b/portal/patient/templates/_Header.tpl.php
@@ -37,7 +37,7 @@ $v_js_includes = $globalsBag->get('v_js_includes');
         <base href="<?php $this->eprint($this->ROOT_URL); ?>" />
         <meta name="description" content="Patient Portal" />
         <meta name="author" content="Form | sjpadgett@gmail.com" />
-        <script src="<?php echo $web_root; ?>/portal/patient/scripts/libs/LAB.min.js"></script>
+        <script src="<?php echo $web_root; ?>/portal/patient/scripts/libs/LAB.min.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
         <script>
             $LAB.script("<?php echo $assets_static_relative; ?>/moment/moment.js")
                 .script("<?php echo $assets_static_relative; ?>/underscore/underscore-min.js").wait()

--- a/portal/patient/templates/_modalFormHeader.tpl.php
+++ b/portal/patient/templates/_modalFormHeader.tpl.php
@@ -30,23 +30,23 @@ $v_js_includes = $globalsBag->get('v_js_includes');
 <meta name="description" content="Patient Profile" />
 <meta name="author" content="Form | sjpadgett@gmail.com" />
 
-<script src="<?php echo $assets_static_relative; ?>/jquery/dist/jquery.min.js"></script>
-<link href="<?php echo $assets_static_relative; ?>/@fortawesome/fontawesome-free/css/all.min.css" rel="stylesheet" />
-<link href="<?php echo $assets_static_relative; ?>/jquery-datetimepicker/build/jquery.datetimepicker.min.css" rel="stylesheet" />
+<script src="<?php echo $assets_static_relative; ?>/jquery/dist/jquery.min.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
+<link href="<?php echo $assets_static_relative; ?>/@fortawesome/fontawesome-free/css/all.min.css?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>" rel="stylesheet" />
+<link href="<?php echo $assets_static_relative; ?>/jquery-datetimepicker/build/jquery.datetimepicker.min.css?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>" rel="stylesheet" />
 <?php if ($this->register) {?>
-    <link href="<?php echo $assets_static_relative; ?>/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
-    <script src="<?php echo $assets_static_relative; ?>/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <link href="<?php echo $assets_static_relative; ?>/bootstrap/dist/css/bootstrap.min.css?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>" rel="stylesheet">
+    <script src="<?php echo $assets_static_relative; ?>/bootstrap/dist/js/bootstrap.bundle.min.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 <?php } ?>
 
-<script src="<?php echo $assets_static_relative; ?>/moment/moment.js"></script>
-<script src="<?php echo $assets_static_relative; ?>/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
-<script src="<?php echo $assets_static_relative; ?>/underscore/underscore-min.js"></script>
-<script src="<?php echo $assets_static_relative; ?>/backbone/backbone-min.js"></script>
+<script src="<?php echo $assets_static_relative; ?>/moment/moment.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
+<script src="<?php echo $assets_static_relative; ?>/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
+<script src="<?php echo $assets_static_relative; ?>/underscore/underscore-min.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
+<script src="<?php echo $assets_static_relative; ?>/backbone/backbone-min.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 <script src="<?php echo $web_root; ?>/portal/patient/scripts/app.js?v=<?php echo $v_js_includes; ?>"></script>
 <script src="<?php echo $web_root; ?>/portal/patient/scripts/model.js?v=<?php echo $v_js_includes; ?>"></script>
 <script src="<?php echo $web_root; ?>/portal/patient/scripts/view.js?v=<?php echo $v_js_includes; ?>"></script>
 <base href="<?php $this->eprint($this->ROOT_URL); ?>" />
-<script src="<?php echo $web_root; ?>/portal/patient/scripts/libs/LAB.min.js"></script>
+<script src="<?php echo $web_root; ?>/portal/patient/scripts/libs/LAB.min.js?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"></script>
 <script>
 $LAB.setGlobalDefaults({BasePath: "<?php $this->eprint($this->ROOT_URL); ?>"});
 </script>

--- a/portal/portal_payment.php
+++ b/portal/portal_payment.php
@@ -361,7 +361,7 @@ if ($alertmsg === '' && (($_POST['form_save'] ?? null) || filter_input(INPUT_GET
     ?>
 
     <title><?php echo xlt('Receipt for Payment'); ?></title>
-    <script src="<?php echo $globalsBag->getString('assets_static_relative'); ?>/jquery/dist/jquery.min.js"></script>
+    <script src="<?php echo $globalsBag->getString('assets_static_relative'); ?>/jquery/dist/jquery.min.js?v=<?php echo attr_url($globalsBag->getString('v_js_includes')); ?>"></script>
     <script>
 
         function goHome() {
@@ -466,7 +466,7 @@ if ($alertmsg === '' && (($_POST['form_save'] ?? null) || filter_input(INPUT_GET
             font-weight: normal
         }
     </style>
-    <script src="<?php echo $globalsBag->getString('assets_static_relative'); ?>/jquery-creditcardvalidator/jquery.creditCardValidator.js"></script>
+    <script src="<?php echo $globalsBag->getString('assets_static_relative'); ?>/jquery-creditcardvalidator/jquery.creditCardValidator.js?v=<?php echo attr_url($globalsBag->getString('v_js_includes')); ?>"></script>
     <script src="<?php echo $globalsBag->getString('webroot') ?>/library/textformat.js?v=<?php echo $v_js_includes; ?>"></script>
     <script src="portal_payment.js?v=<?=$v_js_includes?>"></script>
     <script>

--- a/templates/calendar/default/admin/submit_category.html.twig
+++ b/templates/calendar/default/admin/submit_category.html.twig
@@ -2,9 +2,9 @@
    admin/submit_category.html. Has no [-php-] blocks. #}
 <!-- main navigation -->
 
-<script src="modules/{{ pcDir }}/pnincludes/AnchorPosition.js"></script>
-<script src="modules/{{ pcDir }}/pnincludes/PopupWindow.js"></script>
-<script src="modules/{{ pcDir }}/pnincludes/ColorPicker2.js"></script>
+<script src="modules/{{ pcDir }}/pnincludes/AnchorPosition.js?v={{ assetVersion|attr_url }}"></script>
+<script src="modules/{{ pcDir }}/pnincludes/PopupWindow.js?v={{ assetVersion|attr_url }}"></script>
+<script src="modules/{{ pcDir }}/pnincludes/ColorPicker2.js?v={{ assetVersion|attr_url }}"></script>
 <script>
     var cp = new ColorPicker('window');
     // Runs when a color is clicked

--- a/templates/calendar/default/user/ajax_search.html.twig
+++ b/templates/calendar/default/user/ajax_search.html.twig
@@ -7,9 +7,9 @@
 {% include 'calendar/default/views/header.html.twig' %}
 
 {# include our stylesheet for this view #}
-<link rel="stylesheet" href="{{ assets_dir }}/jquery-datetimepicker/build/jquery.datetimepicker.min.css">
+<link rel="stylesheet" href="{{ assets_dir }}/jquery-datetimepicker/build/jquery.datetimepicker.min.css?v={{ assetVersion|attr_url }}">
 
-<script src="{{ assets_dir }}/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js"></script>
+<script src="{{ assets_dir }}/jquery-datetimepicker/build/jquery.datetimepicker.full.min.js?v={{ assetVersion|attr_url }}"></script>
 
 <!-- main navigation -->
 

--- a/templates/calendar/default/views/header.html.twig
+++ b/templates/calendar/default/views/header.html.twig
@@ -22,6 +22,6 @@
         <!-- Module Styles Ended -->
     {% endif %}
     <!-- the javascript used for the ajax_* style calendars -->
-    <script src="{{ webroot }}/library/js/calendarDirectSelect.js"></script>
+    <script src="{{ webroot }}/library/js/calendarDirectSelect.js?v={{ assetVersion|attr_url }}"></script>
 </head>
 <body class="{{ body_class|default('') }} calsearch_body w-100">

--- a/templates/dicom/dicom-viewer.html.twig
+++ b/templates/dicom/dicom-viewer.html.twig
@@ -4,27 +4,27 @@
     <title>{{ "Dicom Viewer"|xlt  }}</title>
 
     {{ setupHeader(['dwv', 'i18next', 'i18next-xhr-backend', 'i18next-browser-languagedetector', 'jszip', 'magic-wand', 'konva']) }}
-    <script type="text/javascript" src="{{ assets_static_relative }}/flot/dist/es5/jquery.flot.js"></script>
+    <script type="text/javascript" src="{{ assets_static_relative }}/flot/dist/es5/jquery.flot.js?v={{ assetVersion|attr_url }}"></script>
     <!-- Local (dwv) -->
-    <script src="{{web_root}}/library/js/dwv/gui/browser.js"></script>
-    <script src="{{web_root}}/library/js/dwv/gui/colourMap.js"></script>
-    <script src="{{web_root}}/library/js/dwv/gui/custom.js"></script>
-    <script src="{{web_root}}/library/js/dwv/gui/dropboxLoader.js"></script>
-    <script src="{{web_root}}/library/js/dwv/gui/filter.js"></script>
-    <script src="{{web_root}}/library/js/dwv/gui/generic.js"></script>
-    <script src="{{web_root}}/library/js/dwv/gui/undo.js"></script>
-    <script src="{{web_root}}/library/js/dwv/gui/help.js"></script>
-    <script src="{{web_root}}/library/js/dwv/gui/html.js"></script>
-    <script src="{{web_root}}/library/js/dwv/gui/infoController.js"></script>
-    <script src="{{web_root}}/library/js/dwv/gui/infoOverlay.js"></script>
-    <script src="{{web_root}}/library/js/dwv/gui/loader.js"></script>
-    <script src="{{web_root}}/library/js/dwv/gui/tools.js"></script>
-    <script src="{{web_root}}/library/js/dwv/gui/plot.js"></script>
+    <script src="{{web_root}}/library/js/dwv/gui/browser.js?v={{ assetVersion|attr_url }}"></script>
+    <script src="{{web_root}}/library/js/dwv/gui/colourMap.js?v={{ assetVersion|attr_url }}"></script>
+    <script src="{{web_root}}/library/js/dwv/gui/custom.js?v={{ assetVersion|attr_url }}"></script>
+    <script src="{{web_root}}/library/js/dwv/gui/dropboxLoader.js?v={{ assetVersion|attr_url }}"></script>
+    <script src="{{web_root}}/library/js/dwv/gui/filter.js?v={{ assetVersion|attr_url }}"></script>
+    <script src="{{web_root}}/library/js/dwv/gui/generic.js?v={{ assetVersion|attr_url }}"></script>
+    <script src="{{web_root}}/library/js/dwv/gui/undo.js?v={{ assetVersion|attr_url }}"></script>
+    <script src="{{web_root}}/library/js/dwv/gui/help.js?v={{ assetVersion|attr_url }}"></script>
+    <script src="{{web_root}}/library/js/dwv/gui/html.js?v={{ assetVersion|attr_url }}"></script>
+    <script src="{{web_root}}/library/js/dwv/gui/infoController.js?v={{ assetVersion|attr_url }}"></script>
+    <script src="{{web_root}}/library/js/dwv/gui/infoOverlay.js?v={{ assetVersion|attr_url }}"></script>
+    <script src="{{web_root}}/library/js/dwv/gui/loader.js?v={{ assetVersion|attr_url }}"></script>
+    <script src="{{web_root}}/library/js/dwv/gui/tools.js?v={{ assetVersion|attr_url }}"></script>
+    <script src="{{web_root}}/library/js/dwv/gui/plot.js?v={{ assetVersion|attr_url }}"></script>
     <!-- i18n dwv wrapper -->
-    <script src="{{web_root}}/library/js/dwv/dwv_i18n.js"></script>
+    <script src="{{web_root}}/library/js/dwv/dwv_i18n.js?v={{ assetVersion|attr_url }}"></script>
     <!-- Launch the app -->
-    <script src="{{web_root}}/library/js/dwv/dicom_gui.js"></script>
-    <script src="{{web_root}}/library/js/dwv/dicom_launcher.js"></script>
+    <script src="{{web_root}}/library/js/dwv/dicom_gui.js?v={{ assetVersion|attr_url }}"></script>
+    <script src="{{web_root}}/library/js/dwv/dicom_launcher.js?v={{ assetVersion|attr_url }}"></script>
 </head>
 <style type="text/css">
     body {

--- a/templates/documents/general_list.html
+++ b/templates/documents/general_list.html
@@ -14,7 +14,7 @@
 
 {headerTemplate assets='datetime-picker|select2'}
 
-<link rel="stylesheet" href="{$GLOBALS.assets_static_relative}/dropzone/dist/dropzone.css">
+<link rel="stylesheet" href="{$GLOBALS.assets_static_relative}/dropzone/dist/dropzone.css?v={assetVersionNumber}">
 
 <style>
 .select2-selection {
@@ -36,8 +36,8 @@ border-radius: 4px 0 0 4px!important;
 	min-width: 20vw !important;
 }
 </style>
-<script src="{$GLOBALS.webroot}/library/js/DocumentTreeMenu.js"></script>
-<script src="{$GLOBALS.assets_static_relative}/dropzone/dist/dropzone.js"></script>
+<script src="{$GLOBALS.webroot}/library/js/DocumentTreeMenu.js?v={assetVersionNumber}"></script>
+<script src="{$GLOBALS.assets_static_relative}/dropzone/dist/dropzone.js?v={assetVersionNumber}"></script>
 
 <script>
 	function callTemplateModule(patient_id, cuser, templateName, id, edit) {

--- a/templates/super/facilities/form.html.twig
+++ b/templates/super/facilities/form.html.twig
@@ -2,9 +2,9 @@
 <head>
 {{ setupHeader(['opener', 'erx']) }}
 
-<script src="../main/calendar/modules/PostCalendar/pnincludes/AnchorPosition.js"></script>
-<script src="../main/calendar/modules/PostCalendar/pnincludes/PopupWindow.js"></script>
-<script src="../main/calendar/modules/PostCalendar/pnincludes/ColorPicker2.js"></script>
+<script src="../main/calendar/modules/PostCalendar/pnincludes/AnchorPosition.js?v={{ assetVersion|attr_url }}"></script>
+<script src="../main/calendar/modules/PostCalendar/pnincludes/PopupWindow.js?v={{ assetVersion|attr_url }}"></script>
+<script src="../main/calendar/modules/PostCalendar/pnincludes/ColorPicker2.js?v={{ assetVersion|attr_url }}"></script>
 
 <!-- validation library -->
 <!--//Not lbf forms use the new validation, please make sure you have the corresponding values in the list Page validation-->

--- a/tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
+++ b/tests/Tests/Isolated/Common/Twig/TwigTemplateRenderTest.php
@@ -34,10 +34,20 @@ class TwigTemplateRenderTest extends TestCase
 {
     private static ?Environment $twig = null;
 
+    /**
+     * Stand-in for the release value version.php assigns to v_js_includes.
+     *
+     * Pinned so fixtures render a stable cache-buster: a template that drops
+     * `?v={{ assetVersion|attr_url }}` shows up as a fixture diff rather than
+     * rendering an empty `?v=` that asserts nothing.
+     */
+    private const ASSET_VERSION = 82;
+
     protected function setUp(): void
     {
         $GLOBALS['fileroot'] ??= self::fileroot();
         $GLOBALS['date_display_format'] ??= 0;
+        $GLOBALS['v_js_includes'] = self::ASSET_VERSION;
         // Bypass database-dependent translation lookups so xl() returns the
         // original string and xlt()/xla() apply only escaping.
         $GLOBALS['disable_translation'] = true;
@@ -542,6 +552,7 @@ class TwigTemplateRenderTest extends TestCase
 
         $GLOBALS['fileroot'] ??= self::fileroot();
         $GLOBALS['date_display_format'] ??= 0;
+        $GLOBALS['v_js_includes'] = self::ASSET_VERSION;
         $GLOBALS['disable_translation'] = true;
 
         // Also load interface/ so encounter form templates resolve under the same

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-day-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-day-screen-empty.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" href="/interface/themes/ajax_calendar_ie.css">
     <![endif]-->
                 <!-- the javascript used for the ajax_* style calendars -->
-    <script src="/library/js/calendarDirectSelect.js"></script>
+    <script src="/library/js/calendarDirectSelect.js?v=82"></script>
 </head>
 <body class=" calsearch_body w-100">
 

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-month-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-month-screen-empty.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" href="/interface/themes/ajax_calendar_ie.css">
     <![endif]-->
                 <!-- the javascript used for the ajax_* style calendars -->
-    <script src="/library/js/calendarDirectSelect.js"></script>
+    <script src="/library/js/calendarDirectSelect.js?v=82"></script>
 </head>
 <body class=" calsearch_body w-100">
 

--- a/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-week-screen-empty.html
+++ b/tests/Tests/Isolated/Common/Twig/fixtures/render/calendar-week-screen-empty.html
@@ -8,7 +8,7 @@
         <link rel="stylesheet" href="/interface/themes/ajax_calendar_ie.css">
     <![endif]-->
                 <!-- the javascript used for the ajax_* style calendars -->
-    <script src="/library/js/calendarDirectSelect.js"></script>
+    <script src="/library/js/calendarDirectSelect.js?v=82"></script>
 </head>
 <body class=" calsearch_body w-100">
 

--- a/tests/Tests/Isolated/Core/AssetCacheBusterTest.php
+++ b/tests/Tests/Isolated/Core/AssetCacheBusterTest.php
@@ -1,0 +1,300 @@
+<?php
+
+/**
+ * Guard that every inline <script src>/<link href> carries a cache-buster.
+ *
+ * version.php sets the rule: whenever a .js or .css file changes, every URL
+ * that references it must end with `?v=$v_js_includes`, or a browser that
+ * has cached the old copy keeps using it. Header::setupHeader() appends the
+ * parameter for assets declared in config/config.yaml; tags written directly
+ * into a view bypass that and have to append it themselves. How long a stale
+ * asset survives depends on how aggressively a deployment caches static
+ * files, so the rule has to hold everywhere.
+ *
+ * The mirror rule matters too: a stylesheet handed to mPDF is read off the
+ * filesystem, and mPDF's AssetFetcher fopen()s the href verbatim. A query
+ * string on a filesystem path makes that open fail and the stylesheet is
+ * silently dropped from the PDF.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Core;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+#[Group('isolated')]
+#[Group('core')]
+class AssetCacheBusterTest extends TestCase
+{
+    /**
+     * Path prefixes outside the served application: vendored libraries,
+     * generated documentation, and test fixtures.
+     */
+    private const SKIP_PREFIXES = [
+        'ccdaservice/',
+        'contrib/',
+        'docs/',
+        'Documentation/',
+        'gacl/',
+        'public/assets/',
+        'sites/',
+        'swagger/',
+        'tests/',
+    ];
+
+    /**
+     * Files whose asset references legitimately carry no cache-buster, with
+     * the reason. Keep this list short and justified -- the default answer to
+     * a new entry is to append the parameter instead.
+     */
+    private const EXEMPT_FILES = [
+        'acknowledge_license_cert.html' =>
+            'Static HTML served with no template engine, so there is nothing to interpolate.',
+        'admin.php' =>
+            'The multi-site admin page runs without the Composer autoloader, so neither '
+            . 'attr_url() nor OEGlobalsBag is available.',
+        'interface/forms/CAMOS/help.html' =>
+            'Static HTML served with no template engine, so there is nothing to interpolate.',
+        'setup.php' =>
+            'The installer renders before version.php or the application globals are loaded.',
+    ];
+
+    /**
+     * Expressions that resolve to a filesystem path rather than a URL, in
+     * lower case. A reference built from one of these is read by mPDF off
+     * disk and must not carry a query string.
+     */
+    private const FILESYSTEM_ROOT_TOKENS = [
+        '__dir__',
+        'fileroot',
+        'includeroot',
+        'oe_site_dir',
+        'projectdir',
+        'webserver_root',
+    ];
+
+    private const VIEW_EXTENSIONS = ['php', 'twig', 'html', 'htm', 'tpl', 'inc'];
+
+    /**
+     * Stand-in for the `->` of a template expression such as
+     * `{$form->template_dir}`. Without it the tag scan below would read that
+     * `>` as the end of the tag and miss the href entirely.
+     */
+    private const ARROW = "\x01";
+
+    private const TAG_PATTERN = '/<(?:script|link)\b([^>]*)>/i';
+
+    private const ATTR_PATTERN = '/\b(?:src|href)\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s>]+))/i';
+
+    #[Test]
+    #[DataProvider('webReferenceProvider')]
+    public function webReferenceCarriesACacheBuster(string $where, string $url): void
+    {
+        self::assertMatchesRegularExpression(
+            '/[?&]v=/',
+            $url,
+            "$where: asset URL has no ?v= cache-buster, so a browser that cached the"
+            . ' previous copy keeps using it after the file changes (see version.php). Append'
+            . " ?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>"
+            . ' (Twig: ?v={{ assetVersion|attr_url }}, Smarty: ?v={assetVersionNumber}).'
+        );
+    }
+
+    #[Test]
+    #[DataProvider('filesystemReferenceProvider')]
+    public function filesystemReferenceCarriesNoQueryString(string $where, string $url): void
+    {
+        self::assertStringNotContainsString(
+            '?',
+            $url,
+            "$where: this href resolves to a filesystem path, which mPDF fopen()s verbatim."
+            . ' A query string makes the open fail and the stylesheet is dropped from the PDF.'
+        );
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function webReferenceProvider(): iterable
+    {
+        foreach (self::references() as $reference) {
+            [$where, $url, $isFilesystem] = $reference;
+            if ($isFilesystem || self::isExternal($url)) {
+                continue;
+            }
+            yield $where => [$where, $url];
+        }
+    }
+
+    /** @return iterable<string, array{string, string}> */
+    public static function filesystemReferenceProvider(): iterable
+    {
+        foreach (self::references() as $reference) {
+            [$where, $url, $isFilesystem] = $reference;
+            if (!$isFilesystem) {
+                continue;
+            }
+            yield $where => [$where, $url];
+        }
+    }
+
+    /**
+     * Every .js/.css reference in a served view, as "path:line" plus the raw
+     * attribute value and whether it resolves to a filesystem path.
+     *
+     * @return iterable<array{string, string, bool}>
+     */
+    private static function references(): iterable
+    {
+        foreach (self::viewFiles() as $path => $contents) {
+            if (isset(self::EXEMPT_FILES[$path])) {
+                continue;
+            }
+            $stream = self::markupStream($path, $contents);
+            if (!preg_match_all(self::TAG_PATTERN, $stream, $tags, PREG_OFFSET_CAPTURE | PREG_SET_ORDER)) {
+                continue;
+            }
+            foreach ($tags as $tag) {
+                if (!preg_match(self::ATTR_PATTERN, $tag[1][0], $attr)) {
+                    continue;
+                }
+                $url = self::firstNonEmpty($attr);
+                if (!preg_match('/\.(?:js|css)$/i', rtrim(explode('?', $url, 2)[0]))) {
+                    continue;
+                }
+                $url = str_replace(self::ARROW, '->', $url);
+                $line = substr_count(substr($stream, 0, $tag[0][1]), "\n") + 1;
+                yield ["$path:$line", $url, self::isFilesystemPath($url)];
+            }
+        }
+    }
+
+    /**
+     * Tracked view files, keyed by repo-relative path.
+     *
+     * Only tracked files are in scope. Composer installs modules such as
+     * oe-module-claimrev-connect into interface/modules/custom_modules/, and
+     * those live in their own repositories -- a fix has to land there, and any
+     * edit made here is wiped by the next composer install.
+     *
+     * @return iterable<string, string>
+     */
+    private static function viewFiles(): iterable
+    {
+        $root = self::projectRoot();
+        foreach (self::trackedPaths() as $path) {
+            if (!in_array(strtolower(pathinfo($path, PATHINFO_EXTENSION)), self::VIEW_EXTENSIONS, true)) {
+                continue;
+            }
+            foreach (self::SKIP_PREFIXES as $prefix) {
+                if (str_starts_with($path, $prefix)) {
+                    continue 2;
+                }
+            }
+            $contents = file_get_contents($root . '/' . $path);
+            if ($contents === false || !preg_match('/<(?:script|link)\b/i', $contents)) {
+                continue;
+            }
+            yield $path => $contents;
+        }
+    }
+
+    /** @return list<string> */
+    private static function trackedPaths(): array
+    {
+        $git = new Process(['git', 'ls-files'], self::projectRoot());
+        $git->mustRun();
+
+        return array_values(array_filter(explode("\n", $git->getOutput())));
+    }
+
+    /**
+     * Flatten a view into a single markup stream.
+     *
+     * Inline HTML and string-literal bodies pass through verbatim, so a tag
+     * echoed from a heredoc reads the same as one written as inline HTML.
+     * Every other PHP token keeps its source text with quotes, angle brackets
+     * and newlines neutralised, so an interpolated expression stays visible
+     * inside an attribute value without terminating the tag. Newline counts
+     * are preserved throughout, which keeps reported line numbers exact.
+     *
+     * HTML comments are dropped: a commented-out tag is never served.
+     */
+    private static function markupStream(string $path, string $contents): string
+    {
+        $isPhp = str_ends_with($path, '.php') || str_ends_with($path, '.inc');
+        $stream = $isPhp ? self::flattenPhp($contents) : $contents;
+
+        $stream = (string) preg_replace_callback(
+            '/<!--.*?-->/s',
+            static fn(array $m): string => str_repeat("\n", substr_count($m[0], "\n")),
+            $stream
+        );
+
+        return str_replace('->', self::ARROW, $stream);
+    }
+
+    private static function flattenPhp(string $code): string
+    {
+        $out = '';
+        foreach (token_get_all($code) as $token) {
+            if (!is_array($token)) {
+                $out .= str_replace(['"', "'", '<', '>'], ' ', $token);
+                continue;
+            }
+            [$id, $text] = $token;
+            if ($id === T_INLINE_HTML || $id === T_ENCAPSED_AND_WHITESPACE) {
+                $out .= $text;
+            } elseif ($id === T_CONSTANT_ENCAPSED_STRING) {
+                $out .= substr($text, 1, -1);
+            } elseif (in_array($id, [T_OPEN_TAG, T_OPEN_TAG_WITH_ECHO, T_CLOSE_TAG, T_START_HEREDOC, T_END_HEREDOC], true)) {
+                $out .= str_repeat("\n", substr_count($text, "\n"));
+            } else {
+                $out .= str_replace(["\n", '"', "'", '<', '>'], ' ', $text)
+                    . str_repeat("\n", substr_count($text, "\n"));
+            }
+        }
+        return $out;
+    }
+
+    /** @param array<int, string> $attr */
+    private static function firstNonEmpty(array $attr): string
+    {
+        foreach ([1, 2, 3] as $group) {
+            if (($attr[$group] ?? '') !== '') {
+                return $attr[$group];
+            }
+        }
+        return '';
+    }
+
+    private static function isExternal(string $url): bool
+    {
+        return (bool) preg_match('#^(?:[a-z][a-z0-9+.-]*:)?//#i', $url);
+    }
+
+    private static function isFilesystemPath(string $url): bool
+    {
+        $needle = strtolower($url);
+        foreach (self::FILESYSTEM_ROOT_TOKENS as $token) {
+            if (str_contains($needle, $token)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static function projectRoot(): string
+    {
+        return dirname(__DIR__, 4);
+    }
+}


### PR DESCRIPTION
## Summary

`version.php` documents the rule: whenever a `.js` or `.css` file changes, every URL referencing it must end with `?v=$v_js_includes` so browsers do not keep serving a cached copy. `Header::setupHeader()` applies this automatically for assets declared in `config/config.yaml`, but `<script src>` / `<link href>` tags written directly into a view bypass it. Across the tracked views, 105 such references carried no version. How long a stale asset survives depends on how aggressively a given deployment caches static files, so the fix is to make the documented rule hold everywhere and add a test that keeps it that way.

### The guard test (the durable part)

`tests/Tests/Isolated/Core/AssetCacheBusterTest.php` walks every git-tracked view (`.php`, `.twig`, `.html`, `.htm`, `.tpl`, `.inc`), flattens PHP through `token_get_all()` so tags built in heredocs and interpolated strings read the same as inline HTML, strips HTML comments, and asserts both halves of the rule:

1. A web-served `<script src>` / `<link href>` to a `.js`/`.css` carries a cache-buster (`/[?&]v=/`).
2. A reference built from a filesystem root (`$webserver_root`, `getProjectDir()`, `getIncludeRoot()`, `__DIR__`, `OE_SITE_DIR`, `fileroot`) carries **no** query string, because mPDF `fopen()`s that href verbatim and a query string makes the open fail, silently dropping the stylesheet from the PDF.

Scope is `git ls-files` (via `Symfony\Component\Process`) rather than a directory walk because Composer installs `oe-module-claimrev-connect` into `interface/modules/custom_modules/`; those files live in their own repository and any edit here is wiped by the next install. Each failure message names the file:line and the accessor to use for that engine.

### The sweep

Each site uses the accessor its engine already provides:

| Engine | Accessor |
|---|---|
| PHP | `?v=<?php echo attr_url(OEGlobalsBag::getInstance()->getString('v_js_includes')); ?>` |
| Twig | `?v={{ assetVersion\|attr_url }}` (global from `TwigExtension`) |
| Smarty | `?v={assetVersionNumber}` |

`_body-scripts.html.twig` also referenced an undefined `v_js_includes` variable on its existing bootstrap include (rendering an empty `?v=`); it now uses the `assetVersion` global too.

### Counts

| | References |
|---|---|
| In-scope references scanned | 193 |
| Already versioned | 76 |
| Fixed (cache-buster appended) | 105 |
| External (`//` or scheme, not checked) | 8 |
| Filesystem paths (must carry no query string) | 4 |
| Exempt | 14, in 4 files (below) |
| Skipped as vendored (`gacl/`) | 14 |

### Exemptions (with reasons, in the test)

| File | Reason |
|---|---|
| `acknowledge_license_cert.html` | Static HTML served with no template engine; nothing to interpolate. |
| `interface/forms/CAMOS/help.html` | Same. |
| `admin.php` | Multi-site admin page runs without the Composer autoloader, so neither `attr_url()` nor `OEGlobalsBag` is available. |
| `setup.php` | The installer renders before `version.php` or the application globals are loaded. |

## Test plan

- [x] `vendor/bin/phpunit -c phpunit-isolated.xml --filter AssetCacheBusterTest` — 185 tests green (fails 107 on `master` before the sweep)
- [x] pre-commit (phpcs, phpstan, rector, require-checker) green on every commit

