### PR TITLE
fix(dialog): make dlgopen resolvePromiseOn default reachable

### DIFF
--- a/library/dialog.js
+++ b/library/dialog.js
@@ -539,8 +539,7 @@ function dlgopen(url, winname, width, height, forceNewWindow, title, opts) {
         // use is onClosed: fnName ... args not supported however, onClosed: 'reload' is auto defined and requires no function to be created.
         onClosed: false,
         allowExternal: false, // allow a dialog window to a URL that is external to the current url
-        callBack: false, // use {call: 'functionName, args: args, args} if known or use dlgclose.
-        resolvePromiseOn: '' // this may be useful. values are init, shown, show, confirm, alert and close which coincide with dialog events.
+        callBack: false // use {call: 'functionName, args: args, args} if known or use dlgclose.
     };
 
     if (!opts) {
@@ -548,6 +547,9 @@ function dlgopen(url, winname, width, height, forceNewWindow, title, opts) {
     }
     opts = jQuery.extend({}, opts_defaults, opts);
     opts.type = opts.type ? opts.type.toLowerCase() : '';
+    // this may be useful. values are init, shown, show, confirm, alert and close which coincide with dialog events.
+    // Deliberately not in opts_defaults: jQuery.extend would then always supply a value here,
+    // and ?? only falls back on null/undefined, so the 'init' default would never be applied.
     opts.resolvePromiseOn = opts.resolvePromiseOn ?? 'init';
     var mHeight, mWidth, mSize, msSize, dlgContainer, fullURL, where; // a growing list...
 

--- a/tests/js/dialog-resolve-promise.test.js
+++ b/tests/js/dialog-resolve-promise.test.js
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Tests for the promise returned by dlgopen() in library/dialog.js
+ *
+ * Run with: npm run test:js -- tests/js/dialog-resolve-promise.test.js
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const src = fs.readFileSync(
+    path.resolve(__dirname, '../../library/dialog.js'),
+    'utf8'
+);
+
+// Sentinel returned by the timeout arm of a Promise.race, marking a promise
+// that never settled.
+const NEVER_SETTLED = Symbol('never settled');
+
+let dlgopen;
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+
+    const jQuery = require('jquery');
+    global.jQuery = jQuery;
+    global.$ = jQuery;
+    window.jQuery = jQuery;
+
+    // Bootstrap's modal plugin is not available under jsdom. dlgopen only needs
+    // it to exist and to be chainable; the promise is resolved before .modal()
+    // is ever called.
+    jQuery.fn.modal = function () {
+        return this;
+    };
+
+    // Globals dlgopen reads off the top window. Under jsdom, top === window.
+    window.webroot_url = '';
+    window.set_opener = () => {};
+    // Real browsers always define window.opener (null when there is no opener);
+    // jsdom does not, and dialog.js reads it bare at load time.
+    window.opener = null;
+
+    // Supplied by library/js/utility.js on a real page. dialog.js uses it to
+    // lazy-load jQuery and Bootstrap when they are missing.
+    global.includeScript = () => Promise.resolve();
+    window.includeScript = global.includeScript;
+
+    // dialog.js declares dlgopen as a top-level function rather than attaching
+    // it to window, so hand it back out of the loader explicitly.
+    dlgopen = new Function(`${src}\nreturn dlgopen;`)();
+});
+
+describe('dlgopen promise resolution', () => {
+
+    test('resolves when the caller does not pass resolvePromiseOn', async () => {
+        const promise = dlgopen(
+            'about:blank',
+            'defaultResolveDlg',
+            400,
+            300,
+            false,
+            'Default',
+            {type: 'iframe'}
+        );
+
+        // Raced rather than awaited directly: when the default is broken the
+        // promise never settles, and a race reports that as a clear assertion
+        // failure instead of a test-runner timeout.
+        const dialog = await Promise.race([
+            promise,
+            new Promise((resolve) => setTimeout(() => resolve(NEVER_SETTLED), 100)),
+        ]);
+
+        expect(dialog).not.toBe(NEVER_SETTLED);
+    });
+
+    test('resolves when the caller opts into init explicitly', async () => {
+        const dialog = await dlgopen(
+            'about:blank',
+            'explicitInitDlg',
+            400,
+            300,
+            false,
+            'Explicit',
+            {type: 'iframe', resolvePromiseOn: 'init'}
+        );
+
+        expect(dialog).toBeDefined();
+    });
+
+    test('does not resolve on init when the caller selects a later event', async () => {
+        const promise = dlgopen(
+            'about:blank',
+            'closeResolveDlg',
+            400,
+            300,
+            false,
+            'Close',
+            {type: 'iframe', resolvePromiseOn: 'close'}
+        );
+
+        const raced = await Promise.race([
+            promise,
+            new Promise((resolve) => setTimeout(() => resolve(NEVER_SETTLED), 50)),
+        ]);
+
+        expect(raced).toBe(NEVER_SETTLED);
+    });
+});


### PR DESCRIPTION
#### Short description of what this changes or resolves:

`dlgopen()` never applies its documented `resolvePromiseOn` default. Any caller that omits the option gets a promise that never settles, so a chained `.then()` silently never runs.

#### Changes proposed in this pull request:

`opts_defaults` sets `resolvePromiseOn: ''` (`library/dialog.js:543`). `jQuery.extend` therefore always supplies a value, so the fallback three lines down — `opts.resolvePromiseOn = opts.resolvePromiseOn ?? 'init'` — never fires, because `??` only falls back on `null`/`undefined`. The `init` resolver at the end of the promise body is unreachable for every caller that does not pass the option explicitly.

`templates/portal/home.html.twig:303` already passes `resolvePromiseOn: 'init'` explicitly, which would be redundant if the documented default worked.

The fix drops the key from `opts_defaults` so the fallback is reachable, moving the comment that documents the accepted values onto the fallback line. Keeping `??` rather than switching to `||` means a caller that passes `''` deliberately still opts out of promise resolution.

Adds `tests/js/dialog-resolve-promise.test.js` covering three cases: the default resolves, an explicit `resolvePromiseOn: 'init'` resolves, and selecting a later event (`'close'`) does not resolve on init. The first fails on master and passes with this change; the other two pass either way, pinning that explicit opt-ins are unaffected.

#### Was an AI assistant used? Yes
