### PR TITLE
docs(ehi-export): add synthetic CSV samples

### DIFF
--- a/Documentation/EHI_Export/samples/SAMPLE_DATA_README.md
+++ b/Documentation/EHI_Export/samples/SAMPLE_DATA_README.md
@@ -1,0 +1,33 @@
+# Synthetic EHI export samples
+
+These CSV files demonstrate how related clinical records can appear in an
+OpenEMR EHI export. Every person, identifier, address, date, and clinical event
+in this directory is fictional and was created only for documentation.
+
+The samples are intentionally small and focus on commonly used columns. An
+actual export may contain additional columns documented in the generated EHI
+schema reference.
+
+## Relationships
+
+| File | Key relationship |
+| --- | --- |
+| `patient_data.csv` | `pid` identifies the fictional patient |
+| `form_encounter.csv` | `pid` links to the patient; `encounter` identifies the visit |
+| `lists.csv` | `pid` links problems and allergies to the patient |
+| `prescriptions.csv` | `patient_id` and `encounter` link medication orders to the patient and visit |
+| `procedure_order.csv` | `patient_id` and `encounter_id` link lab orders to the patient and visit |
+
+For example, patient `1001` has encounter `5001`, a hypertension problem, an
+active lisinopril prescription, and a basic metabolic panel order. Patient
+`1002` has encounter `5002`, a penicillin allergy, and a complete blood count
+order.
+
+## Important limitations
+
+- These files are examples, not an import package or a complete OpenEMR export.
+- Blank values demonstrate nullable or unavailable data.
+- Codes are illustrative and should be validated against the terminology and
+  configuration used by a real installation.
+- Never use real patient or protected health information in documentation,
+  tests, screenshots, or bug reports.

--- a/Documentation/EHI_Export/samples/form_encounter.csv
+++ b/Documentation/EHI_Export/samples/form_encounter.csv
@@ -1,0 +1,3 @@
+id,date,reason,facility,facility_id,pid,encounter,onset_date,sensitivity,provider_id,billing_facility,class_code,encounter_type_code,encounter_type_description,date_end
+7001,2026-01-15 09:30:00,Hypertension follow-up,Demo Community Clinic,1,1001,5001,2026-01-10,normal,10,1,AMB,AMB,Ambulatory,2026-01-15 10:05:00
+7002,2026-02-03 14:00:00,Fatigue and fever,Demo Community Clinic,1,1002,5002,2026-02-01,normal,11,1,AMB,AMB,Ambulatory,2026-02-03 14:45:00

--- a/Documentation/EHI_Export/samples/lists.csv
+++ b/Documentation/EHI_Export/samples/lists.csv
@@ -1,0 +1,3 @@
+id,date,type,subtype,title,begdate,enddate,diagnosis,activity,comments,pid,user,outcome,reaction,verification,severity_al
+8001,2026-01-15,medical_problem,,Essential hypertension,2024-06-20,,I10,1,Monitoring blood pressure,1001,clinician_demo,,,confirmed,
+8002,2026-02-03,allergy,drug,Penicillin,1998-01-01,,,1,Synthetic allergy example,1002,clinician_demo,,Rash,confirmed,moderate

--- a/Documentation/EHI_Export/samples/patient_data.csv
+++ b/Documentation/EHI_Export/samples/patient_data.csv
@@ -1,0 +1,3 @@
+pid,pubpid,fname,mname,lname,DOB,sex,street,city,state,postal_code,country_code,phone_cell,email,status,language,race,ethnicity,preferred_name,deceased_date
+1001,DEMO-1001,Amira,,Rahman,1984-03-12,Female,101 Example Avenue,Testville,MA,02110,US,555-0101,amira.rahman@example.invalid,married,English,asian,not_hispanic_or_latino,Amira,
+1002,DEMO-1002,Daniel,J,Okafor,1971-11-28,Male,202 Sample Street,Mock City,GA,30303,US,555-0102,,single,English,black_or_african_american,not_hispanic_or_latino,Dan,

--- a/Documentation/EHI_Export/samples/prescriptions.csv
+++ b/Documentation/EHI_Export/samples/prescriptions.csv
@@ -1,0 +1,3 @@
+id,patient_id,date_added,date_modified,provider_id,encounter,start_date,end_date,drug,rxnorm_drugcode,form,dosage,quantity,unit,route,interval,refills,medication,note,active,indication,prn,request_intent,request_intent_title,diagnosis
+9001,1001,2026-01-15,2026-01-15,10,5001,2026-01-15,,Lisinopril,29046,tablet,10 mg,30,tablet,oral,daily,2,1,Synthetic medication order,1,Hypertension,0,order,Order,I10
+9002,1002,2026-02-03,2026-02-03,11,5002,2026-02-03,2026-02-10,Acetaminophen,161,tablet,500 mg,14,tablet,oral,every 6 hours as needed,0,1,Do not exceed labeled maximum,1,Fever,1,order,Order,R50.9

--- a/Documentation/EHI_Export/samples/procedure_order.csv
+++ b/Documentation/EHI_Export/samples/procedure_order.csv
@@ -1,0 +1,3 @@
+procedure_order_id,provider_id,patient_id,encounter_id,date_collected,date_ordered,order_priority,order_status,patient_instructions,activity,control_id,lab_id,specimen_type,specimen_location,clinical_hx,order_diagnosis,procedure_order_type,order_intent
+10001,10,1001,5001,,2026-01-15 09:45:00,routine,pending,Complete before next visit,1,DEMO-LAB-10001,1,blood,clinic,Hypertension medication monitoring,I10,laboratory,order
+10002,11,1002,5002,2026-02-03 14:20:00,2026-02-03 14:10:00,urgent,completed,,1,DEMO-LAB-10002,1,blood,clinic,Fever and fatigue,R50.9,laboratory,order


### PR DESCRIPTION
Short description of what this changes or resolves:

Adds synthetic EHI export CSV examples so patients, researchers, and data consumers can understand common field formats and cross-table relationships without using protected health information.

Closes #10812.

Changes proposed in this pull request:

* Add five synthetic CSV samples for patient_data, form_encounter, lists, prescriptions, and procedure_order.
* Link fictional patients to their encounters, problems or allergies, medications, and laboratory orders.
* Demonstrate dates, clinical codes, free text, and blank values.
* Add SAMPLE_DATA_README.md explaining relationships and limitations.
* Validate the CSV files and cross-file patient and encounter references.

Was an AI assistant used? Yes

ChatGPT generated the initial documentation and sample files under the contributor’s direction. Each generated commit includes a Generated-By: ChatGPT trailer.