### PR TITLE
fix(layouts): apply layout_options.default_value when creating a record

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -18303,7 +18303,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr expects string, \\(float\\|int\\) given\\.$#',
-    'count' => 46,
+    'count' => 45,
     'path' => __DIR__ . '/../../interface/super/edit_layout.php',
 ];
 $ignoreErrors[] = [
@@ -18313,7 +18313,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$text of function attr expects string, mixed given\\.$#',
-    'count' => 35,
+    'count' => 34,
     'path' => __DIR__ . '/../../interface/super/edit_layout.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
+++ b/.phpstan/baseline/offsetAccess.nonOffsetAccessible.php
@@ -23908,7 +23908,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Cannot access offset \'default_value\' on mixed\\.$#',
-    'count' => 3,
+    'count' => 1,
     'path' => __DIR__ . '/../../interface/super/edit_layout.php',
 ];
 $ignoreErrors[] = [

--- a/interface/forms/LBF/new.php
+++ b/interface/forms/LBF/new.php
@@ -1108,6 +1108,14 @@ if (
                         } // End "P" option logic.
                     }
 
+                    // A new form has no stored data, so fall back to the field's
+                    // configured default value. An existing form is left alone, so
+                    // that a value the user deliberately cleared stays cleared.
+                    $default_value = is_array($frow) ? ($frow['default_value'] ?? '') : '';
+                    if (!$formid && ($currvalue === '' || $currvalue === null) && $default_value !== '') {
+                        $currvalue = $default_value;
+                    }
+
                     $this_levels = $this_group;
                     $i = 0;
                     $mincount = min(strlen((string) $this_levels), strlen($group_levels));

--- a/interface/forms/LBF/new.php
+++ b/interface/forms/LBF/new.php
@@ -1109,10 +1109,15 @@ if (
                     }
 
                     // A new form has no stored data, so fall back to the field's
-                    // configured default value. An existing form is left alone, so
-                    // that a value the user deliberately cleared stays cleared.
+                    // configured default value. Restrict this to fields stored with
+                    // the form: patient, history and visit fields belong to records
+                    // that already exist, and saving writes them straight back, so a
+                    // default there would overwrite a stored blank. An existing form
+                    // is left alone as well, so a value the user deliberately cleared
+                    // stays cleared.
+                    $is_form_field = !in_array($source, ['D', 'H', 'E', 'V'], true);
                     $default_value = is_array($frow) ? ($frow['default_value'] ?? '') : '';
-                    if (!$formid && ($currvalue === '' || $currvalue === null) && $default_value !== '') {
+                    if (!$formid && $is_form_field && $default_value !== '' && ($currvalue === '' || $currvalue === null)) {
                         $currvalue = $default_value;
                     }
 

--- a/interface/new/new_comprehensive.php
+++ b/interface/new/new_comprehensive.php
@@ -445,8 +445,8 @@ $constraints = LBF_Validation::generate_validate_constraints("DEM");
                             }
                         }
 
-                        // This form only ever creates a patient, so any field without
-                        // a value takes the layout's configured default.
+                        // This page never loads an existing patient, so a field with
+                        // no value takes the layout's configured default.
                         $default_value = is_array($frow) ? ($frow['default_value'] ?? '') : '';
                         if ($currvalue === null && $default_value !== '') {
                             $currvalue = $default_value;

--- a/interface/new/new_comprehensive.php
+++ b/interface/new/new_comprehensive.php
@@ -445,6 +445,13 @@ $constraints = LBF_Validation::generate_validate_constraints("DEM");
                             }
                         }
 
+                        // This form only ever creates a patient, so any field without
+                        // a value takes the layout's configured default.
+                        $default_value = is_array($frow) ? ($frow['default_value'] ?? '') : '';
+                        if ($currvalue === null && $default_value !== '') {
+                            $currvalue = $default_value;
+                        }
+
                         // Handle a data category (group) change.
                         if (strcmp((string) $this_group, (string) $last_group) != 0) {
                             if (!$SHORT_FORM) {

--- a/interface/super/edit_layout.php
+++ b/interface/super/edit_layout.php
@@ -771,7 +771,6 @@ function writeFieldLine($linedata): void
 {
     global $fld_line_no, $sources, $lbfonly, $extra_html, $validations, $UOR;
     ++$fld_line_no;
-    $checked = $linedata['default_value'] ? " checked" : "";
 
     $session = SessionWrapperFactory::getInstance()->getActiveSession();
     //echo " <tr bgcolor='$bgcolor'>\n";
@@ -965,15 +964,11 @@ function writeFieldLine($linedata): void
         echo "  <td class='text-center optcell'>";
         echo "<textarea name='fld[" . attr($fld_line_no) . "][desc]' rows='3' cols='35' class='form-control form-control-sm optin'>" .
            text($linedata['description']) . "</textarea>";
-        echo "<input type='hidden' name='fld[" . attr($fld_line_no) . "][default]' value='" .
-         attr($linedata['default_value']) . "' />";
         echo "</td>\n";
     } else {
         echo "  <td class='text-center optcell'>";
         echo "<input type='text' name='fld[" . attr($fld_line_no) . "][desc]' value='" .
         attr($linedata['description']) . "' size='20' class='form-control form-control-sm optin' />";
-        echo "<input type='hidden' name='fld[" . attr($fld_line_no) . "][default]' value='" .
-        attr($linedata['default_value']) . "' />";
         echo "</td>\n";
       // if not english and showing layout labels, then show the translation of Description
         if (OEGlobalsBag::getInstance()->getBoolean('translate_layout') && $session->get('language_choice') > 1) {
@@ -981,6 +976,11 @@ function writeFieldLine($linedata): void
             echo "<td class='text-center translation'>" . text(xl_layout_label($descStr)) . "</td>\n";
         }
     }
+    echo "  <td class='text-center optcell' title='" . xla('Value given to this field when a new record is created') . "'>";
+    echo "<input type='text' name='fld[" . attr($fld_line_no) . "][default]' value='" .
+        attr($linedata['default_value']) . "' size='10' maxlength='255' class='form-control form-control-sm optin' />";
+    echo "</td>\n";
+
     echo "  <td class='text-center optcell'>";
     echo "<input type='text' name='fld[" . attr($fld_line_no) . "][codes]' id='codes_fld[" . attr($fld_line_no) . "][codes]' value='" . attr($linedata['codes']) . "' title='" . xla('Code(s)') . "' onclick='select_clin_term_code(this)' size='10' maxlength='255' class='form-control form-control-sm optin' />";
     echo "</td>\n";
@@ -1707,6 +1707,7 @@ if ($layout_id) {
                 if (OEGlobalsBag::getInstance()->getBoolean('translate_layout') && $language_choice > 1) { ?>
                     <th><?php echo xlt('Translation'); ?><span class='help' title='<?php echo xla('The translation of description in current language'); ?>'>&nbsp;(?)</span></th>
                 <?php } ?>
+          <th><?php echo xlt('Default'); ?><span class='help' title='<?php echo xla('Value given to this field when a new record is created'); ?>'>&nbsp;(?)</span></th>
           <th><?php echo xlt('Code(s)'); ?></th>
           <th style='width:1%'><?php echo xlt('?'); ?></th>
        </tr>
@@ -1787,6 +1788,7 @@ if ($layout_id) {
    <th><?php echo xlt('Data Cols'); ?></th>
    <th><?php echo xlt('Options'); ?></th>
    <th><?php echo xlt('Description'); ?></th>
+   <th><?php echo xlt('Default'); ?></th>
    <th><?php echo xlt('Code(s)'); ?></th>
   </tr>
  </thead>
@@ -1838,9 +1840,9 @@ foreach ($sorted_datatypes as $key => $value) {
    <td><input type="text" name="newbackuplistid" id="newbackuplistid" value="" size="8" maxlength="31" class="form-control form-control-sm listid" /></td>
    <td><input class='form-control form-control-sm' type="text" name="newtitlecols" id="newtitlecols" value="" size="3" maxlength="3" /> </td>
    <td><input class='form-control form-control-sm' type="text" name="newdatacols" id="newdatacols" value="" size="3" maxlength="3" /> </td>
-   <td><select name="newedit_options[]" id="newedit_options"  multiple class='form-control form-control-sm typeAddons'></select>
-       <input type="hidden"  name="newdefault" id="newdefault" value="" /> </td>
+   <td><select name="newedit_options[]" id="newedit_options"  multiple class='form-control form-control-sm typeAddons'></select> </td>
    <td><input type="text" class='form-control form-control-sm' name="newdesc" id="newdesc" value="" size="20" /> </td>
+   <td><input type="text" class='form-control form-control-sm' name="newdefault" id="newdefault" value="" size="10" maxlength="255" title="<?php echo xla('Value given to this field when a new record is created'); ?>" /> </td>
    <td><input type='text' class='form-control form-control-sm' name="newcodes" id="newcodes" value="" onclick='select_clin_term_code(this)' size='10' maxlength='255' /> </td>
   </tr>
   <tr>


### PR DESCRIPTION
Fixes #13886

`layout_options.default_value` has been persisted by the Layout Editor since the initial revision but is never read when a layout is rendered, so a layout field cannot actually be given a default value.

### Changes

- **`interface/new/new_comprehensive.php`** — apply the configured default when a field has no value. This page never loads an existing patient, so every field starts out unset.
- **`interface/forms/LBF/new.php`** — apply it for new forms only (`!$formid`), just after the existing `P` ("default to previous value") logic it parallels. Two restrictions keep it from touching stored data: an existing form is left alone so a value the user deliberately cleared stays cleared, and only fields stored with the form qualify. Patient, history and visit fields (`source` `D`/`H`/`E`/`V`) belong to records that already exist and are written straight back to `patient_data` / `history_data` / `shared_attributes` / `form_encounter` on save, so a default there would overwrite a stored blank.
- **`interface/super/edit_layout.php`** — surface the column as a visible "Default" input in both the field list and the add-field row. It was previously emitted as a hidden input in both places, so an administrator had no way to set it. Also drops the `$checked` assignment it fed, which was never used.

Both save paths already handled the column (`default_value = ?` on update, `$_POST['newdefault']` on insert), so only the inputs and the render path were missing.

### Scope

This covers the two screens that render a layout while the underlying record is being created. The History (`HIS`) layout has an equivalent create moment that is not covered — `newHistoryData()` inserts a blank row before the layout renders — tracked separately in #13897.

### Risk

No layout row ships a non-empty `default_value`, so existing installs see no behavior change until an administrator sets one.

### Notes

The baseline counts for `edit_layout.php` are decremented to match: removing the two hidden inputs and the dead `$checked` eliminated three baselined occurrences. No baseline entries are added.

Verified with a cold full `composer phpstan` run: no errors.
