### PR TITLE
chore(deps): bump omnipay/common from 3.4.0 to 3.5.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6390,31 +6390,32 @@
         },
         {
             "name": "omnipay/common",
-            "version": "v3.4.0",
+            "version": "v3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/omnipay-common.git",
-                "reference": "83552de28815c5e46f66360c4d52c3a82a7d5efc"
+                "reference": "cd58a4e7b359b0c5b9748542d422b5cc0d4a692f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/omnipay-common/zipball/83552de28815c5e46f66360c4d52c3a82a7d5efc",
-                "reference": "83552de28815c5e46f66360c4d52c3a82a7d5efc",
+                "url": "https://api.github.com/repos/thephpleague/omnipay-common/zipball/cd58a4e7b359b0c5b9748542d422b5cc0d4a692f",
+                "reference": "cd58a4e7b359b0c5b9748542d422b5cc0d4a692f",
                 "shasum": ""
             },
             "require": {
                 "moneyphp/money": "^3.1|^4.0.3",
-                "php": "^7.2|^8",
+                "php": "^8",
                 "php-http/client-implementation": "^1",
                 "php-http/discovery": "^1.14",
                 "php-http/message": "^1.5",
-                "php-http/message-factory": "^1.1",
-                "symfony/http-foundation": "^2.1|^3|^4|^5|^6|^7"
+                "psr/http-factory": "^1",
+                "symfony/http-foundation": "^2.1|^3|^4|^5|^6|^7|^8"
             },
             "require-dev": {
                 "http-interop/http-factory-guzzle": "^1.1",
                 "omnipay/tests": "^4.1",
                 "php-http/guzzle7-adapter": "^1",
+                "php-http/message-factory": "^1.1",
                 "php-http/mock-client": "^1.6",
                 "squizlabs/php_codesniffer": "^3.8.1"
             },
@@ -6424,7 +6425,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "3.5.x-dev"
                 }
             },
             "autoload": {
@@ -6472,7 +6473,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/omnipay-common/issues",
-                "source": "https://github.com/thephpleague/omnipay-common/tree/v3.4.0"
+                "source": "https://github.com/thephpleague/omnipay-common/tree/v3.5.1"
             },
             "funding": [
                 {
@@ -6480,7 +6481,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-03T09:25:00+00:00"
+            "time": "2026-02-13T11:51:03+00:00"
         },
         {
             "name": "omnipay/stripe",
@@ -7328,61 +7329,6 @@
                 "source": "https://github.com/php-http/message/tree/1.16.2"
             },
             "time": "2024-10-02T11:34:13+00:00"
-        },
-        {
-            "name": "php-http/message-factory",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-http/message-factory.git",
-                "reference": "4d8778e1c7d405cbb471574821c1ff5b68cc8f57"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-http/message-factory/zipball/4d8778e1c7d405cbb471574821c1ff5b68cc8f57",
-                "reference": "4d8778e1c7d405cbb471574821c1ff5b68cc8f57",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com"
-                }
-            ],
-            "description": "Factory interfaces for PSR-7 HTTP Message",
-            "homepage": "http://php-http.org",
-            "keywords": [
-                "factory",
-                "http",
-                "message",
-                "stream",
-                "uri"
-            ],
-            "support": {
-                "issues": "https://github.com/php-http/message-factory/issues",
-                "source": "https://github.com/php-http/message-factory/tree/1.1.0"
-            },
-            "abandoned": "psr/http-factory",
-            "time": "2023-04-14T14:16:17+00:00"
         },
         {
             "name": "php-http/promise",


### PR DESCRIPTION
`composer install` reports six abandoned packages. This removes one of them outright, with no code change.

`omnipay/common` v3.5.0 replaced its `php-http/message-factory` requirement with `psr/http-factory` (thephpleague/omnipay-common#282). `psr/http-factory` is already a direct dependency here, and `php-http/message-factory` had no other dependent in the lock, so bumping `omnipay/common` drops it entirely.

Nothing pinned `omnipay/common` below 3.5 — `league/omnipay`, `omnipay/stripe`, and `academe/omnipay-authorizenetapi` all accept `^3`. It sat at 3.4.0 because it is an indirect dependency, which Dependabot does not bump.

Lock-only change, produced by `composer update omnipay/common`:

```
- Removing php-http/message-factory (1.1.0)
- Upgrading omnipay/common (v3.4.0 => v3.5.1)
```

`composer.json` is untouched. No source file references the `Http\Message\` namespace.

## Remaining abandoned packages

For the record, the other five are not fixable this way:

- **`symfony/inflector`** — pulled by `symfony/property-access` v4.4.44, which is capped by `academe/omnipay-authorizenetapi`'s `^3.2 || ^4.0` constraint. That package has not been touched since July 2022. This also means OpenEMR ships an EOL `symfony/property-access`.
- **`laminas/laminas-config`, `laminas/laminas-loader`** — direct requirements that are genuinely used (the `StandardAutoloader` in every `interface/modules/zend_modules/module/*/Module.php`, plus `ZendModuleRouteLoader`, `XmlExtended`, and `CcdController`). Also pulled transitively by `laminas-modulemanager` and `laminas-http`, so dropping the direct requires would not silence the warnings.
- **`laminas/laminas-json`** — pulled by `laminas-view` 2.x. `laminas-view` 3.x drops it, but `laminas-mvc` 3.8 requires `laminas-view ^2.18`.
- **`yubico/u2flib-server`** — abandoned with no replacement, and still backing U2F MFA. Replacing it means a WebAuthn migration.
