### PR TITLE
fix(fhir): emit Condition.code.coding for unparsed diagnosis strings

### DIFF
--- a/src/Services/FHIR/Condition/Trait/FhirConditionTrait.php
+++ b/src/Services/FHIR/Condition/Trait/FhirConditionTrait.php
@@ -136,26 +136,34 @@ trait FhirConditionTrait
 
     protected function populateCode($dataRecord, FHIRCondition $conditionResource, string $defaultText)
     {
-        $title = $dataRecord['title'] ?? 'Problem';
+        $title = $dataRecord['title'] ?? $defaultText;
         $diagnosis = $dataRecord['diagnosis'] ?? null;
+
+        $codings = [];
         if (is_string($diagnosis) && $diagnosis !== '') {
             // Services querying lists.diagnosis directly hand us the stored
             // "ICD10:I10." string rather than a parsed array
-            $diagnosis = $this->parseDiagnosisCodes($diagnosis, is_string($title) ? $title : '');
-        }
-
-        $diagnosisCode = new FHIRCodeableConcept();
-        if (!empty($diagnosis) && is_array($diagnosis)) {
+            $codings = $this->parseDiagnosisCodes($diagnosis, is_string($title) ? $title : '');
+        } elseif (!empty($diagnosis) && is_array($diagnosis)) {
             foreach ($diagnosis as $code => $codeValues) {
                 if (!is_string($code)) {
                     $code = "$code"; // FHIR expects a string
                 }
-                $diagnosisCoding = new FHIRCoding();
-                $diagnosisCoding->setCode($code);
-                $diagnosisCoding->setDisplay($codeValues['description']);
-                $diagnosisCoding->setSystem($codeValues['system']);
-                $diagnosisCode->addCoding($diagnosisCoding);
+                $codings[] = [
+                    'code' => $code,
+                    'description' => $codeValues['description'],
+                    'system' => $codeValues['system'],
+                ];
             }
+        }
+
+        $diagnosisCode = new FHIRCodeableConcept();
+        foreach ($codings as $coding) {
+            $diagnosisCoding = new FHIRCoding();
+            $diagnosisCoding->setCode($coding['code']);
+            $diagnosisCoding->setDisplay($coding['description']);
+            $diagnosisCoding->setSystem($coding['system']);
+            $diagnosisCode->addCoding($diagnosisCoding);
         }
         $diagnosisCode->setText($title);
         $conditionResource->setCode($diagnosisCode);
@@ -164,7 +172,9 @@ trait FhirConditionTrait
     /**
      * Parse OpenEMR's stored "TYPE:CODE" diagnosis string into coding values.
      *
-     * @return array<string, array{description: string, system: string|null}>
+     * A code value can repeat across systems, so the parsed entries stay a list.
+     *
+     * @return list<array{code: string, description: string, system: string|null}>
      */
     private function parseDiagnosisCodes(string $diagnosis, string $description): array
     {
@@ -173,7 +183,8 @@ trait FhirConditionTrait
         foreach (explode(';', $diagnosis) as $item) {
             $code = $codeTypes->parseCode($item);
             $codeType = is_string($code['code_type'] ?? null) ? $code['code_type'] : '';
-            $parsed[is_string($code['code'] ?? null) ? $code['code'] : ''] = [
+            $parsed[] = [
+                'code' => is_string($code['code'] ?? null) ? $code['code'] : '',
                 'description' => $description,
                 'system' => $codeTypes->getSystemForCodeType($codeType),
             ];

--- a/src/Services/FHIR/Condition/Trait/FhirConditionTrait.php
+++ b/src/Services/FHIR/Condition/Trait/FhirConditionTrait.php
@@ -136,16 +136,16 @@ trait FhirConditionTrait
 
     protected function populateCode($dataRecord, FHIRCondition $conditionResource, string $defaultText)
     {
+        $title = $dataRecord['title'] ?? 'Problem';
         $diagnosis = $dataRecord['diagnosis'] ?? null;
         if (is_string($diagnosis) && $diagnosis !== '') {
             // Services querying lists.diagnosis directly hand us the stored
             // "ICD10:I10." string rather than a parsed array
-            $diagnosis = $this->parseDiagnosisCodes($diagnosis, $dataRecord['title'] ?? '');
+            $diagnosis = $this->parseDiagnosisCodes($diagnosis, is_string($title) ? $title : '');
         }
 
+        $diagnosisCode = new FHIRCodeableConcept();
         if (!empty($diagnosis) && is_array($diagnosis)) {
-            $diagnosisCode = new FHIRCodeableConcept();
-
             foreach ($diagnosis as $code => $codeValues) {
                 if (!is_string($code)) {
                     $code = "$code"; // FHIR expects a string
@@ -156,18 +156,15 @@ trait FhirConditionTrait
                 $diagnosisCoding->setSystem($codeValues['system']);
                 $diagnosisCode->addCoding($diagnosisCoding);
             }
-            $diagnosisCode->setText($dataRecord['title'] ?? 'Problem');
-            $conditionResource->setCode($diagnosisCode);
-        } else {
-            // Fallback to title if no structured diagnosis
-            $diagnosisCode = new FHIRCodeableConcept();
-            $diagnosisCode->setText($dataRecord['title'] ?? 'Problem');
-            $conditionResource->setCode($diagnosisCode);
         }
+        $diagnosisCode->setText($title);
+        $conditionResource->setCode($diagnosisCode);
     }
 
     /**
      * Parse OpenEMR's stored "TYPE:CODE" diagnosis string into coding values.
+     *
+     * @return array<string, array{description: string, system: string|null}>
      */
     private function parseDiagnosisCodes(string $diagnosis, string $description): array
     {
@@ -175,9 +172,10 @@ trait FhirConditionTrait
         $parsed = [];
         foreach (explode(';', $diagnosis) as $item) {
             $code = $codeTypes->parseCode($item);
-            $parsed[$code['code']] = [
+            $codeType = is_string($code['code_type'] ?? null) ? $code['code_type'] : '';
+            $parsed[is_string($code['code'] ?? null) ? $code['code'] : ''] = [
                 'description' => $description,
-                'system' => $codeTypes->getSystemForCodeType($code['code_type']),
+                'system' => $codeTypes->getSystemForCodeType($codeType),
             ];
         }
         return $parsed;

--- a/src/Services/FHIR/Condition/Trait/FhirConditionTrait.php
+++ b/src/Services/FHIR/Condition/Trait/FhirConditionTrait.php
@@ -20,6 +20,7 @@ use OpenEMR\FHIR\R4\FHIRElement\FHIRExtension;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRId;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRMeta;
 use OpenEMR\FHIR\R4\FHIRElement\FHIRReference;
+use OpenEMR\Services\CodeTypesService;
 use OpenEMR\Services\FHIR\Condition\Enum\FhirConditionCategory;
 use OpenEMR\Services\FHIR\FhirCodeSystemConstants;
 use OpenEMR\Services\FHIR\IResourceUSCIGProfileService;
@@ -135,14 +136,21 @@ trait FhirConditionTrait
 
     protected function populateCode($dataRecord, FHIRCondition $conditionResource, string $defaultText)
     {
-        if (!empty($dataRecord['diagnosis']) && is_array($dataRecord['diagnosis'])) {
-            $diagnosisCoding = new FHIRCoding();
+        $diagnosis = $dataRecord['diagnosis'] ?? null;
+        if (is_string($diagnosis) && $diagnosis !== '') {
+            // Services querying lists.diagnosis directly hand us the stored
+            // "ICD10:I10." string rather than a parsed array
+            $diagnosis = $this->parseDiagnosisCodes($diagnosis, $dataRecord['title'] ?? '');
+        }
+
+        if (!empty($diagnosis) && is_array($diagnosis)) {
             $diagnosisCode = new FHIRCodeableConcept();
 
-            foreach ($dataRecord['diagnosis'] as $code => $codeValues) {
+            foreach ($diagnosis as $code => $codeValues) {
                 if (!is_string($code)) {
                     $code = "$code"; // FHIR expects a string
                 }
+                $diagnosisCoding = new FHIRCoding();
                 $diagnosisCoding->setCode($code);
                 $diagnosisCoding->setDisplay($codeValues['description']);
                 $diagnosisCoding->setSystem($codeValues['system']);
@@ -155,6 +163,23 @@ trait FhirConditionTrait
             $diagnosisCode->setText($dataRecord['title'] ?? 'Problem');
             $conditionResource->setCode($diagnosisCode);
         }
+    }
+
+    /**
+     * Parse OpenEMR's stored "TYPE:CODE" diagnosis string into coding values.
+     */
+    private function parseDiagnosisCodes(string $diagnosis, string $description): array
+    {
+        $codeTypes = new CodeTypesService();
+        $parsed = [];
+        foreach (explode(';', $diagnosis) as $item) {
+            $code = $codeTypes->parseCode($item);
+            $parsed[$code['code']] = [
+                'description' => $description,
+                'system' => $codeTypes->getSystemForCodeType($code['code_type']),
+            ];
+        }
+        return $parsed;
     }
 
     protected function populateSubject($dataRecord, FHIRCondition $conditionResource)

--- a/src/Services/FHIR/Condition/Trait/FhirConditionTrait.php
+++ b/src/Services/FHIR/Condition/Trait/FhirConditionTrait.php
@@ -156,6 +156,7 @@ trait FhirConditionTrait
                 $diagnosisCoding->setSystem($codeValues['system']);
                 $diagnosisCode->addCoding($diagnosisCoding);
             }
+            $diagnosisCode->setText($dataRecord['title'] ?? 'Problem');
             $conditionResource->setCode($diagnosisCode);
         } else {
             // Fallback to title if no structured diagnosis

--- a/tests/Tests/Isolated/Services/FHIR/Condition/FhirConditionEncounterDiagnosisServiceTest.php
+++ b/tests/Tests/Isolated/Services/FHIR/Condition/FhirConditionEncounterDiagnosisServiceTest.php
@@ -58,6 +58,7 @@ class FhirConditionEncounterDiagnosisServiceTest extends TestCase
         $record['title'] = 'Essential (primary) hypertension';
 
         $fhirResource = (new FhirConditionEncounterDiagnosisService())->parseOpenEMRRecord($record);
+        $this->assertInstanceOf(FHIRCondition::class, $fhirResource);
 
         $coding = $fhirResource->getCode()->getCoding()[0];
         $this->assertEquals('I10.', $coding->getCode());

--- a/tests/Tests/Isolated/Services/FHIR/Condition/FhirConditionEncounterDiagnosisServiceTest.php
+++ b/tests/Tests/Isolated/Services/FHIR/Condition/FhirConditionEncounterDiagnosisServiceTest.php
@@ -63,6 +63,7 @@ class FhirConditionEncounterDiagnosisServiceTest extends TestCase
         $this->assertEquals('I10.', $coding->getCode());
         $this->assertEquals(FhirCodeSystemConstants::HL7_ICD10, $coding->getSystem());
         $this->assertEquals('Essential (primary) hypertension', $coding->getDisplay());
+        $this->assertEquals('Essential (primary) hypertension', $fhirResource->getCode()->getText());
     }
 
     public function testParseOpenEMRRecord(): void

--- a/tests/Tests/Isolated/Services/FHIR/Condition/FhirConditionEncounterDiagnosisServiceTest.php
+++ b/tests/Tests/Isolated/Services/FHIR/Condition/FhirConditionEncounterDiagnosisServiceTest.php
@@ -67,6 +67,23 @@ class FhirConditionEncounterDiagnosisServiceTest extends TestCase
         $this->assertEquals('Essential (primary) hypertension', $fhirResource->getCode()->getText());
     }
 
+    public function testParseOpenEMRRecordKeepsSameCodeFromDifferentSystems(): void
+    {
+        // A code value can repeat across systems; both codings must survive
+        $record = $this->getDefaultOpenEMRRecord();
+        $record['diagnosis'] = 'ICD10:123;SNOMED:123';
+        $record['title'] = 'Shared code value';
+
+        $fhirResource = (new FhirConditionEncounterDiagnosisService())->parseOpenEMRRecord($record);
+        $this->assertInstanceOf(FHIRCondition::class, $fhirResource);
+
+        $codings = $fhirResource->getCode()->getCoding();
+        $this->assertCount(2, $codings);
+        $systems = [(string)$codings[0]->getSystem(), (string)$codings[1]->getSystem()];
+        $this->assertContains(FhirCodeSystemConstants::HL7_ICD10, $systems);
+        $this->assertContains(FhirCodeSystemConstants::SNOMED_CT, $systems);
+    }
+
     public function testParseOpenEMRRecord(): void
     {
         $record = $this->getDefaultOpenEMRRecord();

--- a/tests/Tests/Isolated/Services/FHIR/Condition/FhirConditionEncounterDiagnosisServiceTest.php
+++ b/tests/Tests/Isolated/Services/FHIR/Condition/FhirConditionEncounterDiagnosisServiceTest.php
@@ -50,6 +50,21 @@ class FhirConditionEncounterDiagnosisServiceTest extends TestCase
             ,'occurrence' => 0
         ];
     }
+    public function testParseOpenEMRRecordWithUnparsedDiagnosisString(): void
+    {
+        // Services that query lists.diagnosis directly pass the stored string
+        $record = $this->getDefaultOpenEMRRecord();
+        $record['diagnosis'] = 'ICD10:I10.';
+        $record['title'] = 'Essential (primary) hypertension';
+
+        $fhirResource = (new FhirConditionEncounterDiagnosisService())->parseOpenEMRRecord($record);
+
+        $coding = $fhirResource->getCode()->getCoding()[0];
+        $this->assertEquals('I10.', $coding->getCode());
+        $this->assertEquals(FhirCodeSystemConstants::HL7_ICD10, $coding->getSystem());
+        $this->assertEquals('Essential (primary) hypertension', $coding->getDisplay());
+    }
+
     public function testParseOpenEMRRecord(): void
     {
         $record = $this->getDefaultOpenEMRRecord();


### PR DESCRIPTION
Fixes #13828. Parses the stored `ICD10:I10.` string so FHIR `Condition` emits `code.coding`, and keeps `code.text`.

#### Was an AI assistant used? Yes
Commits carry `Generated-By: Claude Code`.
