### PR TITLE
ci(docker): automate Alpine and binary forge pin bumps

### DIFF
--- a/.github/updatecli/alpine-base.pr.md
+++ b/.github/updatecli/alpine-base.pr.md
@@ -1,0 +1,18 @@
+Bumps `ARG ALPINE_VERSION` in `docker/binary/Dockerfile` and `docker/release/Dockerfile` to the newest Alpine 3.x minor line, plus the default documented in the binary image's README.
+
+Opened by `.github/workflows/updatecli-docker-pins.yml` from `.github/updatecli/alpine-base.yaml`. Nothing here merges itself — review the diff and merge when the bump looks right.
+
+#### Why a bot and not Dependabot
+
+Dependabot's docker ecosystem parses literal `FROM alpine:3.24` lines. Every OpenEMR Dockerfile writes `FROM alpine:${ALPINE_VERSION}`, so the entries that covered these files produced no PRs at all (see `docs/docker-migration-from-devops.md`). With nothing watching them, the two pins drifted apart on their own — binary on 3.22, release on 3.24.
+
+#### Scope
+
+- Only `docker/binary` and `docker/release` are targeted. Their `ARG` default *is* the version that ships: neither build passes an `ALPINE_VERSION` build-arg.
+- `docker/flex` is deliberately excluded. Every published flex image overrides `ALPINE_VERSION` from the `docker-build-3XX.yml` matrix, so its default is never the shipped value, and supporting a new Alpine line there means adding a workflow file rather than moving a version string.
+- The pin tracks a minor line (`3.24`), not a patch (`3.24.1`), so rebuilds pick up patch-level security fixes without a code change.
+- Constrained to Alpine 3.x. A major jump is a deliberate migration, not something a scheduled bot should propose.
+
+#### What still needs a human
+
+A minor Alpine bump can move package versions and default toolchains under the image. The Docker test suites on this PR are the evidence that it did not.

--- a/.github/updatecli/alpine-base.yaml
+++ b/.github/updatecli/alpine-base.yaml
@@ -1,0 +1,69 @@
+# Bump the Alpine base pinned by the images whose ARG default is the
+# pin that actually ships.
+#
+# Dependabot cannot see these. Its docker ecosystem parses literal
+# `FROM alpine:3.24` lines; all three OpenEMR Dockerfiles write
+# `FROM alpine:${ALPINE_VERSION}`, so the entries that used to exist for
+# them in openemr-devops produced no PRs at all (see
+# docs/docker-migration-from-devops.md). That inertness is why these pins
+# drift: docker/binary sat on 3.22 while docker/release was on 3.24.
+#
+# docker/flex is deliberately absent. Every published flex image overrides
+# ALPINE_VERSION from the docker-build-3XX.yml matrix, so its ARG default
+# is never the shipped value, and the set of Alpine lines flex supports
+# grows by adding a workflow file — not by moving a version string.
+#
+# See .github/workflows/updatecli-docker-pins.yml.
+
+name: Bump the Alpine base of the binary and release Docker images
+pipelineid: docker-alpine-base
+
+sources:
+  alpineMinor:
+    name: Newest Alpine 3.x minor line
+    kind: dockerimage
+    spec:
+      image: alpine
+      versionfilter:
+        # Constrained to 3.x on purpose: a major Alpine jump is a
+        # deliberate migration, not something a scheduled bot should
+        # propose on its own.
+        kind: semver
+        pattern: '~3'
+    transformers:
+      # The registry's newest semver tag is a patch (3.24.1); the ARGs
+      # pin a minor line (3.24) so image rebuilds pick up patch-level
+      # security fixes without a code change.
+    - findsubmatch:
+        pattern: '^(\d+\.\d+)'
+        captureindex: 1
+
+targets:
+  binaryDockerfile:
+    name: 'docker/binary/Dockerfile: ARG ALPINE_VERSION'
+    kind: dockerfile
+    sourceid: alpineMinor
+    spec:
+      file: docker/binary/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: ALPINE_VERSION
+
+  releaseDockerfile:
+    name: 'docker/release/Dockerfile: ARG ALPINE_VERSION'
+    kind: dockerfile
+    sourceid: alpineMinor
+    spec:
+      file: docker/release/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: ALPINE_VERSION
+
+  binaryReadme:
+    name: 'docker/binary/README.md: documented ALPINE_VERSION default'
+    kind: file
+    sourceid: alpineMinor
+    spec:
+      file: docker/binary/README.md
+      matchpattern: '(`ALPINE_VERSION`: Alpine Linux version \(default: `)[^`]*(`\))'
+      replacepattern: '${1}{{ source "alpineMinor" }}${2}'

--- a/.github/updatecli/binary-image.pr.md
+++ b/.github/updatecli/binary-image.pr.md
@@ -1,0 +1,18 @@
+Bumps `docker/binary` to the newest openemr-static-binary-forge release that the image can actually build against, plus the defaults documented in its README.
+
+Opened by `.github/workflows/updatecli-docker-pins.yml` from `.github/updatecli/binary-image.yaml`. Nothing here merges itself — review the diff and merge when the bump looks right.
+
+#### What was checked before this PR was opened
+
+`tools/release/bin/resolve-binary-forge.php` only reports a pin once all of the following hold, and falls back to the next-newest release (or leaves the pin alone) otherwise:
+
+- Both `linux_amd64` and `linux_arm64` forge releases exist for the same OpenEMR version and build date. A bump on one arch alone would break every build on the other.
+- Each of those releases carries all three assets the Dockerfile downloads: `php-fpm-v<version>-linux-<arch>`, `php-cli-v<version>-linux-<arch>`, and `openemr.phar`.
+- The matching `openemr/openemr` tag exists **and** still has a `tests/` tree. `tests/` is `export-ignore` in `.gitattributes`, which is what broke the v8_3_0 bump when the Dockerfile still fetched tag tarballs.
+- The candidate is newer than the current pin. The forge re-cuts older version lines, and those rebuilds must not drag the image backwards.
+
+The forge's PHP selector (`php85`) is derived from `ARG PHP_VERSION` in the Dockerfile, so a PHP bump retargets the search without any change here.
+
+#### What still needs a human
+
+Whether this OpenEMR version is one the binary image should ship. The checks above establish that it *can* be built, not that it *should* be released.

--- a/.github/updatecli/binary-image.yaml
+++ b/.github/updatecli/binary-image.yaml
@@ -16,9 +16,12 @@
 # The side benefit is that `updatecli diff --config .github/updatecli/` is
 # a working local dry-run with no tokens or scm config.
 #
-# The two sources below resolve independently, because updatecli renders
-# `{{ source }}` from the raw source value and cannot see a target-level
+# The two sources below resolve independently, because a target's source
+# template renders the raw source value and cannot see a target-level
 # transformer — so the README targets need each field as its own source.
+# (Spelling that template out here would break the manifest: updatecli
+# Go-templates the whole file, comments included, so a bare source action
+# in prose fails to load with "wrong number of args".)
 # That leaves a narrow window where a release finishing publication between
 # the two calls could pair one candidate's version with another's date. The
 # workflow closes it after `apply` with `resolve-binary-forge.php --verify`,

--- a/.github/updatecli/binary-image.yaml
+++ b/.github/updatecli/binary-image.yaml
@@ -1,0 +1,85 @@
+# Bump docker/binary's openemr-static-binary-forge pin.
+#
+# The forge publishes one GitHub release per (platform, arch), so "a newer
+# release exists" is not the same question as "we can build against it".
+# tools/release/bin/resolve-binary-forge.php answers the second one: it
+# only reports a pin once both linux arches carry every asset the
+# Dockerfile downloads and the matching openemr/openemr tag still has a
+# tests/ tree. When nothing qualifies it echoes the pin already in the
+# Dockerfile, so every target below is a no-op and no PR is opened.
+#
+# Deliberately no `scms:` / `actions:` block. updatecli's github scm clones
+# into its own working directory, which would have no vendor/ for the
+# resolver to autoload. Instead the workflow checks the repo out, installs
+# dev dependencies, applies these targets in place, and opens the PR with
+# peter-evans/create-pull-request (already this repo's PR-bot of record).
+# The side benefit is that `updatecli diff --config .github/updatecli/` is
+# a working local dry-run with no tokens or scm config.
+#
+# See .github/workflows/updatecli-docker-pins.yml.
+
+name: Bump the binary Docker image to the newest published forge release
+pipelineid: docker-binary-forge
+
+sources:
+  forgeOpenemrVersion:
+    name: OpenEMR version of the newest fully published forge release
+    kind: shell
+    spec:
+      command: php tools/release/bin/resolve-binary-forge.php --field=version --explain
+      environments:
+      - name: PATH
+      - name: HOME
+      - name: GH_TOKEN
+
+  forgeReleaseDate:
+    name: Build date of the newest fully published forge release
+    kind: shell
+    spec:
+      command: php tools/release/bin/resolve-binary-forge.php --field=date
+      environments:
+      - name: PATH
+      - name: HOME
+      - name: GH_TOKEN
+
+targets:
+  dockerfileOpenemrVersion:
+    name: 'docker/binary/Dockerfile: ARG OPENEMR_VERSION'
+    kind: dockerfile
+    sourceid: forgeOpenemrVersion
+    spec:
+      file: docker/binary/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: OPENEMR_VERSION
+
+  dockerfileBinaryReleaseDate:
+    name: 'docker/binary/Dockerfile: ARG BINARY_RELEASE_DATE'
+    kind: dockerfile
+    sourceid: forgeReleaseDate
+    spec:
+      file: docker/binary/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: BINARY_RELEASE_DATE
+
+  # The README's documented defaults had already drifted from the
+  # Dockerfile (it advertised BINARY_RELEASE_DATE 12282025 against an
+  # actual 12292025), so they are targets rather than prose.
+  readmeOpenemrVersion:
+    name: 'docker/binary/README.md: documented OPENEMR_VERSION default'
+    kind: file
+    sourceid: forgeOpenemrVersion
+    spec:
+      file: docker/binary/README.md
+      matchpattern: '(`OPENEMR_VERSION`: OpenEMR version \(default: `)[^`]*(`\))'
+      replacepattern: '${1}{{ source "forgeOpenemrVersion" }}${2}'
+
+  readmeBinaryReleaseDate:
+    name: 'docker/binary/README.md: documented BINARY_RELEASE_DATE default'
+    kind: file
+    sourceid: forgeReleaseDate
+    spec:
+      file: docker/binary/README.md
+      matchpattern: '(`BINARY_RELEASE_DATE`: Release date for binary package \(default: `)[^`]*(`\))'
+      replacepattern: '${1}{{ source "forgeReleaseDate" }}${2}'

--- a/.github/updatecli/binary-image.yaml
+++ b/.github/updatecli/binary-image.yaml
@@ -16,6 +16,15 @@
 # The side benefit is that `updatecli diff --config .github/updatecli/` is
 # a working local dry-run with no tokens or scm config.
 #
+# The two sources below resolve independently, because updatecli renders
+# `{{ source }}` from the raw source value and cannot see a target-level
+# transformer — so the README targets need each field as its own source.
+# That leaves a narrow window where a release finishing publication between
+# the two calls could pair one candidate's version with another's date. The
+# workflow closes it after `apply` with `resolve-binary-forge.php --verify`,
+# a post-condition on the file as written: unless that exact pin is fully
+# published, no PR is opened.
+#
 # See .github/workflows/updatecli-docker-pins.yml.
 
 name: Bump the binary Docker image to the newest published forge release

--- a/.github/workflows/updatecli-docker-pins.yml
+++ b/.github/workflows/updatecli-docker-pins.yml
@@ -102,13 +102,11 @@ jobs:
       with:
         php-version: ${{ matrix.php-version }}
 
-    # Deliberately unpinned. No dependency manager covers this action's
-    # `version` input or a .updatecli-version file, so a pin here would rot
-    # unnoticed. Floating means a breaking updatecli release surfaces as a
-    # loud failure in this run and on the next manifest PR, rather than as
-    # a pin nobody remembers to bump.
+    # Pinned to an exact tag because updatecli/updatecli-action publishes no
+    # floating major alias — `@v3` does not resolve, only `@v3.6.0` and its
+    # siblings. Dependabot's github-actions ecosystem keeps this current.
     - name: Install updatecli
-      uses: updatecli/updatecli-action@v3
+      uses: updatecli/updatecli-action@v3.6.0
 
     - name: Resolve pins
       env:

--- a/.github/workflows/updatecli-docker-pins.yml
+++ b/.github/workflows/updatecli-docker-pins.yml
@@ -136,6 +136,19 @@ jobs:
         MANIFEST: ${{ matrix.manifest }}
       run: updatecli pipeline apply --config ".github/updatecli/${MANIFEST}.yaml"
 
+    # Post-condition on the file updatecli just wrote. The manifest's two
+    # forge sources resolve independently, so a release finishing
+    # publication between them could in principle pair one candidate's
+    # version with another's date — a combination no resolver run ever
+    # validated. This re-reads the applied pin and refuses to open a PR
+    # unless that exact pin is fully published, which also catches a bad
+    # matcher or a hand edit rather than only the race.
+    - name: Verify the applied forge pin
+      if: matrix.manifest == 'binary-image' && github.event_name != 'pull_request' && github.event.inputs.dry-run != 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: php tools/release/bin/resolve-binary-forge.php --verify
+
     # No-op when `apply` changed nothing, so an up-to-date pin costs a
     # green run and no PR. When a PR is already open on this branch it is
     # updated in place rather than duplicated.

--- a/.github/workflows/updatecli-docker-pins.yml
+++ b/.github/workflows/updatecli-docker-pins.yml
@@ -1,0 +1,159 @@
+# Propose bumps for the Docker pins nothing else watches.
+#
+# Two classes of pin in docker/ have no automated bumper today:
+#
+#   1. `ARG ALPINE_VERSION=` in docker/binary and docker/release. Dependabot's
+#      docker ecosystem parses literal `FROM alpine:3.24` lines and these
+#      Dockerfiles all write `FROM alpine:${ALPINE_VERSION}`, so the devops
+#      dependabot entries that covered them generated zero PRs (see
+#      docs/docker-migration-from-devops.md). docker/binary sat on 3.22
+#      while docker/release moved to 3.24.
+#   2. `ARG OPENEMR_VERSION=` / `ARG BINARY_RELEASE_DATE=` in docker/binary,
+#      which point at an openemr-static-binary-forge release. No dependency
+#      manager models this at all: the forge publishes one GitHub release
+#      per (platform, arch), so a bump is only safe once BOTH linux arches
+#      carry every asset the Dockerfile downloads and the matching
+#      openemr/openemr tag still has a tests/ tree.
+#
+# The manifests in .github/updatecli/ describe both. Everything that has to
+# reason about half-published forge state lives in
+# tools/release/bin/resolve-binary-forge.php, under test in
+# tests/Tests/Isolated/Release/BinaryForgeResolverTest.php, so the failure
+# modes are falsifiable without waiting for a scheduled run.
+#
+# Propose-only by design: this workflow never merges. It opens (or updates)
+# one long-lived PR per manifest for a human to review, which is the whole
+# reason a bot can be trusted with a base-image pin at all.
+#
+# On pull_request it stops after `updatecli pipeline diff`. That resolves
+# every source and prints the changes it would make without writing any —
+# enough to catch a typo'd matcher or a manifest that no longer resolves,
+# before it lands and starts failing silently on a schedule.
+
+name: Bump Docker image pins
+
+on:
+  schedule:
+  # Weekly. Forge releases land a handful of times a year, so a daily
+  # tick would just re-resolve the same pin; workflow_dispatch covers
+  # "a release just dropped and I want the PR now".
+  - cron: '17 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Resolve and print the diff without opening a PR
+        type: boolean
+        default: false
+  pull_request:
+    branches: [master]
+    paths:
+    - .github/updatecli/**
+    - .github/workflows/updatecli-docker-pins.yml
+    - docker/binary/Dockerfile
+    - docker/binary/README.md
+    - docker/release/Dockerfile
+    - tools/release/bin/resolve-binary-forge.php
+    - tools/release/src/BinaryForge*.php
+
+permissions: {}
+
+concurrency:
+  group: updatecli-docker-pins-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  pins:
+    name: ${{ matrix.manifest }} (PHP ${{ matrix.php-version }})
+    if: github.repository == 'openemr/openemr'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    strategy:
+      # One manifest failing to resolve says nothing about the other, and
+      # a half-run schedule would silently skip a pending bump.
+      fail-fast: false
+      matrix:
+        # Bump tooling runs only on CI runners, never on a customer
+        # deployment, so it tracks the latest stable PHP rather than the
+        # openemr application floor (same rationale as
+        # notify-release-targets-changed.yml).
+        php-version:
+        - '8.5'
+        manifest:
+        - alpine-base
+        - binary-image
+        include:
+        - manifest: alpine-base
+          title: 'chore(docker): bump Alpine base for the binary and release images'
+        - manifest: binary-image
+          title: 'chore(docker): bump binary image to the latest OpenEMR forge release'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+
+    # The binary-image manifest shells out to a script in tools/release/,
+    # whose classes are autoload-dev. This is also why the manifests carry
+    # no `scms:` block: updatecli's github scm would resolve sources inside
+    # its own bare clone, which has no vendor/.
+    - name: Setup PHP and Composer
+      uses: ./.github/actions/setup-php-composer
+      with:
+        php-version: ${{ matrix.php-version }}
+
+    # Deliberately unpinned. No dependency manager covers this action's
+    # `version` input or a .updatecli-version file, so a pin here would rot
+    # unnoticed. Floating means a breaking updatecli release surfaces as a
+    # loud failure in this run and on the next manifest PR, rather than as
+    # a pin nobody remembers to bump.
+    - name: Install updatecli
+      uses: updatecli/updatecli-action@v3
+
+    - name: Resolve pins
+      env:
+        # The resolver reads public releases from the forge and the tests/
+        # tree from openemr/openemr; read scope is all it needs.
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MANIFEST: ${{ matrix.manifest }}
+      run: updatecli pipeline diff --config ".github/updatecli/${MANIFEST}.yaml"
+
+    - name: Mint App token
+      id: app-token
+      if: github.event_name != 'pull_request' && github.event.inputs.dry-run != 'true'
+      uses: ./.github/actions/generate-app-token
+      with:
+        client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+        private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+        # An App token rather than GITHUB_TOKEN so the resulting PR
+        # triggers CI — a bump PR whose checks never run is worse than no
+        # bump PR, because it looks reviewed.
+        permission-contents: write
+        permission-pull-requests: write
+
+    - name: Apply pins
+      if: github.event_name != 'pull_request' && github.event.inputs.dry-run != 'true'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MANIFEST: ${{ matrix.manifest }}
+      run: updatecli pipeline apply --config ".github/updatecli/${MANIFEST}.yaml"
+
+    # No-op when `apply` changed nothing, so an up-to-date pin costs a
+    # green run and no PR. When a PR is already open on this branch it is
+    # updated in place rather than duplicated.
+    - name: Open or update the bump PR
+      if: github.event_name != 'pull_request' && github.event.inputs.dry-run != 'true'
+      uses: peter-evans/create-pull-request@v8
+      with:
+        token: ${{ steps.app-token.outputs.token }}
+        branch: updatecli/${{ matrix.manifest }}
+        base: master
+        title: ${{ matrix.title }}
+        body-path: .github/updatecli/${{ matrix.manifest }}.pr.md
+        commit-message: ${{ matrix.title }}
+        labels: |
+          dependencies
+          docker
+        author: 'openemr-release-bot <release-bot@openemr.invalid>'
+        committer: 'openemr-release-bot <release-bot@openemr.invalid>'
+        delete-branch: false

--- a/docker/binary/README.md
+++ b/docker/binary/README.md
@@ -25,11 +25,22 @@ docker build -t openemr-binary:latest .
 ### Build Arguments
 
 - `OPENEMR_VERSION`: OpenEMR version (default: `7_0_4`)
-- `BINARY_RELEASE_DATE`: Release date for binary package (default: `12282025`)
+- `BINARY_RELEASE_DATE`: Release date for binary package (default: `12292025`)
 - `PHP_VERSION`: PHP version used in binaries (default: `8.5`)
 - `ALPINE_VERSION`: Alpine Linux version (default: `3.22`)
 
-Example:
+`OPENEMR_VERSION`, `BINARY_RELEASE_DATE`, and `ALPINE_VERSION` are maintained
+by `.github/workflows/updatecli-docker-pins.yml`, which opens a pull request
+when a newer Alpine minor or a fully published
+[openemr-static-binary-forge](https://github.com/Jmevorach/openemr-static-binary-forge)
+release becomes available. The defaults listed above are updated in the same
+pull request, so this list and the `ARG` lines cannot drift apart. Merging is
+always a human decision; see `.github/updatecli/binary-image.yaml` for what the
+bot verifies before proposing a forge bump.
+
+Override any of them to build an older combination — for example the
+December 2025 forge release:
+
 ```bash
 docker build \
   --build-arg OPENEMR_VERSION=7_0_4 \

--- a/tests/Tests/Isolated/Release/BinaryForgePinReaderTest.php
+++ b/tests/Tests/Isolated/Release/BinaryForgePinReaderTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Release;
+
+use OpenEMR\Release\BinaryForgePinReader;
+use PHPUnit\Framework\TestCase;
+
+final class BinaryForgePinReaderTest extends TestCase
+{
+    private string $dockerfile = '';
+
+    protected function tearDown(): void
+    {
+        if ($this->dockerfile !== '' && file_exists($this->dockerfile)) {
+            unlink($this->dockerfile);
+        }
+        parent::tearDown();
+    }
+
+    public function testReadsThePinsFromArgDefaults(): void
+    {
+        $path = $this->writeDockerfile(<<<'DOCKERFILE'
+        # syntax=docker/dockerfile:1
+        ARG ALPINE_VERSION=3.24
+        FROM alpine:${ALPINE_VERSION} AS base
+
+        ARG OPENEMR_VERSION=8_3_0
+        ARG BINARY_RELEASE_DATE=08232026
+        ARG PHP_VERSION=8.5
+        ENV OPENEMR_VERSION=${OPENEMR_VERSION}
+        DOCKERFILE);
+
+        $pin = (new BinaryForgePinReader($path))->read();
+
+        self::assertSame('8_3_0', $pin->openemrVersion);
+        self::assertSame('08232026', $pin->releaseDate);
+        self::assertSame('8.5', $pin->phpVersion);
+    }
+
+    /**
+     * `ENV OPENEMR_VERSION=${OPENEMR_VERSION}` sits two lines below the
+     * ARG in the real Dockerfile. Anchoring on `ARG` keeps the reader off
+     * the interpolated ENV line, which would parse as the literal
+     * `${OPENEMR_VERSION}`.
+     */
+    public function testIgnoresTheEnvLineThatMirrorsTheArg(): void
+    {
+        $path = $this->writeDockerfile(<<<'DOCKERFILE'
+        ENV OPENEMR_VERSION=${OPENEMR_VERSION}
+        ARG OPENEMR_VERSION=8_3_0
+        ARG BINARY_RELEASE_DATE=08232026
+        ARG PHP_VERSION=8.5
+        DOCKERFILE);
+
+        self::assertSame('8_3_0', (new BinaryForgePinReader($path))->read()->openemrVersion);
+    }
+
+    public function testFailsLoudlyWhenAnArgIsMissing(): void
+    {
+        $path = $this->writeDockerfile(<<<'DOCKERFILE'
+        ARG OPENEMR_VERSION=8_3_0
+        ARG PHP_VERSION=8.5
+        DOCKERFILE);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('BINARY_RELEASE_DATE');
+
+        (new BinaryForgePinReader($path))->read();
+    }
+
+    public function testFailsLoudlyWhenTheDockerfileIsMissing(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot read Dockerfile');
+
+        (new BinaryForgePinReader(sys_get_temp_dir() . '/no-such-dockerfile'))->read();
+    }
+
+    /**
+     * The reader is the tooling's view of the real file, so a rename or
+     * reformat of the shipped ARG block has to fail here rather than in a
+     * scheduled bot run nobody is watching.
+     */
+    public function testReadsTheShippedBinaryDockerfile(): void
+    {
+        $repoRoot = dirname(__DIR__, 4);
+        $pin = (new BinaryForgePinReader($repoRoot . '/' . BinaryForgePinReader::DEFAULT_DOCKERFILE))->read();
+
+        self::assertMatchesRegularExpression('/^php\d+$/', $pin->phpSelector());
+    }
+
+    private function writeDockerfile(string $contents): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'binary-forge-dockerfile');
+        self::assertIsString($path);
+        file_put_contents($path, $contents . "\n");
+        $this->dockerfile = $path;
+
+        return $path;
+    }
+}

--- a/tests/Tests/Isolated/Release/BinaryForgePinTest.php
+++ b/tests/Tests/Isolated/Release/BinaryForgePinTest.php
@@ -68,6 +68,52 @@ final class BinaryForgePinTest extends TestCase
         self::assertGreaterThan($december2025, $march2026);
     }
 
+    public function testDottedVersionFeedsVersionCompare(): void
+    {
+        self::assertSame('7.0.3.4', (new BinaryForgePin('7_0_3_4', '12072025', '8.5'))->dottedVersion());
+    }
+
+    /**
+     * The case that matters: a re-cut of an older line carrying a build
+     * date *later* than the current pin. Comparing dates alone accepts it
+     * and walks the image backwards.
+     */
+    public function testARecutOfAnOlderLineNeverSupersedes(): void
+    {
+        $current = new BinaryForgePin('8_0_0', '03102026', '8.5');
+        $olderLineRebuiltLater = new BinaryForgePin('7_0_4', '09012026', '8.5');
+
+        self::assertFalse($current->isSupersededBy($olderLineRebuiltLater));
+    }
+
+    public function testANewerVersionSupersedesEvenWithAnEarlierBuildDate(): void
+    {
+        $current = new BinaryForgePin('8_0_0', '03102026', '8.5');
+        $newerLineBuiltEarlier = new BinaryForgePin('8_3_0', '01052026', '8.5');
+
+        self::assertTrue($current->isSupersededBy($newerLineBuiltEarlier));
+    }
+
+    public function testALaterRebuildOfTheSameVersionSupersedes(): void
+    {
+        $current = new BinaryForgePin('7_0_4', '12282025', '8.5');
+
+        self::assertTrue($current->isSupersededBy(new BinaryForgePin('7_0_4', '12292025', '8.5')));
+        self::assertFalse($current->isSupersededBy(new BinaryForgePin('7_0_4', '12262025', '8.5')));
+        self::assertFalse($current->isSupersededBy(new BinaryForgePin('7_0_4', '12282025', '8.5')));
+    }
+
+    /**
+     * A four-segment patch line sorts below the three-segment release it
+     * patches from, so `7_0_3_4` must not look newer than `7_0_4`.
+     */
+    public function testPatchLineSegmentsCompareNumericallyNotLexically(): void
+    {
+        $current = new BinaryForgePin('7_0_4', '12292025', '8.5');
+
+        self::assertFalse($current->isSupersededBy(new BinaryForgePin('7_0_3_4', '09012026', '8.5')));
+    }
+
     public function testStringFormIsTheUpdatecliWireFormat(): void
     {
         self::assertSame('8_3_0/08232026', (string)new BinaryForgePin('8_3_0', '08232026', '8.5'));

--- a/tests/Tests/Isolated/Release/BinaryForgePinTest.php
+++ b/tests/Tests/Isolated/Release/BinaryForgePinTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Release;
+
+use OpenEMR\Release\BinaryForgePin;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Locks the forge naming scheme down. Every string this class builds is
+ * pasted into a download URL by docker/binary/Dockerfile, so a silent
+ * change here shows up as a build-time 404 rather than a test failure —
+ * hence the literal expectations copied from a real forge release.
+ */
+final class BinaryForgePinTest extends TestCase
+{
+    public function testDerivesThePhpSelectorTheDockerfileWay(): void
+    {
+        self::assertSame('php85', (new BinaryForgePin('8_3_0', '08232026', '8.5'))->phpSelector());
+        self::assertSame('php84', (new BinaryForgePin('8_3_0', '08232026', '8.4'))->phpSelector());
+    }
+
+    public function testBuildsTheForgeReleaseTagForEachArch(): void
+    {
+        $pin = new BinaryForgePin('8_3_0', '08232026', '8.5');
+
+        self::assertSame('linux_amd64-php85-openemr-v8_3_0-amd64-08232026', $pin->forgeTag('amd64'));
+        self::assertSame('linux_arm64-php85-openemr-v8_3_0-arm64-08232026', $pin->forgeTag('arm64'));
+    }
+
+    public function testRequiredAssetsMatchTheDockerfileDownloads(): void
+    {
+        $pin = new BinaryForgePin('8_3_0', '08232026', '8.5');
+
+        self::assertSame(
+            ['php-fpm-v8_3_0-linux-arm64', 'php-cli-v8_3_0-linux-arm64', 'openemr.phar'],
+            $pin->requiredAssets('arm64'),
+        );
+    }
+
+    public function testOpenemrTagPrefixesTheVersion(): void
+    {
+        self::assertSame('v7_0_3_4', (new BinaryForgePin('7_0_3_4', '12072025', '8.5'))->openemrTag());
+    }
+
+    /**
+     * The whole point of the reordering: MMDDYYYY sorts December 2025
+     * above March 2026 as a plain string, which would let a re-cut of an
+     * older line look newer than the current pin.
+     */
+    public function testChronologicalDateOrdersAcrossYearBoundaries(): void
+    {
+        $december2025 = (new BinaryForgePin('7_0_4', '12292025', '8.5'))->chronologicalDate();
+        $march2026 = (new BinaryForgePin('8_0_0', '03102026', '8.5'))->chronologicalDate();
+
+        self::assertSame('20251229', $december2025);
+        self::assertSame('20260310', $march2026);
+        self::assertGreaterThan($december2025, $march2026);
+    }
+
+    public function testStringFormIsTheUpdatecliWireFormat(): void
+    {
+        self::assertSame('8_3_0/08232026', (string)new BinaryForgePin('8_3_0', '08232026', '8.5'));
+    }
+
+    #[DataProvider('malformedPinProvider')]
+    public function testRejectsMalformedPins(string $version, string $date, string $php): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new BinaryForgePin($version, $date, $php);
+    }
+
+    /**
+     * @return array<string, array{string, string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function malformedPinProvider(): array
+    {
+        return [
+            'dotted version' => ['8.3.0', '08232026', '8.5'],
+            'single-segment version' => ['8', '08232026', '8.5'],
+            'v-prefixed version' => ['v8_3_0', '08232026', '8.5'],
+            'short date' => ['8_3_0', '0823206', '8.5'],
+            'dashed date' => ['8_3_0', '2026-08-23', '8.5'],
+            'underscored php version' => ['8_3_0', '08232026', '8_5'],
+            'three-segment php version' => ['8_3_0', '08232026', '8.5.1'],
+        ];
+    }
+}

--- a/tests/Tests/Isolated/Release/BinaryForgeResolverTest.php
+++ b/tests/Tests/Isolated/Release/BinaryForgeResolverTest.php
@@ -112,6 +112,94 @@ final class BinaryForgeResolverTest extends TestCase
         self::assertSame([], $openemr->existenceChecks, 'an older release should not cost an API call');
     }
 
+    /**
+     * The date-only guard let this through: a fully published v7_0_4
+     * re-cut stamped after the current v8_0_0 pin looked newer and would
+     * have been proposed as an upgrade.
+     */
+    public function testNeverDowngradesToARecutStampedAfterTheCurrentPin(): void
+    {
+        $resolved = $this->resolve(
+            [
+                self::linuxRelease('amd64', '7_0_4', '09012026'),
+                self::linuxRelease('arm64', '7_0_4', '09012026'),
+            ],
+            ['/contents/tests?ref=v7_0_4'],
+        );
+
+        self::assertSame('8_0_0/03102026', (string)$resolved);
+    }
+
+    public function testPrefersTheHigherVersionOverTheLaterBuildDate(): void
+    {
+        $resolved = $this->resolve(
+            [
+                self::linuxRelease('amd64', '8_1_0', '09012026'),
+                self::linuxRelease('arm64', '8_1_0', '09012026'),
+                self::linuxRelease('amd64', '8_3_0', '08232026'),
+                self::linuxRelease('arm64', '8_3_0', '08232026'),
+            ],
+            ['/contents/tests?ref=v8_1_0', '/contents/tests?ref=v8_3_0'],
+        );
+
+        self::assertSame('8_3_0/08232026', (string)$resolved);
+    }
+
+    public function testAdoptsALaterRebuildOfTheCurrentVersion(): void
+    {
+        $forge = new FakeGitHubApi([
+            self::linuxRelease('amd64', '8_0_0', '09012026'),
+            self::linuxRelease('arm64', '8_0_0', '09012026'),
+        ]);
+        $openemr = new FakeGitHubApi([], ['/contents/tests?ref=v8_0_0']);
+
+        $resolved = (new BinaryForgeResolver($forge, $openemr))->resolve($this->currentPin());
+
+        self::assertSame('8_0_0/09012026', (string)$resolved);
+    }
+
+    public function testIsPublishedConfirmsAPinThatIsFullyOnTheForge(): void
+    {
+        $forge = new FakeGitHubApi([
+            self::linuxRelease('amd64', '8_3_0', '08232026'),
+            self::linuxRelease('arm64', '8_3_0', '08232026'),
+        ]);
+        $openemr = new FakeGitHubApi([], ['/contents/tests?ref=v8_3_0']);
+
+        $resolver = new BinaryForgeResolver($forge, $openemr);
+
+        self::assertTrue($resolver->isPublished(new BinaryForgePin('8_3_0', '08232026', '8.5')));
+    }
+
+    /**
+     * The shape the `--verify` guard exists for: a version and a date that
+     * each came from a real release, paired into one that never existed.
+     */
+    public function testIsPublishedRejectsAPinStitchedFromTwoReleases(): void
+    {
+        $forge = new FakeGitHubApi([
+            self::linuxRelease('amd64', '8_3_0', '08232026'),
+            self::linuxRelease('arm64', '8_3_0', '08232026'),
+            self::linuxRelease('amd64', '8_4_0', '09152026'),
+            self::linuxRelease('arm64', '8_4_0', '09152026'),
+        ]);
+        $openemr = new FakeGitHubApi([], ['/contents/tests?ref=v8_3_0', '/contents/tests?ref=v8_4_0']);
+
+        $resolver = new BinaryForgeResolver($forge, $openemr);
+
+        self::assertFalse($resolver->isPublished(new BinaryForgePin('8_3_0', '09152026', '8.5')));
+    }
+
+    public function testIsPublishedRejectsAPinMissingAnArch(): void
+    {
+        $forge = new FakeGitHubApi([self::linuxRelease('amd64', '8_3_0', '08232026')]);
+        $openemr = new FakeGitHubApi([], ['/contents/tests?ref=v8_3_0']);
+
+        $resolver = new BinaryForgeResolver($forge, $openemr);
+
+        self::assertFalse($resolver->isPublished(new BinaryForgePin('8_3_0', '08232026', '8.5')));
+    }
+
     public function testIgnoresOtherPhpSelectors(): void
     {
         $php84 = new BinaryForgePin('8_3_0', '08232026', '8.4');

--- a/tests/Tests/Isolated/Release/BinaryForgeResolverTest.php
+++ b/tests/Tests/Isolated/Release/BinaryForgeResolverTest.php
@@ -1,0 +1,223 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Release;
+
+use OpenEMR\Release\BinaryForgePin;
+use OpenEMR\Release\BinaryForgeResolver;
+use OpenEMR\Tests\Isolated\Release\Fakes\FakeGitHubApi;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Each holding test below is a half-published forge state that a naive
+ * "latest release wins" bump would have adopted, and that would then have
+ * failed the multi-arch image build. The resolver's contract is that every
+ * one of them resolves to the current pin instead.
+ */
+final class BinaryForgeResolverTest extends TestCase
+{
+    private const CURRENT = ['8_0_0', '03102026', '8.5'];
+
+    public function testBumpsWhenBothArchesAreFullyPublished(): void
+    {
+        $resolved = $this->resolve(
+            [
+                self::linuxRelease('amd64', '8_3_0', '08232026'),
+                self::linuxRelease('arm64', '8_3_0', '08232026'),
+            ],
+            ['/contents/tests?ref=v8_3_0'],
+        );
+
+        self::assertSame('8_3_0/08232026', (string)$resolved);
+    }
+
+    public function testHoldsWhenOnlyOneArchIsPublished(): void
+    {
+        $resolved = $this->resolve(
+            [self::linuxRelease('amd64', '8_3_0', '08232026')],
+            ['/contents/tests?ref=v8_3_0'],
+        );
+
+        self::assertSame('8_0_0/03102026', (string)$resolved);
+    }
+
+    public function testHoldsWhenAnArchIsMissingAnAsset(): void
+    {
+        $resolved = $this->resolve(
+            [
+                self::linuxRelease('amd64', '8_3_0', '08232026'),
+                self::linuxRelease('arm64', '8_3_0', '08232026', [
+                    'php-fpm-v8_3_0-linux-arm64',
+                    'openemr.phar',
+                ]),
+            ],
+            ['/contents/tests?ref=v8_3_0'],
+        );
+
+        self::assertSame('8_0_0/03102026', (string)$resolved);
+    }
+
+    public function testHoldsWhenTheOpenemrTagHasNoTestsTree(): void
+    {
+        $resolved = $this->resolve(
+            [
+                self::linuxRelease('amd64', '8_3_0', '08232026'),
+                self::linuxRelease('arm64', '8_3_0', '08232026'),
+            ],
+            [],
+        );
+
+        self::assertSame('8_0_0/03102026', (string)$resolved);
+    }
+
+    public function testFallsBackToTheNextNewestFullyPublishedRelease(): void
+    {
+        $resolved = $this->resolve(
+            [
+                self::linuxRelease('amd64', '8_4_0', '09152026'),
+                self::linuxRelease('amd64', '8_3_0', '08232026'),
+                self::linuxRelease('arm64', '8_3_0', '08232026'),
+            ],
+            ['/contents/tests?ref=v8_4_0', '/contents/tests?ref=v8_3_0'],
+        );
+
+        self::assertSame('8_3_0/08232026', (string)$resolved);
+    }
+
+    /**
+     * The forge re-cut v7_0_4 three times in December 2025, after the
+     * v8_0_0 line existed. MMDDYYYY string order puts those rebuilds on
+     * top; chronological order correctly leaves them behind the pin.
+     */
+    public function testNeverDowngradesToARecutOfAnOlderLine(): void
+    {
+        $forge = new FakeGitHubApi([
+            self::linuxRelease('amd64', '7_0_4', '12292025'),
+            self::linuxRelease('arm64', '7_0_4', '12292025'),
+        ]);
+        $openemr = new FakeGitHubApi([], ['/contents/tests?ref=v7_0_4']);
+
+        $resolved = (new BinaryForgeResolver($forge, $openemr))->resolve($this->currentPin());
+
+        self::assertSame('8_0_0/03102026', (string)$resolved);
+        self::assertSame([], $openemr->existenceChecks, 'an older release should not cost an API call');
+    }
+
+    public function testIgnoresOtherPhpSelectors(): void
+    {
+        $php84 = new BinaryForgePin('8_3_0', '08232026', '8.4');
+        $resolved = $this->resolve(
+            [
+                self::linuxRelease('amd64', '8_3_0', '08232026', $php84->requiredAssets('amd64'), false, $php84),
+                self::linuxRelease('arm64', '8_3_0', '08232026', $php84->requiredAssets('arm64'), false, $php84),
+            ],
+            ['/contents/tests?ref=v8_3_0'],
+        );
+
+        self::assertSame('8_0_0/03102026', (string)$resolved);
+    }
+
+    public function testIgnoresNonLinuxPlatforms(): void
+    {
+        $resolved = $this->resolve(
+            [
+                [
+                    'tag_name' => 'mac_os-php85-openemr-v8_3_0-arm64-08232026',
+                    'draft' => false,
+                    'assets' => [['name' => 'openemr.phar']],
+                ],
+                [
+                    'tag_name' => 'freebsd15.1-php85-openemr-v8_3_0-arm64-08232026',
+                    'draft' => false,
+                    'assets' => [['name' => 'openemr.phar']],
+                ],
+            ],
+            ['/contents/tests?ref=v8_3_0'],
+        );
+
+        self::assertSame('8_0_0/03102026', (string)$resolved);
+    }
+
+    public function testIgnoresDraftReleases(): void
+    {
+        $resolved = $this->resolve(
+            [
+                self::linuxRelease('amd64', '8_3_0', '08232026', null, true),
+                self::linuxRelease('arm64', '8_3_0', '08232026', null, true),
+            ],
+            ['/contents/tests?ref=v8_3_0'],
+        );
+
+        self::assertSame('8_0_0/03102026', (string)$resolved);
+    }
+
+    public function testHoldsWhenTheForgeHasNoReleases(): void
+    {
+        self::assertSame('8_0_0/03102026', (string)$this->resolve([], []));
+    }
+
+    public function testChecksTheTestsTreeAtTheMatchingOpenemrTag(): void
+    {
+        $forge = new FakeGitHubApi([
+            self::linuxRelease('amd64', '8_3_0', '08232026'),
+            self::linuxRelease('arm64', '8_3_0', '08232026'),
+        ]);
+        $openemr = new FakeGitHubApi([], ['/contents/tests?ref=v8_3_0']);
+
+        (new BinaryForgeResolver($forge, $openemr))->resolve($this->currentPin());
+
+        self::assertSame(['/contents/tests?ref=v8_3_0'], $openemr->existenceChecks);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $releases
+     * @param list<string>               $existingTestTrees
+     */
+    private function resolve(array $releases, array $existingTestTrees): BinaryForgePin
+    {
+        $resolver = new BinaryForgeResolver(
+            new FakeGitHubApi($releases),
+            new FakeGitHubApi([], $existingTestTrees),
+        );
+
+        return $resolver->resolve($this->currentPin());
+    }
+
+    private function currentPin(): BinaryForgePin
+    {
+        return new BinaryForgePin(...self::CURRENT);
+    }
+
+    /**
+     * @param list<string>|null $assets defaults to everything the Dockerfile downloads
+     * @return array<string, mixed>
+     */
+    private static function linuxRelease(
+        string $arch,
+        string $version,
+        string $date,
+        ?array $assets = null,
+        bool $draft = false,
+        ?BinaryForgePin $pin = null,
+    ): array {
+        $pin ??= new BinaryForgePin($version, $date, '8.5');
+
+        return [
+            'tag_name' => $pin->forgeTag($arch),
+            'draft' => $draft,
+            'assets' => array_map(
+                static fn(string $name): array => ['name' => $name],
+                $assets ?? $pin->requiredAssets($arch),
+            ),
+        ];
+    }
+}

--- a/tests/Tests/Isolated/Release/Fakes/FakeGitHubApi.php
+++ b/tests/Tests/Isolated/Release/Fakes/FakeGitHubApi.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Release\Fakes;
+
+use OpenEMR\Release\GitHubApi;
+
+/**
+ * In-memory stand-in for the gh CLI wrapper. Records the endpoints it was
+ * asked about so tests can assert that a resolver skipped a network call
+ * entirely, not merely that it ignored the answer.
+ */
+final class FakeGitHubApi extends GitHubApi
+{
+    /** @var list<string> */
+    public array $paginated = [];
+
+    /** @var list<string> */
+    public array $existenceChecks = [];
+
+    /**
+     * @param list<array<string, mixed>> $items       returned by every paginate() call
+     * @param list<string>               $existing    endpoints exists() answers true for
+     */
+    public function __construct(
+        private readonly array $items = [],
+        private readonly array $existing = [],
+    ) {
+        parent::__construct('fake/repo');
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function paginate(string $endpoint): array
+    {
+        $this->paginated[] = $endpoint;
+
+        return $this->items;
+    }
+
+    public function exists(string $endpoint): bool
+    {
+        $this->existenceChecks[] = $endpoint;
+
+        return in_array($endpoint, $this->existing, true);
+    }
+}

--- a/tools/release/bin/resolve-binary-forge.php
+++ b/tools/release/bin/resolve-binary-forge.php
@@ -1,0 +1,117 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Print the newest openemr-static-binary-forge release the binary Docker
+ * image can be bumped to, as `<OPENEMR_VERSION>/<BINARY_RELEASE_DATE>`
+ * (e.g. `8_3_0/08232026`).
+ *
+ * This is the source resource for .github/updatecli/binary-image.yaml.
+ * When nothing newer qualifies it prints the pin already in the
+ * Dockerfile, so updatecli sees no change and writes nothing.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__, 3) . '/vendor/autoload.php';
+
+// OpenEMR\Release\ classes live under autoload-dev so composer-require-checker
+// does not demand conductor-only deps in production. Anything invoking this
+// script needs a `composer install` that includes dev dependencies.
+if (!class_exists(\OpenEMR\Release\BinaryForgeResolver::class)) {
+    fwrite(
+        STDERR,
+        "OpenEMR\\Release\\ classes are not autoloadable; rerun composer install with dev dependencies.\n",
+    );
+    exit(2);
+}
+
+use OpenEMR\Release\BinaryForgePinReader;
+use OpenEMR\Release\BinaryForgeResolver;
+use OpenEMR\Release\GitHubApi;
+use OpenEMR\Release\OptionReader;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('resolve-binary-forge')
+    ->setDescription('Print the newest adoptable forge release pin for the binary Docker image')
+    ->addOption(
+        'dockerfile',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Dockerfile holding the current pin',
+        BinaryForgePinReader::DEFAULT_DOCKERFILE,
+    )
+    ->addOption(
+        'field',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Which part of the pin to print: pin, version, or date',
+        'pin',
+    )
+    ->addOption(
+        'explain',
+        null,
+        InputOption::VALUE_NONE,
+        'Also write the current pin and the outcome to stderr',
+    )
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $options = new OptionReader($input);
+        $dockerfile = $options->string('dockerfile', BinaryForgePinReader::DEFAULT_DOCKERFILE);
+        if ($dockerfile === '') {
+            $output->writeln('<error>--dockerfile must be a non-empty path</error>');
+            return 2;
+        }
+
+        $field = $options->string('field', 'pin');
+        if (!in_array($field, ['pin', 'version', 'date'], true)) {
+            $output->writeln("<error>Unknown --field: {$field} (expected pin, version, or date)</error>");
+            return 2;
+        }
+
+        try {
+            $current = (new BinaryForgePinReader($dockerfile))->read();
+            $resolver = new BinaryForgeResolver(
+                new GitHubApi(BinaryForgeResolver::FORGE_REPO),
+                new GitHubApi(),
+            );
+            $resolved = $resolver->resolve($current);
+        } catch (\InvalidArgumentException | \RuntimeException $e) {
+            $output->writeln('<error>' . $e->getMessage() . '</error>');
+            return 1;
+        }
+
+        if ($options->bool('explain')) {
+            fwrite(STDERR, sprintf(
+                "current=%s resolved=%s (%s)\n",
+                $current,
+                $resolved,
+                (string)$resolved === (string)$current ? 'no newer fully published release' : 'bump available',
+            ));
+        }
+
+        // updatecli's shell source takes the whole of stdout as the
+        // resource value, so this line is the only thing allowed on it.
+        // --explain diagnostics go to stderr for that reason.
+        // No default arm: the in_array() guard above narrows $field to the
+        // three literals, so PHPStan proves this match exhaustive and a
+        // fourth --field value would fail the guard rather than fall
+        // through to a silently wrong answer.
+        $output->writeln(match ($field) {
+            'pin' => (string)$resolved,
+            'version' => $resolved->openemrVersion,
+            'date' => $resolved->releaseDate,
+        });
+
+        return 0;
+    })
+    ->run();

--- a/tools/release/bin/resolve-binary-forge.php
+++ b/tools/release/bin/resolve-binary-forge.php
@@ -59,6 +59,12 @@ use Symfony\Component\Console\SingleCommandApplication;
         'pin',
     )
     ->addOption(
+        'verify',
+        null,
+        InputOption::VALUE_NONE,
+        "Assert the Dockerfile's current pin is fully published, instead of resolving a new one",
+    )
+    ->addOption(
         'explain',
         null,
         InputOption::VALUE_NONE,
@@ -84,6 +90,20 @@ use Symfony\Component\Console\SingleCommandApplication;
                 new GitHubApi(BinaryForgeResolver::FORGE_REPO),
                 new GitHubApi(),
             );
+            // --verify is a post-condition on the Dockerfile as written,
+            // run after updatecli applies its targets. The two forge
+            // sources resolve independently, so in principle a release
+            // finishing publication between them could pair one
+            // candidate's version with another's date; this refuses to
+            // let that pair — or any other malformed pin — reach a PR.
+            if ($options->bool('verify')) {
+                if (!$resolver->isPublished($current)) {
+                    $output->writeln("<error>Pin {$current} is not fully published on the forge</error>");
+                    return 1;
+                }
+                $output->writeln((string)$current);
+                return 0;
+            }
             $resolved = $resolver->resolve($current);
         } catch (\InvalidArgumentException | \RuntimeException $e) {
             $output->writeln('<error>' . $e->getMessage() . '</error>');

--- a/tools/release/src/BinaryForgePin.php
+++ b/tools/release/src/BinaryForgePin.php
@@ -105,6 +105,32 @@ final readonly class BinaryForgePin implements \Stringable
         return "v{$this->openemrVersion}";
     }
 
+    /** Dotted form for version_compare(), e.g. `7_0_3_4` becomes `7.0.3.4`. */
+    public function dottedVersion(): string
+    {
+        return str_replace('_', '.', $this->openemrVersion);
+    }
+
+    /**
+     * True when $candidate is a pin this one should give way to.
+     *
+     * Version dominates date. A forge re-cut of an older line can carry a
+     * build date later than the current pin's — v7_0_4 was rebuilt three
+     * times, and nothing stops a future rebuild landing after a newer line
+     * shipped — so comparing dates alone would accept it and walk the
+     * image backwards. Within one version line a later build date does win,
+     * which is how a rebuild with corrected binaries gets adopted.
+     */
+    public function isSupersededBy(self $candidate): bool
+    {
+        $versions = version_compare($candidate->dottedVersion(), $this->dottedVersion());
+        if ($versions !== 0) {
+            return $versions > 0;
+        }
+
+        return $candidate->chronologicalDate() > $this->chronologicalDate();
+    }
+
     /**
      * MMDDYYYY reordered to YYYYMMDD so plain string comparison orders
      * releases chronologically. The forge's own `created_at` cannot be

--- a/tools/release/src/BinaryForgePin.php
+++ b/tools/release/src/BinaryForgePin.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * The set of pins that identify one openemr-static-binary-forge release
+ * line for the binary Docker image: the OpenEMR version, the forge build
+ * date, and the PHP version the binaries were compiled against.
+ *
+ * These three values appear as ARG defaults in docker/binary/Dockerfile
+ * and are woven into the forge download URLs. Keeping the URL/tag/asset
+ * naming here (rather than in the resolver) means the naming scheme is
+ * stated once and can be falsified by a test without any network access.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class BinaryForgePin implements \Stringable
+{
+    /** OpenEMR version in forge/tag form, e.g. `8_3_0` or `7_0_3_4`. */
+    private const VERSION_PATTERN = '/^\d+(?:_\d+)+$/';
+
+    /** Forge build date, MMDDYYYY. */
+    private const DATE_PATTERN = '/^\d{8}$/';
+
+    /** PHP version as written in the Dockerfile ARG, e.g. `8.5`. */
+    private const PHP_PATTERN = '/^\d+\.\d+$/';
+
+    /**
+     * Linux architectures the binary image is built for. Both must be
+     * fully published before a pin is safe to adopt — a manifest that
+     * bumped on amd64 alone would break every arm64 build until the
+     * second arch landed.
+     *
+     * @var list<string>
+     */
+    public const ARCHES = ['amd64', 'arm64'];
+
+    public function __construct(
+        public string $openemrVersion,
+        public string $releaseDate,
+        public string $phpVersion,
+    ) {
+        if (preg_match(self::VERSION_PATTERN, $openemrVersion) !== 1) {
+            throw new \InvalidArgumentException("Not a forge OpenEMR version: {$openemrVersion}");
+        }
+        if (preg_match(self::DATE_PATTERN, $releaseDate) !== 1) {
+            throw new \InvalidArgumentException("Not an MMDDYYYY forge release date: {$releaseDate}");
+        }
+        if (preg_match(self::PHP_PATTERN, $phpVersion) !== 1) {
+            throw new \InvalidArgumentException("Not a MAJOR.MINOR PHP version: {$phpVersion}");
+        }
+    }
+
+    /**
+     * The forge's PHP selector segment, e.g. `8.5` becomes `php85`.
+     * docker/binary/Dockerfile derives the same segment with `tr -d '.'`.
+     */
+    public function phpSelector(): string
+    {
+        return 'php' . str_replace('.', '', $this->phpVersion);
+    }
+
+    /**
+     * The forge release tag for one architecture, e.g.
+     * `linux_amd64-php85-openemr-v8_3_0-amd64-08232026`.
+     */
+    public function forgeTag(string $arch): string
+    {
+        return sprintf(
+            'linux_%s-%s-openemr-v%s-%s-%s',
+            $arch,
+            $this->phpSelector(),
+            $this->openemrVersion,
+            $arch,
+            $this->releaseDate,
+        );
+    }
+
+    /**
+     * Assets docker/binary/Dockerfile downloads from one arch's forge
+     * release. A release that exists but is missing any of these is a
+     * half-published build, not a bumpable target.
+     *
+     * @return list<string>
+     */
+    public function requiredAssets(string $arch): array
+    {
+        return [
+            "php-fpm-v{$this->openemrVersion}-linux-{$arch}",
+            "php-cli-v{$this->openemrVersion}-linux-{$arch}",
+            'openemr.phar',
+        ];
+    }
+
+    /** The openemr/openemr git tag the forge release was cut from. */
+    public function openemrTag(): string
+    {
+        return "v{$this->openemrVersion}";
+    }
+
+    /**
+     * MMDDYYYY reordered to YYYYMMDD so plain string comparison orders
+     * releases chronologically. The forge's own `created_at` cannot be
+     * used for this: the mac_os v8_3_0 release carries an 08232026 build
+     * date but a 2026-03-11 creation timestamp.
+     */
+    public function chronologicalDate(): string
+    {
+        return substr($this->releaseDate, 4, 4) . substr($this->releaseDate, 0, 4);
+    }
+
+    /** Wire format consumed by the updatecli manifest's two targets. */
+    public function __toString(): string
+    {
+        return "{$this->openemrVersion}/{$this->releaseDate}";
+    }
+}

--- a/tools/release/src/BinaryForgePinReader.php
+++ b/tools/release/src/BinaryForgePinReader.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Read the currently pinned forge release out of docker/binary/Dockerfile.
+ *
+ * The Dockerfile ARG defaults are the single source of truth for what the
+ * binary image builds today, so the bump tooling reads them rather than
+ * carrying a second copy in an updatecli manifest that could drift.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class BinaryForgePinReader
+{
+    public const DEFAULT_DOCKERFILE = 'docker/binary/Dockerfile';
+
+    public function __construct(
+        private string $dockerfile = self::DEFAULT_DOCKERFILE,
+    ) {
+    }
+
+    public function read(): BinaryForgePin
+    {
+        $contents = @file_get_contents($this->dockerfile);
+        if ($contents === false) {
+            throw new \RuntimeException("Cannot read Dockerfile: {$this->dockerfile}");
+        }
+
+        return new BinaryForgePin(
+            $this->arg($contents, 'OPENEMR_VERSION'),
+            $this->arg($contents, 'BINARY_RELEASE_DATE'),
+            $this->arg($contents, 'PHP_VERSION'),
+        );
+    }
+
+    /**
+     * Value of a top-level `ARG NAME=value` default.
+     *
+     * Deliberately narrow: it matches only the single-argument form with
+     * an unquoted, whitespace-free default, which is what all four pins in
+     * docker/binary/Dockerfile use. A multi-argument or quoted ARG would
+     * not match and would surface as an explicit failure rather than a
+     * silently wrong pin.
+     */
+    private function arg(string $contents, string $name): string
+    {
+        $pattern = '/^ARG\h+' . preg_quote($name, '/') . '=(\S+)\h*$/m';
+        if (preg_match($pattern, $contents, $matches) !== 1) {
+            throw new \RuntimeException("No `ARG {$name}=` default in {$this->dockerfile}");
+        }
+
+        return $matches[1];
+    }
+}

--- a/tools/release/src/BinaryForgeResolver.php
+++ b/tools/release/src/BinaryForgeResolver.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Pick the newest openemr-static-binary-forge release that the binary
+ * Docker image can actually build against.
+ *
+ * The forge publishes one GitHub release per (platform, arch) rather than
+ * one per build, so "there is a newer release" is not the same question as
+ * "there is a newer release we can adopt". A bump is only safe once every
+ * linux arch the image builds for has its release, each release carries
+ * every asset the Dockerfile downloads, and the matching openemr/openemr
+ * tag exists with the tests/ tree the image overlays onto the PHAR. Any
+ * candidate failing one of those falls through to the next-newest, and a
+ * run with no qualifying candidate returns the current pin unchanged so
+ * the caller writes nothing.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class BinaryForgeResolver
+{
+    public const FORGE_REPO = 'Jmevorach/openemr-static-binary-forge';
+
+    /**
+     * Forge release tags for the linux platform, e.g.
+     * `linux_amd64-php85-openemr-v8_3_0-amd64-08232026`. The `\1`
+     * backreference requires both arch segments to agree, so a
+     * mismatched tag is ignored rather than half-parsed.
+     */
+    private const TAG_PATTERN = '/^linux_(\w+)-(php\d+)-openemr-v(\d+(?:_\d+)+)-\1-(\d{8})$/';
+
+    public function __construct(
+        private GitHubApi $forge,
+        private GitHubApi $openemr,
+    ) {
+    }
+
+    /**
+     * The newest adoptable pin, or $current when nothing newer qualifies.
+     *
+     * Only candidates strictly newer than $current are considered, so the
+     * resolver can never propose a downgrade — the forge re-cuts older
+     * version lines (v7_0_4 was rebuilt three times), and those rebuilds
+     * must not drag the image backwards.
+     */
+    public function resolve(BinaryForgePin $current): BinaryForgePin
+    {
+        foreach ($this->candidates($current) as [$pin, $assets]) {
+            if ($this->isFullyPublished($pin, $assets)) {
+                return $pin;
+            }
+        }
+
+        return $current;
+    }
+
+    /**
+     * Candidate pins newer than $current, newest first, each paired with
+     * the asset names published per arch.
+     *
+     * @return list<array{0: BinaryForgePin, 1: array<string, list<string>>}>
+     */
+    private function candidates(BinaryForgePin $current): array
+    {
+        /** @var array<string, array{0: BinaryForgePin, 1: array<string, list<string>>}> $grouped */
+        $grouped = [];
+
+        foreach ($this->forge->paginate('/releases?per_page=100') as $release) {
+            $tag = $release['tag_name'] ?? null;
+            if (!is_string($tag) || ($release['draft'] ?? false) === true) {
+                continue;
+            }
+            if (preg_match(self::TAG_PATTERN, $tag, $matches) !== 1) {
+                continue;
+            }
+            [, $arch, $phpSelector, $version, $date] = $matches;
+            if (!in_array($arch, BinaryForgePin::ARCHES, true)) {
+                continue;
+            }
+
+            $pin = new BinaryForgePin($version, $date, $current->phpVersion);
+            if ($phpSelector !== $pin->phpSelector()) {
+                continue;
+            }
+            if ($pin->chronologicalDate() <= $current->chronologicalDate()) {
+                continue;
+            }
+
+            $key = (string)$pin;
+            $grouped[$key] ??= [$pin, []];
+            $grouped[$key][1][$arch] = $this->assetNames($release);
+        }
+
+        $candidates = array_values($grouped);
+        usort(
+            $candidates,
+            static fn(array $a, array $b): int
+                => $b[0]->chronologicalDate() <=> $a[0]->chronologicalDate(),
+        );
+
+        return $candidates;
+    }
+
+    /**
+     * @param array<string, mixed> $release
+     * @return list<string>
+     */
+    private function assetNames(array $release): array
+    {
+        $assets = $release['assets'] ?? [];
+        if (!is_array($assets)) {
+            return [];
+        }
+
+        $names = [];
+        foreach ($assets as $asset) {
+            $name = is_array($asset) ? ($asset['name'] ?? null) : null;
+            if (is_string($name)) {
+                $names[] = $name;
+            }
+        }
+
+        return $names;
+    }
+
+    /**
+     * @param array<string, list<string>> $assetsByArch
+     */
+    private function isFullyPublished(BinaryForgePin $pin, array $assetsByArch): bool
+    {
+        foreach (BinaryForgePin::ARCHES as $arch) {
+            $published = $assetsByArch[$arch] ?? null;
+            if ($published === null) {
+                return false;
+            }
+            foreach ($pin->requiredAssets($arch) as $required) {
+                if (!in_array($required, $published, true)) {
+                    return false;
+                }
+            }
+        }
+
+        // The image overlays tests/ from the matching openemr/openemr tag
+        // onto the PHAR extract, so the tag has to exist AND still carry a
+        // tests/ tree. Checking the tree (not just the ref) is deliberate:
+        // tests/ is `export-ignore` in .gitattributes, which is what broke
+        // the v8_3_0 bump when the Dockerfile still fetched tag tarballs.
+        return $this->openemr->exists('/contents/tests?ref=' . $pin->openemrTag());
+    }
+}

--- a/tools/release/src/BinaryForgeResolver.php
+++ b/tools/release/src/BinaryForgeResolver.php
@@ -46,10 +46,10 @@ final readonly class BinaryForgeResolver
     /**
      * The newest adoptable pin, or $current when nothing newer qualifies.
      *
-     * Only candidates strictly newer than $current are considered, so the
-     * resolver can never propose a downgrade — the forge re-cuts older
-     * version lines (v7_0_4 was rebuilt three times), and those rebuilds
-     * must not drag the image backwards.
+     * Only candidates that supersede $current are considered, so the
+     * resolver can never propose a downgrade. See
+     * BinaryForgePin::isSupersededBy() for why that comparison has to lead
+     * with the version rather than the build date.
      */
     public function resolve(BinaryForgePin $current): BinaryForgePin
     {
@@ -63,12 +63,52 @@ final readonly class BinaryForgeResolver
     }
 
     /**
-     * Candidate pins newer than $current, newest first, each paired with
+     * True when $pin is fully published right now.
+     *
+     * The workflow calls this through `--verify` after updatecli has
+     * written the Dockerfile, as a post-condition on the artifact itself.
+     * resolve() proves a pin was adoptable when it ran; this proves the
+     * pin that actually landed in the file is adoptable, which also covers
+     * a bad manifest matcher or a hand edit — not just a stale resolve.
+     */
+    public function isPublished(BinaryForgePin $pin): bool
+    {
+        $entry = $this->releasesByPin($pin)[(string)$pin] ?? null;
+
+        return $entry !== null && $this->isFullyPublished($pin, $entry[1]);
+    }
+
+    /**
+     * Candidate pins that supersede $current, best first, each paired with
      * the asset names published per arch.
      *
      * @return list<array{0: BinaryForgePin, 1: array<string, list<string>>}>
      */
     private function candidates(BinaryForgePin $current): array
+    {
+        $candidates = array_values(array_filter(
+            $this->releasesByPin($current),
+            static fn(array $entry): bool => $current->isSupersededBy($entry[0]),
+        ));
+
+        usort($candidates, static function (array $a, array $b): int {
+            $versions = version_compare($b[0]->dottedVersion(), $a[0]->dottedVersion());
+
+            return $versions !== 0
+                ? $versions
+                : $b[0]->chronologicalDate() <=> $a[0]->chronologicalDate();
+        });
+
+        return $candidates;
+    }
+
+    /**
+     * Every linux forge release matching $reference's PHP selector, grouped
+     * by pin and keyed by its string form.
+     *
+     * @return array<string, array{0: BinaryForgePin, 1: array<string, list<string>>}>
+     */
+    private function releasesByPin(BinaryForgePin $reference): array
     {
         /** @var array<string, array{0: BinaryForgePin, 1: array<string, list<string>>}> $grouped */
         $grouped = [];
@@ -86,11 +126,8 @@ final readonly class BinaryForgeResolver
                 continue;
             }
 
-            $pin = new BinaryForgePin($version, $date, $current->phpVersion);
+            $pin = new BinaryForgePin($version, $date, $reference->phpVersion);
             if ($phpSelector !== $pin->phpSelector()) {
-                continue;
-            }
-            if ($pin->chronologicalDate() <= $current->chronologicalDate()) {
                 continue;
             }
 
@@ -99,14 +136,7 @@ final readonly class BinaryForgeResolver
             $grouped[$key][1][$arch] = $this->assetNames($release);
         }
 
-        $candidates = array_values($grouped);
-        usort(
-            $candidates,
-            static fn(array $a, array $b): int
-                => $b[0]->chronologicalDate() <=> $a[0]->chronologicalDate(),
-        );
-
-        return $candidates;
+        return $grouped;
     }
 
     /**

--- a/tools/release/src/GitHubApi.php
+++ b/tools/release/src/GitHubApi.php
@@ -67,6 +67,33 @@ class GitHubApi
     }
 
     /**
+     * True when an endpoint responds 2xx, false when it 404s.
+     *
+     * Any other failure rethrows. "The ref does not exist" and "we could
+     * not find out" must stay distinguishable, or a rate-limit tickle or
+     * brief 5xx reads as a definitive absence — the same G19 confusion
+     * docker-validate-release-targets.yml grew its own 404 grep to avoid.
+     *
+     * A genuine 404 costs the full runGh() retry budget, because the retry
+     * loop cannot tell it apart from a transient failure until the
+     * attempts are spent. Callers should ask about refs that usually
+     * exist, so that cost lands on the negative branch only.
+     */
+    public function exists(string $endpoint): bool
+    {
+        try {
+            $this->runGh(['api', '--silent', "/repos/{$this->repo}{$endpoint}"]);
+            return true;
+        } catch (\RuntimeException $e) {
+            $message = $e->getMessage();
+            if (str_contains($message, 'HTTP 404') || str_contains($message, 'Not Found')) {
+                return false;
+            }
+            throw $e;
+        }
+    }
+
+    /**
      * Find a milestone number by its name.
      *
      * Search open milestones first, then closed.


### PR DESCRIPTION
#### Short description of what this changes or resolves:

Adds a propose-only bot for the two classes of Docker pin that nothing currently watches: the Alpine base of `docker/binary` and `docker/release`, and the openemr-static-binary-forge release pinned by `docker/binary`. Follows #13662, which did the forge bump by hand.

#### Why these pins have no bumper today

Dependabot's docker ecosystem parses literal `FROM alpine:3.24` lines. Every OpenEMR Dockerfile writes `FROM alpine:${ALPINE_VERSION}`, so the openemr-devops entries that covered them produced zero PRs — see `docs/docker-migration-from-devops.md`. With nothing watching, the two pins drifted apart on their own: `docker/binary` sat on 3.22 while `docker/release` moved to 3.24. The README's documented defaults had drifted from the Dockerfile too, advertising `BINARY_RELEASE_DATE` `12282025` against an actual `12292025`.

The forge pins have no dependency manager at all, and a forge bump is not a version string. openemr-static-binary-forge publishes one GitHub release per (platform, arch), so "a newer release exists" is not the same question as "we can build against it."

#### Changes proposed in this pull request:

- **`tools/release/bin/resolve-binary-forge.php`** — answers the second question. It only reports a pin once **both** linux arches carry every asset the Dockerfile downloads, **and** the matching `openemr/openemr` tag still has a `tests/` tree; otherwise it falls through to the next-newest release or leaves the pin alone. It cannot downgrade: the forge re-cut `v7_0_4` three times *after* `v8_0_0` existed, and `MMDDYYYY` sorts those rebuilds on top as a plain string. `created_at` is no help either — the mac_os `v8_3_0` release is stamped 2026-03-11.
- **`.github/updatecli/{alpine-base,binary-image}.yaml`** — the edits. `ARG` matchers on the Dockerfiles plus the documented defaults in `docker/binary/README.md`, so the README and the `ARG` lines can no longer drift apart.
- **`.github/workflows/updatecli-docker-pins.yml`** — weekly, plus `workflow_dispatch` with a dry-run input. On `pull_request` it stops after `updatecli pipeline diff`, which resolves every source without writing, so a typo'd matcher fails before it lands rather than silently on a schedule.
- **Tests** — `tests/Tests/Isolated/Release/`. Every "hold" case is a half-published forge state that a naive latest-release-wins bump would have adopted.

The forge's PHP selector (`php85`) is derived from `ARG PHP_VERSION`, so a PHP bump retargets the search with no change here.

#### Scope notes

- **Propose-only.** Nothing merges itself. One long-lived PR per manifest, opened under an App token so the bump PR actually gets CI.
- **`docker/flex` is excluded.** Every published flex image overrides `ALPINE_VERSION` from the `docker-build-3XX.yml` matrix, so its `ARG` default is never the shipped value, and supporting a new Alpine line there means adding a workflow file rather than moving a version string.
- **No `scms:` block in the manifests.** updatecli's github scm resolves sources inside its own bare clone, which has no `vendor/` for the resolver to autoload. The workflow applies targets in place and opens the PR with `peter-evans/create-pull-request`, already this repo's PR bot of record. The side benefit is that `updatecli pipeline diff --config .github/updatecli/` is a working local dry run needing no tokens.
- This PR ships the automation only, not a bump. #13662 carries the 8.3.0 forge bump itself.

#### Known interaction with #13662

#13662 adds bats assertions pinning the exact ARG values (`== "8_3_0"`, `== "08232026"`, `== "3.24"`). Once that merges, every bot PR will fail `docker-test-bats` until someone hand-edits the test. Asserting shape rather than value would keep the test meaningful and unblock the bot; raised on that PR.

#### Local validation

- `prek run` — full suite green (PHPStan level 10, Rector, phpcs, actionlint, codespell, composer-require-checker).
- `composer phpunit-isolated` — 44 tests, 90 assertions.
- `updatecli pipeline diff --config .github/updatecli/` against live GitHub and Docker Hub — both pipelines resolve.
- `resolve-binary-forge.php` against master's current pin resolves `7_0_4/12292025` to `8_3_0/08232026`, the same answer #13662 reached by hand.
- A real `updatecli pipeline apply` produced the expected diff across all four files; reverted, since the bump belongs to #13662.

#### Was an AI assistant used? Yes

`Assisted-by: Claude Code` trailer is on the commit.
