### PR TITLE
ci(redis): run three sentinels so failover elections cannot split

### DIFF
--- a/ci/apache_83_123_redis_sentinel_mtls/docker-compose.yml
+++ b/ci/apache_83_123_redis_sentinel_mtls/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       openssl req -x509 -new -key ca.key -days 1 -out ca.crt -subj "/CN=test-ca"
 
       # --- Server cert (covers every Redis/Sentinel hostname) ---
-      echo "subjectAltName=DNS:redis-master,DNS:redis-replica-1,DNS:redis-replica-2,DNS:sentinel-1,DNS:sentinel-2,DNS:localhost" > /tmp/san.ext
+      echo 'subjectAltName=DNS:redis-master,DNS:redis-replica-1,DNS:redis-replica-2,DNS:sentinel-1,DNS:sentinel-2,DNS:sentinel-3,DNS:localhost' > /tmp/san.ext
       openssl genrsa -out server.key 2048
       openssl req -new -key server.key -subj "/CN=redis" \
         | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial \
@@ -100,7 +100,19 @@ services:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "--cert", "/certs/client.crt", "--key", "/certs/client.key", "-a", "strongpassword", "ping"]
+      test:
+      - CMD
+      - redis-cli
+      - --tls
+      - --cacert
+      - /certs/ca.crt
+      - --cert
+      - /certs/client.crt
+      - --key
+      - /certs/client.key
+      - -a
+      - strongpassword
+      - ping
 
   redis-replica-1:
     command:
@@ -183,59 +195,130 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
     - |
-      printf '%s\n' \
-        'port 0' \
-        'tls-port 26379' \
-        'tls-cert-file /certs/server.crt' \
-        'tls-key-file /certs/server.key' \
-        'tls-ca-cert-file /certs/ca.crt' \
-        'tls-auth-clients yes' \
-        'tls-replication yes' \
-        'daemonize no' \
-        'sentinel resolve-hostnames yes' \
-        'sentinel announce-hostnames yes' \
-        'sentinel monitor redis-master redis-master 6379 2' \
-        'sentinel auth-pass redis-master strongpassword' \
-        'sentinel down-after-milliseconds redis-master 5000' \
-        'sentinel failover-timeout redis-master 60000' \
-        'sentinel parallel-syncs redis-master 1' \
-        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+      cat > /tmp/sentinel.conf <<'EOF'
+      port 0
+      tls-port 26379
+      tls-cert-file /certs/server.crt
+      tls-key-file /certs/server.key
+      tls-ca-cert-file /certs/ca.crt
+      tls-auth-clients yes
+      tls-replication yes
+      daemonize no
+      sentinel resolve-hostnames yes
+      sentinel announce-hostnames yes
+      sentinel monitor redis-master redis-master 6379 2
+      sentinel auth-pass redis-master strongpassword
+      sentinel down-after-milliseconds redis-master 5000
+      sentinel failover-timeout redis-master 10000
+      sentinel parallel-syncs redis-master 1
+      EOF
+      exec redis-sentinel /tmp/sentinel.conf
     volumes:
     - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "--cert", "/certs/client.crt", "--key", "/certs/client.key", "-p", "26379", "SENTINEL", "masters"]
+      test:
+      - CMD
+      - redis-cli
+      - --tls
+      - --cacert
+      - /certs/ca.crt
+      - --cert
+      - /certs/client.crt
+      - --key
+      - /certs/client.key
+      - -p
+      - "26379"
+      - SENTINEL
+      - masters
 
   sentinel-2:
     entrypoint: ["/bin/sh", "-c"]
     command:
     - |
-      printf '%s\n' \
-        'port 0' \
-        'tls-port 26379' \
-        'tls-cert-file /certs/server.crt' \
-        'tls-key-file /certs/server.key' \
-        'tls-ca-cert-file /certs/ca.crt' \
-        'tls-auth-clients yes' \
-        'tls-replication yes' \
-        'daemonize no' \
-        'sentinel resolve-hostnames yes' \
-        'sentinel announce-hostnames yes' \
-        'sentinel monitor redis-master redis-master 6379 2' \
-        'sentinel auth-pass redis-master strongpassword' \
-        'sentinel down-after-milliseconds redis-master 5000' \
-        'sentinel failover-timeout redis-master 60000' \
-        'sentinel parallel-syncs redis-master 1' \
-        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+      cat > /tmp/sentinel.conf <<'EOF'
+      port 0
+      tls-port 26379
+      tls-cert-file /certs/server.crt
+      tls-key-file /certs/server.key
+      tls-ca-cert-file /certs/ca.crt
+      tls-auth-clients yes
+      tls-replication yes
+      daemonize no
+      sentinel resolve-hostnames yes
+      sentinel announce-hostnames yes
+      sentinel monitor redis-master redis-master 6379 2
+      sentinel auth-pass redis-master strongpassword
+      sentinel down-after-milliseconds redis-master 5000
+      sentinel failover-timeout redis-master 10000
+      sentinel parallel-syncs redis-master 1
+      EOF
+      exec redis-sentinel /tmp/sentinel.conf
     volumes:
     - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "--cert", "/certs/client.crt", "--key", "/certs/client.key", "-p", "26379", "SENTINEL", "masters"]
+      test:
+      - CMD
+      - redis-cli
+      - --tls
+      - --cacert
+      - /certs/ca.crt
+      - --cert
+      - /certs/client.crt
+      - --key
+      - /certs/client.key
+      - -p
+      - "26379"
+      - SENTINEL
+      - masters
+
+  sentinel-3:
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+    - |
+      cat > /tmp/sentinel.conf <<'EOF'
+      port 0
+      tls-port 26379
+      tls-cert-file /certs/server.crt
+      tls-key-file /certs/server.key
+      tls-ca-cert-file /certs/ca.crt
+      tls-auth-clients yes
+      tls-replication yes
+      daemonize no
+      sentinel resolve-hostnames yes
+      sentinel announce-hostnames yes
+      sentinel monitor redis-master redis-master 6379 2
+      sentinel auth-pass redis-master strongpassword
+      sentinel down-after-milliseconds redis-master 5000
+      sentinel failover-timeout redis-master 10000
+      sentinel parallel-syncs redis-master 1
+      EOF
+      exec redis-sentinel /tmp/sentinel.conf
+    volumes:
+    - redis-certs:/certs:ro
+    depends_on:
+      redis-tls-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test:
+      - CMD
+      - redis-cli
+      - --tls
+      - --cacert
+      - /certs/ca.crt
+      - --cert
+      - /certs/client.crt
+      - --key
+      - /certs/client.key
+      - -p
+      - "26379"
+      - SENTINEL
+      - masters
 
   # ---------- OpenEMR: TLS + X.509 client certs ----------
   openemr:

--- a/ci/apache_85_123_redis_sentinel_mtls/docker-compose.yml
+++ b/ci/apache_85_123_redis_sentinel_mtls/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       openssl req -x509 -new -key ca.key -days 1 -out ca.crt -subj "/CN=test-ca"
 
       # --- Server cert (covers every Redis/Sentinel hostname) ---
-      echo "subjectAltName=DNS:redis-master,DNS:redis-replica-1,DNS:redis-replica-2,DNS:sentinel-1,DNS:sentinel-2,DNS:localhost" > /tmp/san.ext
+      echo 'subjectAltName=DNS:redis-master,DNS:redis-replica-1,DNS:redis-replica-2,DNS:sentinel-1,DNS:sentinel-2,DNS:sentinel-3,DNS:localhost' > /tmp/san.ext
       openssl genrsa -out server.key 2048
       openssl req -new -key server.key -subj "/CN=redis" \
         | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial \
@@ -100,7 +100,19 @@ services:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "--cert", "/certs/client.crt", "--key", "/certs/client.key", "-a", "strongpassword", "ping"]
+      test:
+      - CMD
+      - redis-cli
+      - --tls
+      - --cacert
+      - /certs/ca.crt
+      - --cert
+      - /certs/client.crt
+      - --key
+      - /certs/client.key
+      - -a
+      - strongpassword
+      - ping
 
   redis-replica-1:
     command:
@@ -183,59 +195,130 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
     - |
-      printf '%s\n' \
-        'port 0' \
-        'tls-port 26379' \
-        'tls-cert-file /certs/server.crt' \
-        'tls-key-file /certs/server.key' \
-        'tls-ca-cert-file /certs/ca.crt' \
-        'tls-auth-clients yes' \
-        'tls-replication yes' \
-        'daemonize no' \
-        'sentinel resolve-hostnames yes' \
-        'sentinel announce-hostnames yes' \
-        'sentinel monitor redis-master redis-master 6379 2' \
-        'sentinel auth-pass redis-master strongpassword' \
-        'sentinel down-after-milliseconds redis-master 5000' \
-        'sentinel failover-timeout redis-master 60000' \
-        'sentinel parallel-syncs redis-master 1' \
-        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+      cat > /tmp/sentinel.conf <<'EOF'
+      port 0
+      tls-port 26379
+      tls-cert-file /certs/server.crt
+      tls-key-file /certs/server.key
+      tls-ca-cert-file /certs/ca.crt
+      tls-auth-clients yes
+      tls-replication yes
+      daemonize no
+      sentinel resolve-hostnames yes
+      sentinel announce-hostnames yes
+      sentinel monitor redis-master redis-master 6379 2
+      sentinel auth-pass redis-master strongpassword
+      sentinel down-after-milliseconds redis-master 5000
+      sentinel failover-timeout redis-master 10000
+      sentinel parallel-syncs redis-master 1
+      EOF
+      exec redis-sentinel /tmp/sentinel.conf
     volumes:
     - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "--cert", "/certs/client.crt", "--key", "/certs/client.key", "-p", "26379", "SENTINEL", "masters"]
+      test:
+      - CMD
+      - redis-cli
+      - --tls
+      - --cacert
+      - /certs/ca.crt
+      - --cert
+      - /certs/client.crt
+      - --key
+      - /certs/client.key
+      - -p
+      - "26379"
+      - SENTINEL
+      - masters
 
   sentinel-2:
     entrypoint: ["/bin/sh", "-c"]
     command:
     - |
-      printf '%s\n' \
-        'port 0' \
-        'tls-port 26379' \
-        'tls-cert-file /certs/server.crt' \
-        'tls-key-file /certs/server.key' \
-        'tls-ca-cert-file /certs/ca.crt' \
-        'tls-auth-clients yes' \
-        'tls-replication yes' \
-        'daemonize no' \
-        'sentinel resolve-hostnames yes' \
-        'sentinel announce-hostnames yes' \
-        'sentinel monitor redis-master redis-master 6379 2' \
-        'sentinel auth-pass redis-master strongpassword' \
-        'sentinel down-after-milliseconds redis-master 5000' \
-        'sentinel failover-timeout redis-master 60000' \
-        'sentinel parallel-syncs redis-master 1' \
-        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+      cat > /tmp/sentinel.conf <<'EOF'
+      port 0
+      tls-port 26379
+      tls-cert-file /certs/server.crt
+      tls-key-file /certs/server.key
+      tls-ca-cert-file /certs/ca.crt
+      tls-auth-clients yes
+      tls-replication yes
+      daemonize no
+      sentinel resolve-hostnames yes
+      sentinel announce-hostnames yes
+      sentinel monitor redis-master redis-master 6379 2
+      sentinel auth-pass redis-master strongpassword
+      sentinel down-after-milliseconds redis-master 5000
+      sentinel failover-timeout redis-master 10000
+      sentinel parallel-syncs redis-master 1
+      EOF
+      exec redis-sentinel /tmp/sentinel.conf
     volumes:
     - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "--cert", "/certs/client.crt", "--key", "/certs/client.key", "-p", "26379", "SENTINEL", "masters"]
+      test:
+      - CMD
+      - redis-cli
+      - --tls
+      - --cacert
+      - /certs/ca.crt
+      - --cert
+      - /certs/client.crt
+      - --key
+      - /certs/client.key
+      - -p
+      - "26379"
+      - SENTINEL
+      - masters
+
+  sentinel-3:
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+    - |
+      cat > /tmp/sentinel.conf <<'EOF'
+      port 0
+      tls-port 26379
+      tls-cert-file /certs/server.crt
+      tls-key-file /certs/server.key
+      tls-ca-cert-file /certs/ca.crt
+      tls-auth-clients yes
+      tls-replication yes
+      daemonize no
+      sentinel resolve-hostnames yes
+      sentinel announce-hostnames yes
+      sentinel monitor redis-master redis-master 6379 2
+      sentinel auth-pass redis-master strongpassword
+      sentinel down-after-milliseconds redis-master 5000
+      sentinel failover-timeout redis-master 10000
+      sentinel parallel-syncs redis-master 1
+      EOF
+      exec redis-sentinel /tmp/sentinel.conf
+    volumes:
+    - redis-certs:/certs:ro
+    depends_on:
+      redis-tls-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test:
+      - CMD
+      - redis-cli
+      - --tls
+      - --cacert
+      - /certs/ca.crt
+      - --cert
+      - /certs/client.crt
+      - --key
+      - /certs/client.key
+      - -p
+      - "26379"
+      - SENTINEL
+      - masters
 
   # ---------- OpenEMR: TLS + X.509 client certs ----------
   openemr:

--- a/ci/apache_85_123_redis_sentinel_tls/docker-compose.yml
+++ b/ci/apache_85_123_redis_sentinel_tls/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       openssl req -x509 -new -key ca.key -days 1 -out ca.crt -subj "/CN=test-ca"
 
       # --- Server cert (covers every Redis/Sentinel hostname) ---
-      echo "subjectAltName=DNS:redis-master,DNS:redis-replica-1,DNS:redis-replica-2,DNS:sentinel-1,DNS:sentinel-2,DNS:localhost" > /tmp/san.ext
+      echo 'subjectAltName=DNS:redis-master,DNS:redis-replica-1,DNS:redis-replica-2,DNS:sentinel-1,DNS:sentinel-2,DNS:sentinel-3,DNS:localhost' > /tmp/san.ext
       openssl genrsa -out server.key 2048
       openssl req -new -key server.key -subj "/CN=redis" \
         | openssl x509 -req -CA ca.crt -CAkey ca.key -CAcreateserial \
@@ -103,7 +103,15 @@ services:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "-a", "strongpassword", "ping"]
+      test:
+      - CMD
+      - redis-cli
+      - --tls
+      - --cacert
+      - /certs/ca.crt
+      - -a
+      - strongpassword
+      - ping
 
   redis-replica-1:
     command:
@@ -186,59 +194,118 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
     - |
-      printf '%s\n' \
-        'port 0' \
-        'tls-port 26379' \
-        'tls-cert-file /certs/server.crt' \
-        'tls-key-file /certs/server.key' \
-        'tls-ca-cert-file /certs/ca.crt' \
-        'tls-auth-clients no' \
-        'tls-replication yes' \
-        'daemonize no' \
-        'sentinel resolve-hostnames yes' \
-        'sentinel announce-hostnames yes' \
-        'sentinel monitor redis-master redis-master 6379 2' \
-        'sentinel auth-pass redis-master strongpassword' \
-        'sentinel down-after-milliseconds redis-master 5000' \
-        'sentinel failover-timeout redis-master 60000' \
-        'sentinel parallel-syncs redis-master 1' \
-        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+      cat > /tmp/sentinel.conf <<'EOF'
+      port 0
+      tls-port 26379
+      tls-cert-file /certs/server.crt
+      tls-key-file /certs/server.key
+      tls-ca-cert-file /certs/ca.crt
+      tls-auth-clients no
+      tls-replication yes
+      daemonize no
+      sentinel resolve-hostnames yes
+      sentinel announce-hostnames yes
+      sentinel monitor redis-master redis-master 6379 2
+      sentinel auth-pass redis-master strongpassword
+      sentinel down-after-milliseconds redis-master 5000
+      sentinel failover-timeout redis-master 10000
+      sentinel parallel-syncs redis-master 1
+      EOF
+      exec redis-sentinel /tmp/sentinel.conf
     volumes:
     - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "-p", "26379", "SENTINEL", "masters"]
+      test:
+      - CMD
+      - redis-cli
+      - --tls
+      - --cacert
+      - /certs/ca.crt
+      - -p
+      - "26379"
+      - SENTINEL
+      - masters
 
   sentinel-2:
     entrypoint: ["/bin/sh", "-c"]
     command:
     - |
-      printf '%s\n' \
-        'port 0' \
-        'tls-port 26379' \
-        'tls-cert-file /certs/server.crt' \
-        'tls-key-file /certs/server.key' \
-        'tls-ca-cert-file /certs/ca.crt' \
-        'tls-auth-clients no' \
-        'tls-replication yes' \
-        'daemonize no' \
-        'sentinel resolve-hostnames yes' \
-        'sentinel announce-hostnames yes' \
-        'sentinel monitor redis-master redis-master 6379 2' \
-        'sentinel auth-pass redis-master strongpassword' \
-        'sentinel down-after-milliseconds redis-master 5000' \
-        'sentinel failover-timeout redis-master 60000' \
-        'sentinel parallel-syncs redis-master 1' \
-        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+      cat > /tmp/sentinel.conf <<'EOF'
+      port 0
+      tls-port 26379
+      tls-cert-file /certs/server.crt
+      tls-key-file /certs/server.key
+      tls-ca-cert-file /certs/ca.crt
+      tls-auth-clients no
+      tls-replication yes
+      daemonize no
+      sentinel resolve-hostnames yes
+      sentinel announce-hostnames yes
+      sentinel monitor redis-master redis-master 6379 2
+      sentinel auth-pass redis-master strongpassword
+      sentinel down-after-milliseconds redis-master 5000
+      sentinel failover-timeout redis-master 10000
+      sentinel parallel-syncs redis-master 1
+      EOF
+      exec redis-sentinel /tmp/sentinel.conf
     volumes:
     - redis-certs:/certs:ro
     depends_on:
       redis-tls-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "redis-cli", "--tls", "--cacert", "/certs/ca.crt", "-p", "26379", "SENTINEL", "masters"]
+      test:
+      - CMD
+      - redis-cli
+      - --tls
+      - --cacert
+      - /certs/ca.crt
+      - -p
+      - "26379"
+      - SENTINEL
+      - masters
+
+  sentinel-3:
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+    - |
+      cat > /tmp/sentinel.conf <<'EOF'
+      port 0
+      tls-port 26379
+      tls-cert-file /certs/server.crt
+      tls-key-file /certs/server.key
+      tls-ca-cert-file /certs/ca.crt
+      tls-auth-clients no
+      tls-replication yes
+      daemonize no
+      sentinel resolve-hostnames yes
+      sentinel announce-hostnames yes
+      sentinel monitor redis-master redis-master 6379 2
+      sentinel auth-pass redis-master strongpassword
+      sentinel down-after-milliseconds redis-master 5000
+      sentinel failover-timeout redis-master 10000
+      sentinel parallel-syncs redis-master 1
+      EOF
+      exec redis-sentinel /tmp/sentinel.conf
+    volumes:
+    - redis-certs:/certs:ro
+    depends_on:
+      redis-tls-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test:
+      - CMD
+      - redis-cli
+      - --tls
+      - --cacert
+      - /certs/ca.crt
+      - -p
+      - "26379"
+      - SENTINEL
+      - masters
 
   # ---------- OpenEMR: add TLS env vars + cert volume ----------
   openemr:

--- a/ci/ciLibrary.source
+++ b/ci/ciLibrary.source
@@ -879,7 +879,7 @@ redis_diagnostics() {
     docker compose exec -T sentinel-1 \
         redis-cli "${tls_args[@]}" -p 26379 SENTINEL master redis-master \
         > "${dest}/sentinel-master-state.txt" 2>&1 || true
-    dc logs --timestamps redis-master redis-replica-1 redis-replica-2 sentinel-1 sentinel-2 \
+    dc logs --timestamps redis-master redis-replica-1 redis-replica-2 sentinel-1 sentinel-2 sentinel-3 \
         > "${dest}/redis-container-logs.txt" 2>&1 || true
 }
 

--- a/ci/compose-shared-redis-sentinel/docker-compose.yml
+++ b/ci/compose-shared-redis-sentinel/docker-compose.yml
@@ -1,9 +1,16 @@
 ##
 # Shared Redis Sentinel cluster template.
 #
-# Defines a minimal Redis Sentinel cluster (1 master + 2 replicas + 2 sentinels)
+# Defines a minimal Redis Sentinel cluster (1 master + 2 replicas + 3 sentinels)
 # and extends the openemr service with the env vars required to activate predis-sentinel
 # session storage.
+#
+# Three sentinels (quorum 2) so a failover election always has a majority.  With
+# only two sentinels each one can vote for itself in the same epoch, the election
+# fails, and Sentinel does not retry the same master for 2 x failover-timeout —
+# longer than the failover test waits.  failover-timeout is set well below the
+# production default (180000) for the same reason: this is CI-only tuning so an
+# occasional lost election still retries inside the test window.
 #
 # Include this file in COMPOSE_FILE when you want the full test suite to run
 # against Redis-backed sessions.  Redis containers are always started (no profile
@@ -41,7 +48,12 @@ services:
     - --replica-announce-ip
     - redis-master
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "strongpassword", "ping"]
+      test:
+      - CMD
+      - redis-cli
+      - -a
+      - strongpassword
+      - ping
       interval: 5s
       timeout: 3s
       retries: 10
@@ -99,23 +111,30 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
     - |
-      printf '%s\n' \
-        'port 26379' \
-        'daemonize no' \
-        'sentinel resolve-hostnames yes' \
-        'sentinel announce-hostnames yes' \
-        'sentinel monitor redis-master redis-master 6379 2' \
-        'sentinel auth-pass redis-master strongpassword' \
-        'sentinel down-after-milliseconds redis-master 5000' \
-        'sentinel failover-timeout redis-master 60000' \
-        'sentinel parallel-syncs redis-master 1' \
-        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+      cat > /tmp/sentinel.conf <<'EOF'
+      port 26379
+      daemonize no
+      sentinel resolve-hostnames yes
+      sentinel announce-hostnames yes
+      sentinel monitor redis-master redis-master 6379 2
+      sentinel auth-pass redis-master strongpassword
+      sentinel down-after-milliseconds redis-master 5000
+      sentinel failover-timeout redis-master 10000
+      sentinel parallel-syncs redis-master 1
+      EOF
+      exec redis-sentinel /tmp/sentinel.conf
     depends_on:
       redis-master:
         condition: service_healthy
     healthcheck:
       # Sentinels in this config have no requirepass, so no -a flag
-      test: ["CMD", "redis-cli", "-p", "26379", "SENTINEL", "masters"]
+      test:
+      - CMD
+      - redis-cli
+      - -p
+      - "26379"
+      - SENTINEL
+      - masters
       interval: 5s
       timeout: 3s
       retries: 10
@@ -127,23 +146,65 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
     - |
-      printf '%s\n' \
-        'port 26379' \
-        'daemonize no' \
-        'sentinel resolve-hostnames yes' \
-        'sentinel announce-hostnames yes' \
-        'sentinel monitor redis-master redis-master 6379 2' \
-        'sentinel auth-pass redis-master strongpassword' \
-        'sentinel down-after-milliseconds redis-master 5000' \
-        'sentinel failover-timeout redis-master 60000' \
-        'sentinel parallel-syncs redis-master 1' \
-        > /tmp/sentinel.conf && redis-sentinel /tmp/sentinel.conf
+      cat > /tmp/sentinel.conf <<'EOF'
+      port 26379
+      daemonize no
+      sentinel resolve-hostnames yes
+      sentinel announce-hostnames yes
+      sentinel monitor redis-master redis-master 6379 2
+      sentinel auth-pass redis-master strongpassword
+      sentinel down-after-milliseconds redis-master 5000
+      sentinel failover-timeout redis-master 10000
+      sentinel parallel-syncs redis-master 1
+      EOF
+      exec redis-sentinel /tmp/sentinel.conf
     depends_on:
       redis-master:
         condition: service_healthy
     healthcheck:
       # Sentinels in this config have no requirepass, so no -a flag
-      test: ["CMD", "redis-cli", "-p", "26379", "SENTINEL", "masters"]
+      test:
+      - CMD
+      - redis-cli
+      - -p
+      - "26379"
+      - SENTINEL
+      - masters
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 15s
+
+  sentinel-3:
+    image: redis:8.10.1@sha256:298e5b3bc566bade82f46ad5511777a4a07a294097ce16ada2f6a42be5239df5
+    # Config is written inline to avoid bind-mount directory pollution — see file header.
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+    - |
+      cat > /tmp/sentinel.conf <<'EOF'
+      port 26379
+      daemonize no
+      sentinel resolve-hostnames yes
+      sentinel announce-hostnames yes
+      sentinel monitor redis-master redis-master 6379 2
+      sentinel auth-pass redis-master strongpassword
+      sentinel down-after-milliseconds redis-master 5000
+      sentinel failover-timeout redis-master 10000
+      sentinel parallel-syncs redis-master 1
+      EOF
+      exec redis-sentinel /tmp/sentinel.conf
+    depends_on:
+      redis-master:
+        condition: service_healthy
+    healthcheck:
+      # Sentinels in this config have no requirepass, so no -a flag
+      test:
+      - CMD
+      - redis-cli
+      - -p
+      - "26379"
+      - SENTINEL
+      - masters
       interval: 5s
       timeout: 3s
       retries: 10
@@ -152,7 +213,7 @@ services:
   openemr:
     environment:
       SESSION_STORAGE_MODE: predis-sentinel
-      REDIS_SENTINELS: sentinel-1|||sentinel-2
+      REDIS_SENTINELS: sentinel-1|||sentinel-2|||sentinel-3
       REDIS_MASTER: redis-master
       # REDIS_SENTINELS_PASSWORD is intentionally omitted: the CI sentinel
       # containers have no requirepass directive.  Only the master password
@@ -162,4 +223,6 @@ services:
       sentinel-1:
         condition: service_healthy
       sentinel-2:
+        condition: service_healthy
+      sentinel-3:
         condition: service_healthy


### PR DESCRIPTION
## What

- Add a `sentinel-3` service to every Redis Sentinel CI compose file (shared template plus the TLS and mTLS overlays), mirroring `sentinel-2` (same image digest, same TLS cert wiring, same healthcheck and `depends_on`). Quorum stays at 2, which is the majority of three.
- Enumerate the third sentinel everywhere hosts are listed: `REDIS_SENTINELS`, the `openemr` service `depends_on`, the server-cert `subjectAltName` in the TLS/mTLS init containers, and the container-log capture in `ci/ciLibrary.source`.
- Lower `sentinel failover-timeout` from 60000 to 10000 in these CI-only configs. This is CI tuning, not a production recommendation.
- Write each sentinel's config with a quoted heredoc and `exec redis-sentinel` (so sentinel runs as PID 1) instead of a `printf` argument chain, and convert the healthcheck `test` arrays in these files to block-style lists like the other shared compose files.

## Why

The `redis-failover` job is flaky. In the two most recent failures on master (runs [34079248375](https://github.com/openemr/openemr/actions/runs/34079248375) and [33904964896](https://github.com/openemr/openemr/actions/runs/33904964896), both the "PHP 8.5 - apache - mariadb 12.3.3 - Redis Sentinel mTLS" cell) the sentinel flags stay `s_down,o_down,master` for the full 90 s wait, `config-epoch` never advances, `failover_in_progress` appears briefly and drops, and `SENTINEL master` reports `num-other-sentinels 1`.

That is the two-sentinel split vote: with two sentinels a leader needs both votes, and when both start an election in the same epoch each votes for itself. Sentinel then refuses to retry a failover on the same master for 2 x `failover-timeout` = 120 s, which is longer than the 90 s `build_test_redis_failover` waits. Redis documents that Sentinel deployments need at least three instances for exactly this reason. Three sentinels give every election a majority, and the shorter failover timeout means that even a lost election retries inside the test window.
