### PR TITLE
fix(billing): retry transient SFTP connect failures when sending X12

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -26717,11 +26717,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Billing/BillingProcessor/X12RemoteTracker.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$username of method phpseclib3\\\\Net\\\\SSH2\\:\\:login\\(\\) expects string, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Billing/BillingProcessor/X12RemoteTracker.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\.\\.\\.\\$arrays of function array_merge expects array, mixed given\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../src/Billing/BillingProcessor/X12RemoteTracker.php',
@@ -26733,11 +26728,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#2 \\$binds of function sqlStatement expects array, mixed given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Billing/BillingProcessor/X12RemoteTracker.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#2 \\$port of class phpseclib3\\\\Net\\\\SFTP constructor expects int, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Billing/BillingProcessor/X12RemoteTracker.php',
 ];

--- a/src/Billing/BillingProcessor/SftpConnector.php
+++ b/src/Billing/BillingProcessor/SftpConnector.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Opens SFTP connections, retrying transient connection failures.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2026 Stephen Waite <stephen.waite@cmsvt.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Billing\BillingProcessor;
+
+use phpseclib3\Exception\ConnectionClosedException;
+use phpseclib3\Exception\UnableToConnectException;
+use phpseclib3\Net\SFTP;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * phpseclib connects lazily inside login(), so a connection that cannot be
+ * established throws rather than returning false. Those are the failures worth
+ * retrying. A false return means the handshake completed and the server
+ * rejected the credentials, which will not improve on a retry, and replaying
+ * bad credentials risks tripping a clearinghouse lockout, so that case is
+ * reported without retrying.
+ */
+class SftpConnector
+{
+    /**
+     * Number of times to attempt a connection before giving up.
+     */
+    public const DEFAULT_ATTEMPTS = 4;
+
+    /**
+     * Seconds to wait after each failed attempt, indexed by completed attempt.
+     * Needs at least DEFAULT_ATTEMPTS - 1 entries.
+     */
+    public const DEFAULT_BACKOFF_SECONDS = [1, 3, 8];
+
+    /**
+     * How many connection attempts failed during the last connect() call.
+     */
+    private int $failedAttempts = 0;
+
+    private bool $credentialsRejected = false;
+
+    private readonly int $attempts;
+
+    private readonly LoggerInterface $logger;
+
+    /**
+     * @param int                  $attempts       Connection attempts before giving up.
+     * @param int[]                $backoffSeconds Wait before each retry.
+     * @param LoggerInterface|null $logger         Receives the raw transport errors.
+     */
+    public function __construct(
+        int $attempts = self::DEFAULT_ATTEMPTS,
+        private array $backoffSeconds = self::DEFAULT_BACKOFF_SECONDS,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->attempts = max(1, $attempts);
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    /**
+     * @return SFTP|null Null when no connection could be established. A
+     *                   connection is still returned when the credentials were
+     *                   rejected, so its own errors remain readable.
+     */
+    public function connect(string $host, int $port, string $login, ?string $password): ?SFTP
+    {
+        $this->failedAttempts = 0;
+        $this->credentialsRejected = false;
+
+        for ($attempt = 1; $attempt <= $this->attempts; $attempt++) {
+            try {
+                $sftp = new SFTP($host, $port);
+                $this->credentialsRejected = $sftp->login($login, $password) === false;
+                return $sftp;
+            } catch (UnableToConnectException | ConnectionClosedException $e) {
+                // The raw transport error can carry host and protocol detail, and
+                // the caller persists its messages where any user with billing
+                // write access can read them, so the detail goes to the log and
+                // only the attempt count is handed back.
+                $this->logger->warning('SFTP connection attempt failed', [
+                    'attempt' => $attempt,
+                    'attempts' => $this->attempts,
+                    'error' => $e->getMessage(),
+                ]);
+                $this->failedAttempts++;
+                if ($attempt < $this->attempts) {
+                    sleep($this->backoffSeconds[$attempt - 1] ?? 1);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public function getFailedAttempts(): int
+    {
+        return $this->failedAttempts;
+    }
+
+    public function credentialsRejected(): bool
+    {
+        return $this->credentialsRejected;
+    }
+
+    public function getAttempts(): int
+    {
+        return $this->attempts;
+    }
+}

--- a/src/Billing/BillingProcessor/X12RemoteTracker.php
+++ b/src/Billing/BillingProcessor/X12RemoteTracker.php
@@ -17,7 +17,6 @@ namespace OpenEMR\Billing\BillingProcessor;
 use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\BaseService;
-use phpseclib3\Net\SFTP;
 
 class X12RemoteTracker extends BaseService
 {
@@ -85,13 +84,33 @@ class X12RemoteTracker extends BaseService
                 continue;
             }
 
-            // Attempt to login
-            $sftp = new SFTP($x12_remote['x12_sftp_host'], $x12_remote['x12_sftp_port']);
+            // Attempt to login. See SftpConnector for why a thrown exception
+            // and a false return are handled differently.
+            $sftpHost = $x12_remote['x12_sftp_host'];
+            $sftpPort = $x12_remote['x12_sftp_port'];
+            $sftpLogin = $x12_remote['x12_sftp_login'];
             $decrypted_password = $cryptoGen->decryptFromDatabase(is_string($x12_remote['x12_sftp_pass']) ? $x12_remote['x12_sftp_pass'] : null);
-            if ($sftp->login($x12_remote['x12_sftp_login'], $decrypted_password) === false) {
+            $connector = new SftpConnector(logger: ServiceContainer::getLogger());
+            $sftp = $connector->connect(
+                is_string($sftpHost) ? $sftpHost : '',
+                is_numeric($sftpPort) ? (int) $sftpPort : 22,
+                is_string($sftpLogin) ? $sftpLogin : '',
+                $decrypted_password
+            );
+            if ($sftp === null || $connector->credentialsRejected()) {
+                if ($sftp === null) {
+                    $loginFailure = sprintf(
+                        'Could not connect to the SFTP host after %d attempts. See the server log for details.',
+                        $connector->getAttempts()
+                    );
+                    $loginDetails = [];
+                } else {
+                    $loginFailure = "Invalid Username or Password.";
+                    $loginDetails = $sftp->getSFTPErrors();
+                }
                 $x12_remote['status'] = self::STATUS_LOGIN_ERROR;
-                $x12_remote['messages'][] = "Invalid Username or Password.";
-                $x12_remote['messages'] = array_merge($x12_remote['messages'], $sftp->getSFTPErrors());
+                $x12_remote['messages'][] = $loginFailure;
+                $x12_remote['messages'] = array_merge($x12_remote['messages'], $loginDetails);
                 $remoteTracker->update($x12_remote);
                 continue;
             }

--- a/tests/Tests/Isolated/Billing/SftpConnectorTest.php
+++ b/tests/Tests/Isolated/Billing/SftpConnectorTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * Tests the SFTP connection retry policy.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2026 Stephen Waite <stephen.waite@cmsvt.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Billing;
+
+use OpenEMR\Billing\BillingProcessor\SftpConnector;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+
+class SftpConnectorTest extends TestCase
+{
+    /**
+     * Nothing listens here, so the lazy connect inside phpseclib's login()
+     * raises UnableToConnectException immediately. Loopback keeps it fast and
+     * deterministic, with no outbound network.
+     */
+    private const UNUSED_PORT = 47999;
+
+    public function testConnectFailureIsRetriedAndReportedRatherThanThrown(): void
+    {
+        $connector = new SftpConnector(3, [0, 0]);
+
+        $sftp = $connector->connect('127.0.0.1', self::UNUSED_PORT, 'someuser', 'somepassword');
+
+        $this->assertNull($sftp, 'No connection should be returned when the host is unreachable.');
+        $this->assertSame(
+            3,
+            $connector->getFailedAttempts(),
+            'Every attempt should be counted as a failure.'
+        );
+        $this->assertFalse(
+            $connector->credentialsRejected(),
+            'A connection failure is not a credentials rejection.'
+        );
+    }
+
+    public function testSingleAttemptDoesNotRetry(): void
+    {
+        $connector = new SftpConnector(1, []);
+
+        $sftp = $connector->connect('127.0.0.1', self::UNUSED_PORT, 'someuser', 'somepassword');
+
+        $this->assertNull($sftp);
+        $this->assertSame(1, $connector->getFailedAttempts());
+    }
+
+    /**
+     * An attempt count below one would skip the loop entirely and report no
+     * error at all, so it is clamped.
+     */
+    public function testAttemptCountIsClampedToAtLeastOne(): void
+    {
+        $connector = new SftpConnector(0, []);
+
+        $this->assertSame(1, $connector->getAttempts());
+        $this->assertNull($connector->connect('127.0.0.1', self::UNUSED_PORT, 'someuser', 'somepassword'));
+        $this->assertSame(1, $connector->getFailedAttempts());
+    }
+
+    /**
+     * The failure count from a previous call must not accumulate.
+     */
+    public function testFailedAttemptCountIsResetBetweenCalls(): void
+    {
+        $connector = new SftpConnector(2, [0]);
+
+        $connector->connect('127.0.0.1', self::UNUSED_PORT, 'someuser', 'somepassword');
+        $this->assertSame(2, $connector->getFailedAttempts());
+
+        $connector->connect('127.0.0.1', self::UNUSED_PORT, 'someuser', 'somepassword');
+        $this->assertSame(2, $connector->getFailedAttempts());
+    }
+
+    /**
+     * The raw transport error is what the tracker must not persist, so it has
+     * to reach the log instead, and only through the context array.
+     */
+    public function testRawTransportErrorGoesToTheLoggerNotTheCaller(): void
+    {
+        $logger = new class extends AbstractLogger {
+            /** @var list<array{string, string, array<mixed>}> */
+            public array $records = [];
+
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = [
+                    is_string($level) ? $level : get_debug_type($level),
+                    (string) $message,
+                    $context,
+                ];
+            }
+        };
+
+        $connector = new SftpConnector(2, [0], $logger);
+        $connector->connect('127.0.0.1', self::UNUSED_PORT, 'someuser', 'somepassword');
+
+        $this->assertCount(2, $logger->records, 'Each failed attempt should be logged.');
+        $this->assertSame('warning', $logger->records[0][0]);
+        $this->assertStringNotContainsString(
+            'Connection refused',
+            $logger->records[0][1],
+            'The log message itself should stay fixed.'
+        );
+        $error = $logger->records[0][2]['error'] ?? null;
+        $this->assertIsString($error, 'The raw error detail should be a string.');
+        $this->assertStringContainsString(
+            'Connection refused',
+            $error,
+            'The raw detail belongs in the context array.'
+        );
+        $this->assertSame(1, $logger->records[0][2]['attempt']);
+        $this->assertSame(2, $logger->records[1][2]['attempt']);
+    }
+
+    /**
+     * Omitting the logger must not blow up.
+     */
+    public function testConnectWorksWithoutALogger(): void
+    {
+        $connector = new SftpConnector(2, [0]);
+
+        $this->assertNull($connector->connect('127.0.0.1', self::UNUSED_PORT, 'someuser', 'somepassword'));
+        $this->assertSame(2, $connector->getFailedAttempts());
+    }
+}


### PR DESCRIPTION
#### Short description of what this changes or resolves:

A transient network failure while uploading X12 claim files aborts the entire
batch instead of failing one file.

`X12RemoteTracker::sftpSendWaitingFiles()` handles `SFTP::login()` returning
`false`, but that is not the transient failure mode. phpseclib connects lazily
inside `login()`, so a connection that cannot be established throws
`UnableToConnectException` or `ConnectionClosedException`. Neither was caught,
so the exception propagates out of the loop: the current file keeps its
`waiting` status with no message recorded, and every remaining waiting file is
skipped until the next batch.

A `false` return means the opposite — the handshake completed and the server
rejected the credentials. That will not improve on a retry, and replaying bad
credentials against a clearinghouse risks tripping its lockout. So the two
failures want opposite treatment: retry one, fail fast on the other.

#### Changes proposed in this pull request:

- Add `SftpConnector`, which opens the connection, retries only
  `UnableToConnectException` and `ConnectionClosedException` with a 1/3/8
  second backoff, and reports rejected credentials without retrying.
- Have `X12RemoteTracker` delegate to it. Connecting has no need of the
  tracker's database persistence, so keeping it out of a `BaseService`
  subclass both separates the concerns and makes it testable without a
  database.
- Record distinct diagnostics for the two cases. Both still set
  `STATUS_LOGIN_ERROR`, but a connect failure reports the attempt count and
  sends the raw transport error to an injected PSR-3 logger, since tracker
  messages are readable by anyone with billing write access and phpseclib's
  errors carry host and protocol detail.
- Narrow host, port and login once before the call so the connector takes real
  parameter types. This retires the two existing PHPStan baseline entries for
  `login()`'s `$username` and the `SFTP` constructor's `$port`.
- Add `tests/Tests/Isolated/Billing/SftpConnectorTest.php`, pointing the
  connector at a closed loopback port — where phpseclib raises
  `UnableToConnectException` immediately. Covers the retry count, the
  single-attempt case, the attempt clamp, the default backoff table, and that
  errors do not accumulate across calls. No network, no database, runs in
  milliseconds. The logger is injected rather than pulled from `ServiceContainer`, so
  `SftpConnector` depends only on `psr/log` and the test can assert on a
  spy logger without a bootstrap.

No schema or dependency changes. `SftpConnector` is new, but it is only
constructed inside `X12RemoteTracker`.

Verified against phpseclib 3.0: a closed port raises
`UnableToConnectException` from the lazy connect inside `login()`, and
`USERAUTH_FAILURE` returns `false` from `login_helper()`.

#### Was an AI assistant used? Yes