### PR TITLE
fix(globals): read version.php independently of include scope

### DIFF
--- a/.phpstan/baseline/binaryOp.invalid.php
+++ b/.phpstan/baseline/binaryOp.invalid.php
@@ -2428,7 +2428,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Binary operation "\\." between non\\-falsy\\-string and mixed results in an error\\.$#',
-    'count' => 9,
+    'count' => 3,
     'path' => __DIR__ . '/../../interface/globals.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/variable.undefined.php
+++ b/.phpstan/baseline/variable.undefined.php
@@ -837,11 +837,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/globals.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$v_js_includes might not be defined\\.$#',
-    'count' => 6,
-    'path' => __DIR__ . '/../../interface/globals.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$webroot might not be defined\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/help_modal.php',

--- a/.phpstan/fatal-baseline-caps.php
+++ b/.phpstan/fatal-baseline-caps.php
@@ -49,7 +49,7 @@ return [
         'return.missing.php' => 0,
         'staticMethod.notFound.php' => 0,
         'trait.notFound.php' => 0,
-        'variable.undefined.php' => 487,
+        'variable.undefined.php' => 486,
     ],
     'confidentNonObject' => [
         'classConstant.nonObject.php' => 0,

--- a/interface/globals.php
+++ b/interface/globals.php
@@ -27,6 +27,7 @@ use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Kernel;
 use OpenEMR\Core\ModulesApplication;
 use OpenEMR\Core\OEGlobalsBag;
+use OpenEMR\Core\VersionFile;
 use OpenEMR\Services\CodeTypes\Subscriber\CodeTypeEventsSubscriber;
 use OpenEMR\Services\FHIR\Subscriber\CalculatedObservationEventsSubscriber;
 use OpenEMR\Services\FHIR\Subscriber\UuidMappingEventsSubscriber;
@@ -398,16 +399,28 @@ require_once(__DIR__ . "/../library/sql.inc.php");
 $globalsBag->set("adodb", $GLOBALS['adodb'] ?? null);
 $globalsBag->set("dbh", $GLOBALS['dbh'] ?? null);
 
-// Include the version file
-require_once(__DIR__ . "/../version.php");
-$globalsBag->set("v_major", $v_major ?? null);
-$globalsBag->set("v_minor", $v_minor ?? null);
-$globalsBag->set("v_patch", $v_patch ?? null);
-$globalsBag->set("v_tag", $v_tag ?? null);
-$globalsBag->set("v_realpatch", $v_realpatch ?? null);
-$globalsBag->set("v_database", $v_database ?? null);
-$globalsBag->set("v_acl", $v_acl ?? null);
-$globalsBag->set("v_js_includes", $v_js_includes ?? null);
+// Read the version file. VersionFile evaluates it in its own scope, because
+// a require_once here is a no-op when another entry point already included
+// version.php, and the $v_* variables would then be undefined in this scope.
+// Storing them as null poisons every reader: the keys are present, so
+// getString() ignores its default and throws instead.
+$versionFile = VersionFile::load(dirname(__DIR__));
+$v_major = $versionFile->major;
+$v_minor = $versionFile->minor;
+$v_patch = $versionFile->patch;
+$v_tag = $versionFile->tag;
+$v_realpatch = $versionFile->realpatch;
+$v_database = $versionFile->database;
+$v_acl = $versionFile->acl;
+$v_js_includes = $versionFile->jsIncludes;
+$globalsBag->set('v_major', $v_major);
+$globalsBag->set('v_minor', $v_minor);
+$globalsBag->set('v_patch', $v_patch);
+$globalsBag->set('v_tag', $v_tag);
+$globalsBag->set('v_realpatch', $v_realpatch);
+$globalsBag->set('v_database', $v_database);
+$globalsBag->set('v_acl', $v_acl);
+$globalsBag->set('v_js_includes', $v_js_includes);
 
 ini_set('default_charset', 'utf-8');
 $HTML_CHARSET = "UTF-8";

--- a/library/classes/Installer.class.php
+++ b/library/classes/Installer.class.php
@@ -22,6 +22,7 @@ use OpenEMR\Common\Command\RootCliGuard;
 use OpenEMR\Common\Crypto\KeyVersion;
 use OpenEMR\Common\Crypto\PasswordBasedCrypto;
 use OpenEMR\Common\Installer\InstallerInterface;
+use OpenEMR\Core\VersionFile;
 use OpenEMR\Gacl\GaclApi;
 use Psr\Log\LoggerInterface;
 
@@ -551,27 +552,15 @@ class Installer implements InstallerInterface
      */
     public function add_version_info(): bool
     {
-        include __DIR__ . "/../../version.php";
-        /**
-         * This annotation declares variables from the legacy include
-         * so PHPStan recognizes them.
-         *
-         * @var string $v_major
-         * @var string $v_minor
-         * @var string $v_patch
-         * @var string $v_realpatch
-         * @var string $v_tag
-         * @var string $v_database
-         * @var string $v_acl
-         */
+        $version = VersionFile::load(dirname(__DIR__, 2));
         $version_fields = array_map($this->escapeSql(...), [
-            'v_major' => $v_major,
-            'v_minor' => $v_minor,
-            'v_patch' => $v_patch,
-            'v_realpatch' => $v_realpatch,
-            'v_tag' => $v_tag,
-            'v_database' => $v_database,
-            'v_acl' => $v_acl
+            'v_major' => $version->major,
+            'v_minor' => $version->minor,
+            'v_patch' => $version->patch,
+            'v_realpatch' => $version->realpatch,
+            'v_tag' => $version->tag,
+            'v_database' => (string) $version->database,
+            'v_acl' => (string) $version->acl
         ]);
         $update_parts = array_map(fn($field): string => sprintf("%s = '%s'", $field, $version_fields[$field]), array_keys($version_fields));
 

--- a/src/Core/VersionFile.php
+++ b/src/Core/VersionFile.php
@@ -80,13 +80,14 @@ final readonly class VersionFile
             throw new \RuntimeException('Version file not found: ' . $path);
         }
 
-        $collect = static function () use ($path): array {
+        $collect = static function (string $path): array {
             require $path;
+            // Drop the parameter so only what version.php declared is returned.
             unset($path);
             return get_defined_vars();
         };
 
-        return $collect();
+        return $collect($path);
     }
 
     /**

--- a/src/Core/VersionFile.php
+++ b/src/Core/VersionFile.php
@@ -1,0 +1,141 @@
+<?php
+
+/**
+ * VersionFile - the values declared by the project's version.php
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Core;
+
+/**
+ * version.php assigns its values to variables in whatever scope includes it,
+ * which makes every reader dependent on being the first to include it: a
+ * require_once is a no-op once another entry point (admin.php, the installer)
+ * has run it, and the variables are then simply absent. This value object is
+ * the scope-independent way to read those values.
+ *
+ * Each load re-evaluates version.php. In a dev environment that means a fresh
+ * cache-busting token for {@see self::$jsIncludes} every time, so bootstrap
+ * loads once and publishes the result; callers should read the published
+ * values rather than loading again.
+ */
+final readonly class VersionFile
+{
+    public function __construct(
+        public string $major,
+        public string $minor,
+        public string $patch,
+        public string $tag,
+        public string $realpatch,
+        public int $database,
+        public int $acl,
+        public int|string $jsIncludes,
+    ) {
+    }
+
+    /**
+     * Read the version.php at the root of an OpenEMR project directory.
+     */
+    public static function load(string $projectDir): self
+    {
+        return self::fromFile($projectDir . '/version.php');
+    }
+
+    public static function fromFile(string $path): self
+    {
+        $values = self::evaluate($path);
+
+        return new self(
+            major: self::stringValue($values, 'v_major', $path),
+            minor: self::stringValue($values, 'v_minor', $path),
+            patch: self::stringValue($values, 'v_patch', $path),
+            tag: self::stringValue($values, 'v_tag', $path),
+            realpatch: self::stringValue($values, 'v_realpatch', $path),
+            database: self::intValue($values, 'v_database', $path),
+            acl: self::intValue($values, 'v_acl', $path),
+            jsIncludes: self::scalarValue($values, 'v_js_includes', $path),
+        );
+    }
+
+    /**
+     * Evaluate the version file in an isolated scope and collect what it declared.
+     *
+     * The plain require is deliberate. require_once would yield nothing at all
+     * whenever some other bootstrap path had already included the file, which
+     * is the failure this class exists to prevent. Re-evaluating is safe:
+     * version.php only assigns variables.
+     *
+     * @return array<string, mixed>
+     */
+    private static function evaluate(string $path): array
+    {
+        if (!is_file($path)) {
+            throw new \RuntimeException('Version file not found: ' . $path);
+        }
+
+        $collect = static function () use ($path): array {
+            require $path;
+            unset($path);
+            return get_defined_vars();
+        };
+
+        return $collect();
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private static function stringValue(array $values, string $name, string $path): string
+    {
+        $value = $values[$name] ?? null;
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_int($value)) {
+            return (string) $value;
+        }
+
+        throw self::invalid($name, $path);
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private static function intValue(array $values, string $name, string $path): int
+    {
+        $value = $values[$name] ?? null;
+        if (is_int($value)) {
+            return $value;
+        }
+        if (is_string($value) && ctype_digit($value)) {
+            return (int) $value;
+        }
+
+        throw self::invalid($name, $path);
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private static function scalarValue(array $values, string $name, string $path): int|string
+    {
+        $value = $values[$name] ?? null;
+        if (is_int($value) || is_string($value)) {
+            return $value;
+        }
+
+        throw self::invalid($name, $path);
+    }
+
+    private static function invalid(string $name, string $path): \RuntimeException
+    {
+        return new \RuntimeException(sprintf('%s does not declare a usable $%s', $path, $name));
+    }
+}

--- a/tests/Tests/Isolated/Core/VersionFileTest.php
+++ b/tests/Tests/Isolated/Core/VersionFileTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Core;
+
+use OpenEMR\Core\VersionFile;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class VersionFileTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/version_file_test_' . uniqid('', true);
+        if (!mkdir($this->tempDir, 0700, true) && !is_dir($this->tempDir)) {
+            // @codeCoverageIgnoreStart
+            // Defensive - only fires if the OS refuses to create a fresh
+            // temp directory, which is not a path real CI exercises.
+            $this->fail('could not create temp dir ' . $this->tempDir);
+            // @codeCoverageIgnoreEnd
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $file = $this->tempDir . '/version.php';
+        if (is_file($file)) {
+            unlink($file);
+        }
+        if (is_dir($this->tempDir)) {
+            rmdir($this->tempDir);
+        }
+    }
+
+    private function writeVersionFile(string $body): string
+    {
+        $path = $this->tempDir . '/version.php';
+        file_put_contents($path, '<?php' . PHP_EOL . PHP_EOL . $body);
+        return $path;
+    }
+
+    /**
+     * The values version.php declares survive a prior inclusion elsewhere.
+     *
+     * This is the regression: interface/globals.php used to read the $v_*
+     * variables a require_once left in its own scope, and a require_once is a
+     * no-op once any other entry point has included the file.
+     */
+    #[Test]
+    public function readsValuesEvenWhenTheFileWasAlreadyIncluded(): void
+    {
+        $path = $this->writeVersionFile(<<<'PHP'
+        $v_major = '8';
+        $v_minor = '4';
+        $v_patch = '0';
+        $v_tag = '-dev';
+        $v_realpatch = '0';
+        $v_database = 543;
+        $v_acl = 13;
+        $v_js_includes = 82;
+        PHP);
+
+        // Consume the one-shot inclusion the way admin.php does.
+        require_once $path;
+
+        $version = VersionFile::fromFile($path);
+
+        $this->assertSame('8', $version->major);
+        $this->assertSame('4', $version->minor);
+        $this->assertSame('0', $version->patch);
+        $this->assertSame('-dev', $version->tag);
+        $this->assertSame('0', $version->realpatch);
+        $this->assertSame(543, $version->database);
+        $this->assertSame(13, $version->acl);
+        $this->assertSame(82, $version->jsIncludes);
+    }
+
+    #[Test]
+    public function loadResolvesVersionPhpUnderTheProjectDirectory(): void
+    {
+        $this->writeVersionFile(<<<'PHP'
+        $v_major = '7';
+        $v_minor = '0';
+        $v_patch = '3';
+        $v_tag = '';
+        $v_realpatch = '2';
+        $v_database = 500;
+        $v_acl = 10;
+        $v_js_includes = 'ab12cd34';
+        PHP);
+
+        $version = VersionFile::load($this->tempDir);
+
+        $this->assertSame('7', $version->major);
+        $this->assertSame('2', $version->realpatch);
+        $this->assertSame(500, $version->database);
+        $this->assertSame('ab12cd34', $version->jsIncludes);
+    }
+
+    /**
+     * A dev environment computes $v_js_includes as an md5 rather than an int,
+     * and forks are free to quote the numeric values.
+     */
+    #[Test]
+    public function acceptsTheAlternateTypesVersionFilesUseInPractice(): void
+    {
+        $path = $this->writeVersionFile(<<<'PHP'
+        $v_major = 8;
+        $v_minor = '4';
+        $v_patch = '0';
+        $v_tag = '';
+        $v_realpatch = '0';
+        $v_database = '543';
+        $v_acl = '13';
+        $v_js_includes = md5('fixed');
+        PHP);
+
+        $version = VersionFile::fromFile($path);
+
+        $this->assertSame('8', $version->major);
+        $this->assertSame(543, $version->database);
+        $this->assertSame(13, $version->acl);
+        $this->assertSame(md5('fixed'), $version->jsIncludes);
+    }
+
+    #[Test]
+    public function rejectsAMissingFile(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Version file not found');
+
+        VersionFile::load($this->tempDir);
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function unusableValueProvider(): array
+    {
+        return [
+            'missing variable' => ['unset($v_major);', 'v_major'],
+            'null value' => ['$v_major = null;', 'v_major'],
+            'array value' => ['$v_major = [];', 'v_major'],
+            'non-numeric database' => ["\$v_database = 'five';", 'v_database'],
+            'float js includes' => ['$v_js_includes = 1.5;', 'v_js_includes'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('unusableValueProvider')]
+    public function rejectsAnUnusableValue(string $override, string $expectedName): void
+    {
+        $body = <<<'PHP'
+        $v_major = '8';
+        $v_minor = '4';
+        $v_patch = '0';
+        $v_tag = '';
+        $v_realpatch = '0';
+        $v_database = 543;
+        $v_acl = 13;
+        $v_js_includes = 82;
+        PHP;
+        $path = $this->writeVersionFile($body . PHP_EOL . $override);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('does not declare a usable $' . $expectedName);
+
+        VersionFile::fromFile($path);
+    }
+
+    /**
+     * The project's own version.php has to satisfy the reader.
+     */
+    #[Test]
+    public function readsTheProjectVersionFile(): void
+    {
+        $version = VersionFile::load(dirname(__DIR__, 4));
+
+        $this->assertNotSame('', $version->major);
+        $this->assertGreaterThan(0, $version->database);
+        $this->assertGreaterThan(0, $version->acl);
+        $this->assertNotSame('', (string) $version->jsIncludes);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #13826.

`interface/globals.php` read the version numbers from the `$v_*` variables `version.php` leaves in the including scope. `require_once` is a no-op once any other entry point (`admin.php`, the installer) has included that file, so the variables were often undefined and every key landed in the globals bag as `null`.

`null` is worse than absent. `OEGlobalsBag::get()` resolves through `array_key_exists()`, so the key reads as *present* and `getString('v_js_includes', $default)` skips its default and hands `null` to Symfony's `ParameterBag::getString()`, which throws `UnexpectedValueException`. 21 call sites read the key that way, including `interface/main/tabs/main.php`. The same `null` also left the theme URLs built later in `globals.php` with an empty `?v=`.

## Fix

- New `OpenEMR\Core\VersionFile` value object. It evaluates `version.php` in its own scope with a plain `require` — the include-scope and include-once problems both disappear — and parses the result into typed properties, throwing if a value is missing or unusable.
- `globals.php` loads it and publishes the values, so the `$v_*` locals downstream scripts inherit and the eight globals-bag keys are always populated with real values.
- `Installer::add_version_info()` uses it too. That method had its own workaround for the same problem (a bare `include` so `require_once` couldn't swallow it, plus seven `@var` annotations to tell PHPStan what the include declared); both are gone.

Types are preserved exactly as `version.php` declares them — `v_major`…`v_realpatch` stay strings, `v_database`/`v_acl` stay ints — so `sql_upgrade.php`'s `is_string($v_major)` guard and everything else that reads the bag behave as before. `VersionFile` also accepts the variants a version file can legitimately carry: an int `$v_major`, quoted numerics, and the md5 `$v_js_includes` a dev environment computes.

`version.php` itself is untouched: it must stay loadable without the autoloader (`admin.php` includes it bare), and the release-prep mutator rewrites its top-level assignments.

## Test plan

- [x] New `tests/Tests/Isolated/Core/VersionFileTest.php` — 10 tests / 32 assertions, including the regression itself (values still read after the file was already `require_once`d elsewhere), the type variants, and the failure cases
- [x] `composer phpunit-isolated --filter 'VersionFileTest|SoftwareVersionTest|SchemaVersionTest|InstallerTest'` — 137 tests, 692 assertions, green
- [x] `composer phpcs` on the changed files
- [x] `composer phpstan-baseline` — subtractive: `$v_js_includes might not be defined` (6 occurrences in `globals.php`) is now a defined variable, so the entry is gone
