### PR TITLE
fix(files): stop fetching the MIME list from the dead rawgit CDN

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -18513,11 +18513,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr expects string, mixed given\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../interface/super/manage_site_files.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$text of function errorLogEscape expects string, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/super/manage_site_files.php',
 ];
@@ -18528,16 +18523,11 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function text expects string, mixed given\\.$#',
-    'count' => 6,
+    'count' => 5,
     'path' => __DIR__ . '/../../interface/super/manage_site_files.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$value of method OpenEMR\\\\Common\\\\Crypto\\\\CryptoInterface\\:\\:encryptForFilesystem\\(\\) expects string\\|null, string\\|false given\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/manage_site_files.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Parameter \\#2 \\$haystack of function in_array expects array, mixed given\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/super/manage_site_files.php',
 ];

--- a/.phpstan/baseline/booleanAnd.rightAlwaysTrue.php
+++ b/.phpstan/baseline/booleanAnd.rightAlwaysTrue.php
@@ -34,11 +34,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Right side of && is always true\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/manage_site_files.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Right side of && is always true\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../portal/patient/fwk/libs/util/parsecsv.lib.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -2093,7 +2093,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 5,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/super/manage_site_files.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/empty.variable.php
+++ b/.phpstan/baseline/empty.variable.php
@@ -187,16 +187,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/super/edit_list.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Variable \\$resp in empty\\(\\) always exists and is not falsy\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/manage_site_files.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Variable \\$responseErrorAsString in empty\\(\\) always exists and is always falsy\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/manage_site_files.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Variable \\$form_patient_id in empty\\(\\) is never defined\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../library/MedEx/API.php',

--- a/.phpstan/baseline/foreach.nonIterable.php
+++ b/.phpstan/baseline/foreach.nonIterable.php
@@ -1198,7 +1198,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\\.$#',
-    'count' => 4,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/super/manage_site_files.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/method.nonObject.php
+++ b/.phpstan/baseline/method.nonObject.php
@@ -2537,11 +2537,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../interface/reports/pat_ledger.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Cannot call method getStatusCode\\(\\) on mixed\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/manage_site_files.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Cannot call method getGroupEvents\\(\\) on mixed\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../interface/therapy_groups/therapy_groups_controllers/participants_controller.php',

--- a/.phpstan/baseline/openemr.forbiddenErrorLog.php
+++ b/.phpstan/baseline/openemr.forbiddenErrorLog.php
@@ -183,11 +183,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../interface/super/manage_site_files.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Use a PSR\\-3 logger such as OpenEMR\\\\BC\\\\ServiceContainer\\:\\:getLogger\\(\\) instead of error_log\\(\\)\\.$#',
     'count' => 5,
     'path' => __DIR__ . '/../../interface/usergroup/npi_lookup.php',
 ];

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -3183,7 +3183,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Direct access to \\$_POST is forbidden\\. Use Symfony\'s Request object instead\\.$#',
-    'count' => 5,
+    'count' => 2,
     'path' => __DIR__ . '/../../interface/super/manage_site_files.php',
 ];
 $ignoreErrors[] = [

--- a/interface/super/manage_site_files.php
+++ b/interface/super/manage_site_files.php
@@ -8,8 +8,10 @@
  * @link      https://www.open-emr.org
  * @author    Rod Roark <rod@sunsetsystems.com>
  * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2010-2016 Rod Roark <rod@sunsetsystems.com>
  * @copyright Copyright (c) 2018 Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -19,6 +21,7 @@ use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Common\Acl\AccessDeniedHelper;
 use OpenEMR\Common\Acl\AclMain;
 use OpenEMR\Common\Csrf\CsrfUtils;
+use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Session\SessionWrapperFactory;
 use OpenEMR\Core\Header;
 use OpenEMR\Core\OEGlobalsBag;
@@ -90,45 +93,47 @@ if (isset($_POST['generate_thumbnails'])) {
  */
 
 if (OEGlobalsBag::getInstance()->getBoolean('secure_upload')) {
-    $mime_types  = ['image/*', 'text/*', 'audio/*', 'video/*'];
+    // Seed the "Black list" picker with wildcard categories plus the document
+    // types uploads commonly need. This pool only populates the picker: the
+    // "Add manually" box accepts any type name, and isWhiteFile() in
+    // library/sanitize.inc.php enforces whatever list the admin saves.
+    $mime_types = [
+        'image/*',
+        'text/*',
+        'audio/*',
+        'video/*',
+        'application/dicom',
+        'application/dicom+zip',
+        'application/json',
+        'application/msword',
+        'application/pdf',
+        'application/rtf',
+        'application/vnd.ms-excel',
+        'application/vnd.ms-powerpoint',
+        'application/vnd.oasis.opendocument.presentation',
+        'application/vnd.oasis.opendocument.spreadsheet',
+        'application/vnd.oasis.opendocument.text',
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'application/xml',
+        'application/zip',
+        'image/gif',
+        'image/jpeg',
+        'image/png',
+        'image/tiff',
+        'text/csv',
+        'text/plain',
+        'text/xml',
+    ];
 
-    $responseError = false;
-    $responseErrorAsString = "";
-    try {
-        $resp = (new GuzzleHttp\Client())->get('https://cdn.rawgit.com/jshttp/mime-db/master/db.json', [
-            'timeout' => 5
-        ]);
-    } catch (GuzzleHttp\Exception\ClientException $e) {
-        $responseErrorAsString = $e->getResponse()->getBody()->getContents();
-        $responseError = true;
-    }
-
-    if (!$responseError && empty($responseErrorAsString) && !empty($resp) && ($resp->getStatusCode() == 200) && $resp->getBody()) {
-        $all_mime_types = json_decode($resp->getBody(), true);
-        foreach ($all_mime_types as $name => $value) {
-            $mime_types[] = $name;
-        }
-    } else {
-        if (!empty($resp)) {
-            $errorStatusCode = $resp->getStatusCode();
-        }
-        error_log('Get list of mime-type error: "' . errorLogEscape($responseErrorAsString) . '" - Code: ' . errorLogEscape($errorStatusCode ?? 0));
-        $mime_types_list = [
-            'application/pdf',
-            'image/jpeg',
-            'image/png',
-            'image/gif',
-            'application/msword',
-            'application/vnd.oasis.opendocument.spreadsheet',
-            'text/plain'
-        ];
-        $mime_types = array_merge($mime_types, $mime_types_list);
-    }
-
-    if (isset($_POST['submit_form'])) {
+    $request = CurrentRequest::get();
+    if ($request->request->has('submit_form')) {
         CsrfUtils::checkCsrfInput(INPUT_POST, dieOnFail: true);
 
-        $new_white_list = empty($_POST['white_list']) ? [] : $_POST['white_list'];
+        // The multi-select submits nothing when the admin clears the whole
+        // list; all() returns [] for a missing key and rejects a scalar.
+        $new_white_list = $request->request->all('white_list');
 
         // truncate white list from list_options table
         sqlStatement("DELETE FROM `list_options` WHERE `list_id` = 'files_white_list'");


### PR DESCRIPTION
## What

Remove the outbound request to `https://cdn.rawgit.com/jshttp/mime-db/master/db.json` from `interface/super/manage_site_files.php` (Admin -> System -> Files) and seed the MIME picker from a static list instead.

## Why

rawgit.com shut down in 2019 and now answers with a redirect. Every render of the Files page with `secure_upload` enabled still blocked on that dead CDN for up to 5 seconds. The code only caught `ClientException`, so when the request timed out or was reset a `ConnectException` propagated and the page returned HTTP 500. That is the intermittent failure behind the `HhMainMenuLinksTest` "Admin -> System -> Files" e2e flake, where the tab title comes back as "Unknown" instead of "File management" (2 of the last 12 master failures).

## Behavior

The fetched list only ever populated the left-hand "Black list" picker. It never gated uploads: `isWhiteFile()` in `library/sanitize.inc.php` enforces whatever the admin saves to `files_white_list` in `list_options`, and the "Add manually" box already accepts any type name. Since the CDN died, the page has been running its fallback branch in practice, so the pool has been the four wildcards plus seven fixed types for years.

The static pool now contains the same four wildcards (`image/*`, `text/*`, `audio/*`, `video/*`), every type in the fallback list, the types seeded into `files_white_list` by `sql/database.sql` (DICOM, zip), and the common office/document types (Office, OpenDocument, RTF, CSV, JSON, XML, TIFF). Nothing about what uploads are accepted changes. The `error_log` call for the failed fetch and its now-dead variables are gone, the submit check and the submitted white list are read through the Symfony `Request` object instead of `$_POST`, and the PHPStan baseline entries for those lines were regenerated (removals only).

No bundled MIME database was available to enumerate: `jshttp/mime-db` only appears as a `require-dev` of `guzzle/psr7`, and `symfony/mime`'s type map is a private constant with no enumeration API.

