### PR TITLE
ci(byte-identical): retry curl on transient network errors

### DIFF
--- a/.github/scripts/validate-byte-identical.sh
+++ b/.github/scripts/validate-byte-identical.sh
@@ -196,7 +196,7 @@ FAIL=0
 # Echoes the HTTP status; writes the body to ${TMP_REMOTE}.
 fetch_status() {
   local url="$1"
-  curl -sS --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 --retry-connrefused \
+  curl -sS --connect-timeout 10 --max-time 30 --retry 3 --retry-delay 2 --retry-all-errors \
     -o "${TMP_REMOTE}" -w '%{http_code}' "${url}"
 }
 

--- a/tests/bats/ci-scripts/validate-byte-identical/curl-mock.sh
+++ b/tests/bats/ci-scripts/validate-byte-identical/curl-mock.sh
@@ -18,7 +18,7 @@ while [[ $# -gt 0 ]]; do
     -o) output_file="$2"; shift 2 ;;
     -w) shift 2 ;;
     --connect-timeout|--max-time|--retry|--retry-delay) shift 2 ;;
-    --retry-connrefused|-sS|-s|-S) shift ;;
+    --retry-all-errors|-sS|-s|-S) shift ;;
     http://*|https://*) url="$1"; shift ;;
     *) shift ;;
   esac


### PR DESCRIPTION
## Summary

- Swap `--retry-connrefused` for `--retry-all-errors` in the raw-file fetch inside `.github/scripts/validate-byte-identical.sh` so the existing 3-retry loop covers mid-handshake TCP resets, TLS failures, and 5xx responses — not just `ECONNREFUSED`.
- Update the bats curl mock's known-flag list to match.

## Why

The scheduled run [34094610746](https://github.com/openemr/openemr/actions/runs/34094610746) (2026-09-07 07:15 UTC) failed with:

```
✓ rel-830:.github/scripts/expand-docker-tags.sh matches master
curl: (35) Recv failure: Connection reset by peer
##[error]Process completed with exit code 35.
```

Only 16 files had been diffed — no drift was surfaced. `set -euo pipefail` at the top of the script propagates curl's exit code and aborts the whole workflow. `--retry-connrefused` only triggers on `ECONNREFUSED`; a `raw.githubusercontent.com` CDN edge dropping mid-handshake (exit 35) isn't retried. `--retry-all-errors` (curl 7.71+, present on all supported GHA runners) folds this class of transient failure into the existing 3-retry loop.

Real drift is still surfaced by `fetch_status`'s HTTP-200-vs-non-200 comparison — unchanged.

## Test plan

- [x] Local `bats tests/bats/ci-scripts/validate-byte-identical/` — all 16 tests pass.
- [x] Verified `curl -sS --retry-all-errors ...` succeeds against the real `raw.githubusercontent.com` URL scheme on curl 8.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)