### PR TITLE
test(docker): cover the tooearly vendor hook call site

### DIFF
--- a/docker/release/openemr.sh
+++ b/docker/release/openemr.sh
@@ -38,9 +38,14 @@ SQLCONF_FILE="${OE_ROOT}/sites/default/sqlconf.php"
 # ============================================================================
 # Load helper functions from devtoolsLibrary.source
 # This provides utility functions for database operations, configuration, etc.
+#
+# The Dockerfile copies the library to /root/devtoolsLibrary.source, which is
+# where it lives in every image we ship. DEVTOOLS_LIB overrides that path so
+# tests can source the in-repo copy; without it a test runner has no way to get
+# past this line, and nothing below it can be exercised outside a container.
 
 # shellcheck source=SCRIPTDIR/utilities/devtoolsLibrary.source
-. /root/devtoolsLibrary.source
+. "${DEVTOOLS_LIB:-/root/devtoolsLibrary.source}"
 
 # ============================================================================
 # DATABASE CONFIGURATION

--- a/docker/release/utilities/devtoolsLibrary.source
+++ b/docker/release/utilities/devtoolsLibrary.source
@@ -812,6 +812,18 @@ generateMultisiteBank() {
 # ${HOOKS_ROOT}/tooearly        before any container work has started
 #                               runs every launch, but you shouldn't use it
 #
+# Name hook scripts using only letters, digits, underscores, and hyphens. No
+# dots, which means no .sh extension. run-parts executes them in name order, so
+# prefix with a number to sequence them: 10-restore-config, 20-warm-cache.
+#
+# The no-dots rule is not cosmetic. The two run-parts implementations disagree:
+# busybox, which the Alpine-based production image ships, runs every executable
+# file in the directory, while Debian's debianutils run-parts silently skips any
+# filename containing a dot. A hook named 10-backup.sh therefore runs in
+# production today purely because the base image is Alpine, and would disappear
+# without a word if that base ever moved to a Debian derivative. Stick to the
+# stricter rule and the hook runs the same way under either.
+#
 # postconfig and postupgrade run inside the envelope of the config and upgrade task,
 # after OpenEMR's completed its own work. Because these upgrades can't be rolled
 # back, these tasks will only have one opportunity to run, and although failure will

--- a/tests/bats/docker/release/openemr_functional.bats
+++ b/tests/bats/docker/release/openemr_functional.bats
@@ -37,9 +37,13 @@ require_entrypoint_tools() {
         timeout 10 "$OPENEMR"
 
     # 01ok's output proves execution actually reached the call site, so the
-    # non-zero status below cannot be the script dying on its way there.
+    # exit status below cannot be the script dying on its way there.
     assert_output --partial 'reached-01'
-    assert_failure
+    # Exactly 1, not merely non-zero: openemr.sh runs under `set -e`, so
+    # run_vendor_hook's `return 1` propagates as the script's exit status. A
+    # bare assert_failure would also accept timeout's 124, letting a hang after
+    # the hook masquerade as a clean abort.
+    assert_failure 1
 
     # The load-bearing assertion: "[TIMING] Step 0-Start" is the first thing
     # openemr.sh emits after `run_vendor_hook tooearly`. Its absence is what
@@ -63,7 +67,7 @@ require_entrypoint_tools() {
     # Positive control, as above: without it every assertion below would also
     # hold for a script that died before it ever reached the call site.
     assert_output --partial 'tooearly-ran'
-    assert_failure
+    assert_failure 1
     # tooearly is documented as running "before any container work has
     # started". Nothing downstream of the call site may have run: no swarm
     # coordination, no certificate generation, no database contact.

--- a/tests/bats/docker/release/openemr_functional.bats
+++ b/tests/bats/docker/release/openemr_functional.bats
@@ -7,14 +7,69 @@ load '../helpers'
 setup() {
     SCRIPT_DIR="$(get_script_dir release)"
     OPENEMR="${SCRIPT_DIR}/openemr.sh"
+    LIB="${SCRIPT_DIR}/utilities/devtoolsLibrary.source"
     [[ -f "$OPENEMR" ]]
+    [[ -f "$LIB" ]]
 }
 
-@test "openemr: with K8S=admin script does not immediately syntax-error" {
-    # Quick run to ensure script parses and starts; it will fail when trying to run mysqladmin etc.
-    run bash -c "if command -v timeout >/dev/null 2>&1; then timeout 5 env K8S=admin MYSQL_HOST=localhost MYSQL_ROOT_PASS=root '$OPENEMR' 2>&1; else env K8S=admin MYSQL_HOST=localhost MYSQL_ROOT_PASS=root '$OPENEMR' 2>&1; fi"
-    refute_output --partial "syntax error"
-    [ "$status" -ne 2 ]
+# Executing openemr.sh outside a container needs two things the image provides
+# and a test runner does not: run-parts (Debian/busybox, absent on macOS) and
+# GNU timeout. Skip rather than fail where they are missing -- CI runs on
+# ubuntu-24.04, which has both.
+require_entrypoint_tools() {
+    command -v run-parts >/dev/null 2>&1 || skip 'run-parts not installed'
+    command -v timeout >/dev/null 2>&1 || skip 'timeout not installed'
+}
+
+@test "openemr: a failing tooearly hook aborts launch" {
+    require_entrypoint_tools
+
+    local hooks="${BATS_TEST_TMPDIR}/hooks"
+    mkdir -p "${hooks}/tooearly"
+    # No dots in hook filenames: Debian's run-parts, which is what runs here,
+    # silently skips anything with an extension. See the hook docblock in
+    # devtoolsLibrary.source.
+    printf '#!/bin/sh\necho reached-01\n' > "${hooks}/tooearly/01ok"
+    printf '#!/bin/sh\nexit 1\n' > "${hooks}/tooearly/02fail"
+    chmod +x "${hooks}/tooearly/01ok" "${hooks}/tooearly/02fail"
+
+    run env "DEVTOOLS_LIB=${LIB}" "HOOKS_ROOT=${hooks}" K8S=admin \
+        timeout 10 "$OPENEMR"
+
+    # 01ok's output proves execution actually reached the call site, so the
+    # non-zero status below cannot be the script dying on its way there.
+    assert_output --partial 'reached-01'
+    assert_failure
+
+    # The load-bearing assertion: "[TIMING] Step 0-Start" is the first thing
+    # openemr.sh emits after `run_vendor_hook tooearly`. Its absence is what
+    # distinguishes "the hook stopped the launch" -- the documented contract --
+    # from "the hook failed and the script carried on anyway."
+    refute_output --partial '[TIMING] Step 0-Start'
+}
+
+@test "openemr: tooearly hook runs before any container work" {
+    require_entrypoint_tools
+
+    local hooks="${BATS_TEST_TMPDIR}/hooks"
+    mkdir -p "${hooks}/tooearly"
+    printf '#!/bin/sh\necho tooearly-ran\nexit 1\n' > "${hooks}/tooearly/01fail"
+    chmod +x "${hooks}/tooearly/01fail"
+
+    run env "DEVTOOLS_LIB=${LIB}" "HOOKS_ROOT=${hooks}" K8S=admin \
+        MYSQL_HOST=localhost MYSQL_ROOT_PASS=root \
+        timeout 10 "$OPENEMR"
+
+    # Positive control, as above: without it every assertion below would also
+    # hold for a script that died before it ever reached the call site.
+    assert_output --partial 'tooearly-ran'
+    assert_failure
+    # tooearly is documented as running "before any container work has
+    # started". Nothing downstream of the call site may have run: no swarm
+    # coordination, no certificate generation, no database contact.
+    refute_output --partial '[TIMING] Step 0-Start'
+    refute_output --partial 'Generating self-signed SSL certificate'
+    refute_output --partial 'Waiting for MySQL'
 }
 
 @test "openemr: CONFIGURATION is set after prepareVariables when sourced with env" {

--- a/tests/bats/docker/release/scripts.bats
+++ b/tests/bats/docker/release/scripts.bats
@@ -15,6 +15,14 @@ setup() {
     assert_script_syntax "${SCRIPT_DIR}/openemr.sh"
 }
 
+@test "openemr.sh is executable" {
+    # Without the mode bit, tests that invoke openemr.sh directly get exit 126
+    # and "Permission denied" instead of running it -- which passes a loose
+    # assertion for entirely the wrong reason. openemr_functional.bats depends
+    # on this.
+    [[ -x "${SCRIPT_DIR}/openemr.sh" ]]
+}
+
 @test "openemr.sh uses bash and sources devtoolsLibrary" {
     assert_script_contains "${SCRIPT_DIR}/openemr.sh" 'devtoolsLibrary.source'
     assert_script_contains "${SCRIPT_DIR}/openemr.sh" 'set -euo pipefail'


### PR DESCRIPTION
Closes #13857 (items 1 and 3; item 2 was withdrawn as incorrect).

#13659 added vendor lifecycle hooks and tested `run_vendor_hook` itself. It did not test the call sites, and the documented contract — a failing hook stops container launch — is a property of those call sites under `set -euo pipefail`, not of the function.

## Making a call-site test possible

Two things blocked one.

`docker/release/openemr.sh` was committed mode `100644`, so the existing functional test never executed it. Invoking it directly returned `126` / "Permission denied", which satisfied both of that test's assertions — `refute_output --partial "syntax error"` matches "Permission denied", and `126 -ne 2`. The script is executable in every image (each Dockerfile `chmod 500`s it on `COPY`) and `docker/binary/openemr.sh` is already `100755`, so the mode fix changes nothing at runtime.

The script also sourced its library from a hardcoded `/root/devtoolsLibrary.source`, so outside a container it exited at that line before reaching any call site. `DEVTOOLS_LIB` now overrides that path.

## The tests

`tooearly` sits between the source line and the first real work, so a failing hook aborts there. Both new tests use a hook that emits output before failing — that output proves execution reached the call site, so the non-zero exit cannot be the script dying on the way there. The absence of `[TIMING] Step 0-Start`, the first thing `openemr.sh` emits after the call, is what proves the launch stopped rather than continued.

Mutation-checked against the release suite: dropping the mode bit, restoring the hardcoded library path, appending `|| true` to the call, and deleting the call outright each fail both tests. Unmutated, all 95 release / 44 binary / 57 flex tests pass.

`prelaunch`, `postconfig`, and `postupgrade` need real container state and stay uncovered. The replaced test's syntax checking is not lost — `scripts.bats` already runs `bash -n` over `openemr.sh`.

## Hook filename rules

The hook docblock gave no naming guidance, and the two `run-parts` implementations disagree:

| Filename | busybox (Alpine, production) | debianutils (Ubuntu, where BATS runs) |
|---|---|---|
| `01plain` | runs | runs |
| `02dotted.sh` | runs | **skipped** |
| `03-dashed` | runs | runs |
| `04_under` | runs | runs |
| `05.multi.dots` | runs | **skipped** |

Verified on `alpine:3.22`, `3.23`, `3.24`, `edge`, `ubuntu:22.04`, `ubuntu:24.04`, `debian:12`. `.sh` is what most vendors will reach for, and it works today only because production is Alpine — it would stop running silently if the base ever moved to a Debian derivative. The docblock now states the stricter rule that behaves identically under both.
