### PR TITLE
fix: repair the post-upgrade API responses on a locally built release image

### DIFF
--- a/.phpstan/baseline/openemr.exitInCatchOrFinally.php
+++ b/.phpstan/baseline/openemr.exitInCatchOrFinally.php
@@ -4,11 +4,6 @@ $ignoreErrors = [];
 $ignoreErrors[] = [
     'message' => '#^exit/die inside a catch block swallows the caught exception and aborts the process\\.$#',
     'count' => 1,
-    'path' => __DIR__ . '/../../apis/dispatch.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^exit/die inside a catch block swallows the caught exception and aborts the process\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../ccdaservice/ccda_gateway.php',
 ];
 $ignoreErrors[] = [
@@ -130,11 +125,6 @@ $ignoreErrors[] = [
     'message' => '#^exit/die inside a catch block swallows the caught exception and aborts the process\\.$#',
     'count' => 3,
     'path' => __DIR__ . '/../../library/deletedrug.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^exit/die inside a catch block swallows the caught exception and aborts the process\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../oauth2/authorize.php',
 ];
 $ignoreErrors[] = [
     'message' => '#^exit/die inside a catch block swallows the caught exception and aborts the process\\.$#',

--- a/apis/dispatch.php
+++ b/apis/dispatch.php
@@ -20,7 +20,9 @@ require_once "../vendor/autoload.php";
 use OpenEMR\BC\FallbackRouter;
 use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Http\HttpRestRequest;
+use OpenEMR\Common\Http\RequestTerminator;
 use OpenEMR\RestControllers\ApiApplication;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 // create the Request object
@@ -45,15 +47,14 @@ try {
     // what was otherwise a complete, correct payload. A post-send failure -- a
     // kernel.terminate listener, a broken output filter -- is a log-only event.
     if (!headers_sent()) {
-        header('Content-Type: application/json');
-        http_response_code(Response::HTTP_INTERNAL_SERVER_ERROR);
         // The message stays out of the body. Exception text here is whatever
         // failed deepest in the stack -- openemr#13905 put a SQLSTATE naming a
         // missing column into this field, readable by any anonymous caller of
         // /apis/default/fhir/metadata. It is already in the error log above,
         // where it is useful and not disclosed.
-        die(json_encode([
-            'error' => 'An error occurred while processing the request.',
-        ]));
+        (new RequestTerminator())->respond(new JsonResponse(
+            ['error' => 'An error occurred while processing the request.'],
+            Response::HTTP_INTERNAL_SERVER_ERROR
+        ));
     }
 }

--- a/apis/dispatch.php
+++ b/apis/dispatch.php
@@ -47,9 +47,13 @@ try {
     if (!headers_sent()) {
         header('Content-Type: application/json');
         http_response_code(Response::HTTP_INTERNAL_SERVER_ERROR);
+        // The message stays out of the body. Exception text here is whatever
+        // failed deepest in the stack -- openemr#13905 put a SQLSTATE naming a
+        // missing column into this field, readable by any anonymous caller of
+        // /apis/default/fhir/metadata. It is already in the error log above,
+        // where it is useful and not disclosed.
         die(json_encode([
             'error' => 'An error occurred while processing the request.',
-            'message' => $e->getMessage(),
         ]));
     }
 }

--- a/apis/dispatch.php
+++ b/apis/dispatch.php
@@ -39,13 +39,17 @@ try {
     // we manually handle it as we don't know if something failed in the symfony component or in our code
     error_log($e->getMessage());
     error_log($e->getTraceAsString());
-    // should never get here, but if we do, we can return a generic error response
+    // Only answer when nothing has gone out yet. Once headers are sent the response
+    // body is already being read by the client, so emitting an error document here
+    // appends a second JSON object to the first and every client fails to parse
+    // what was otherwise a complete, correct payload. A post-send failure -- a
+    // kernel.terminate listener, a broken output filter -- is a log-only event.
     if (!headers_sent()) {
         header('Content-Type: application/json');
         http_response_code(Response::HTTP_INTERNAL_SERVER_ERROR);
+        die(json_encode([
+            'error' => 'An error occurred while processing the request.',
+            'message' => $e->getMessage(),
+        ]));
     }
-    die(json_encode([
-        'error' => 'An error occurred while processing the request.',
-        'message' => $e->getMessage(),
-    ]));
 }

--- a/docker/release/openemr.sh
+++ b/docker/release/openemr.sh
@@ -520,7 +520,125 @@ check_upgrade() {
         return 0
     fi
 
+    # The docker-version marker only advances at a release branch-cut, so it
+    # cannot see a schema change that lands mid-cycle: version.php's
+    # $v_database moves as soon as the upgrade SQL is merged, while the marker
+    # stays on the last release's number. Booting such an image over an
+    # existing install therefore runs new code against the previous release's
+    # schema with no migration -- see openemr#13905, where every API request
+    # died writing an api_log column that release did not have. Compare the
+    # schema revisions directly so the migration runs on version drift too,
+    # not just on marker drift.
+    # check_schema_upgrade failure aborts the entrypoint via set -e -- the
+    # same reasoning as run_upgrade above applies; do not wrap it.
+    check_schema_upgrade
+
     return 0
+}
+
+# Runs the database migration when the code's schema revision is ahead of the
+# installed one, independent of the docker-version marker.
+#
+# No-op on the ordinary paths: a fresh install is not configured yet when this
+# runs, and a release upgrade has already been migrated by fsupgrade-<N>.sh,
+# which advances the version table to the code's revision.
+check_schema_upgrade() {
+    local config_state
+    config_state=$(is_configured)
+    if [[ "${config_state}" != "1" ]]; then
+        return 0
+    fi
+
+    # version.php is a standalone file of assignments, so requiring it directly
+    # is safe here and deliberately avoids bootstrapping the application.
+    local -i code_schema_version
+    code_schema_version=$(php -r "require '${OE_ROOT}/version.php'; echo (int)\$v_database;")
+    if [[ "${code_schema_version}" -le 0 ]]; then
+        echo "ERROR: could not read \$v_database from ${OE_ROOT}/version.php." >&2
+        return 1
+    fi
+
+    wait_for_mysql
+
+    # One row, two columns: the installed schema revision and the release it
+    # belongs to. sql_upgrade.php keys its migration files on the latter.
+    #
+    # This reads the container's configured database, which is the site the
+    # image provisions. It is the trigger only -- once drift is detected the
+    # migration below covers every site under sites/.
+    local version_row
+    version_row=$(mariadb \
+        --host="${MYSQL_HOST}" \
+        --port="${MYSQL_PORT}" \
+        --user="${MYSQL_ROOT_USER}" \
+        --password="${MYSQL_ROOT_PASS}" \
+        "${MYSQL_SSL_OPTS[@]}" \
+        --skip-column-names \
+        --batch \
+        "${MYSQL_DATABASE}" \
+        -e 'SELECT v_database, CONCAT_WS(".", v_major, v_minor, v_patch) FROM version LIMIT 1') || {
+        echo "ERROR: could not read the version table from ${MYSQL_DATABASE}; cannot tell whether a schema upgrade is due." >&2
+        return 1
+    }
+
+    local -i installed_schema_version
+    local installed_release
+    IFS=$'\t' read -r installed_schema_version installed_release <<< "${version_row}"
+
+    if [[ "${code_schema_version}" -le "${installed_schema_version}" ]]; then
+        return 0
+    fi
+
+    echo "Schema upgrade detected: database is at revision ${installed_schema_version} (${installed_release}), code needs ${code_schema_version}"
+    run_schema_upgrade "${installed_release}"
+}
+
+# Applies sql_upgrade.php to every site, starting from the release the database
+# is currently at.
+#
+# Mirrors the migration half of fsupgrade-<N>.sh rather than calling it: those
+# scripts also perform filesystem work keyed to a specific release, and there is
+# no release boundary to key to here.
+run_schema_upgrade() {
+    local from_release="$1"
+
+    [[ "${AUTHORITY}" = "yes" ]] && update_leader_heartbeat
+
+    local dirdata
+    local sitename
+    for dirdata in "${OE_ROOT}"/sites/*/; do
+        sitename="${dirdata%/}"
+        sitename="${sitename##*/}"
+
+        echo "Start: Upgrade database for ${sitename} from ${from_release}"
+        [[ "${AUTHORITY}" = "yes" ]] && update_leader_heartbeat
+
+        # sql_upgrade.php resolves its site from $_GET['site'], so prepend the
+        # assignment rather than editing the script in place.
+        if ! {
+            echo "<?php \$_GET['site'] = '${sitename}'; ?>"
+            cat "${OE_ROOT}/sql_upgrade.php"
+        } > "${OE_ROOT}/TEMPsql_upgrade.php"; then
+            echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
+            rm -f "${OE_ROOT}/TEMPsql_upgrade.php"
+            return 1
+        fi
+
+        # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
+        if ! su-exec apache php -f "${OE_ROOT}/TEMPsql_upgrade.php" -- --from="${from_release}"; then
+            echo "ERROR: Database upgrade failed for ${sitename} from ${from_release}" >&2
+            echo "The database may be partially upgraded. Review the errors above and either" >&2
+            echo "correct the underlying problem or restore your pre-upgrade backup." >&2
+            rm -f "${OE_ROOT}/TEMPsql_upgrade.php"
+            return 1
+        fi
+
+        rm -f "${OE_ROOT}/TEMPsql_upgrade.php"
+        echo "Completed: Upgrade database for ${sitename} from ${from_release}"
+    done
+
+    [[ "${AUTHORITY}" = "yes" ]] && update_leader_heartbeat
+    echo "Schema upgrade completed successfully"
 }
 
 # Performs the actual OpenEMR upgrade by running upgrade scripts.

--- a/docker/release/openemr.sh
+++ b/docker/release/openemr.sh
@@ -536,19 +536,13 @@ check_upgrade() {
     return 0
 }
 
-# Runs the database migration when the code's schema revision is ahead of the
-# installed one, independent of the docker-version marker.
+# Migrates any site whose schema revision is behind the code's, independent of
+# the docker-version marker.
 #
 # No-op on the ordinary paths: a fresh install is not configured yet when this
 # runs, and a release upgrade has already been migrated by fsupgrade-<N>.sh,
 # which advances the version table to the code's revision.
 check_schema_upgrade() {
-    local config_state
-    config_state=$(is_configured)
-    if [[ "${config_state}" != "1" ]]; then
-        return 0
-    fi
-
     # version.php is a standalone file of assignments, so requiring it directly
     # is safe here and deliberately avoids bootstrapping the application.
     local -i code_schema_version
@@ -558,26 +552,70 @@ check_schema_upgrade() {
         return 1
     fi
 
+    # Every site is evaluated on its own. Sites in a multisite bank can sit at
+    # different revisions, and the release a site is migrating *from* selects
+    # which files sql_upgrade.php applies -- it skips every file older than the
+    # --from it is given. Deriving one release from one database and reusing it
+    # everywhere would silently skip the migrations a lagging site still needs,
+    # then stamp its version row as current.
+    local dirdata
+    local sitename
+    for dirdata in "${OE_ROOT}"/sites/*/; do
+        sitename="${dirdata%/}"
+        sitename="${sitename##*/}"
+        upgrade_site_schema "${sitename}" "${code_schema_version}"
+    done
+
+    return 0
+}
+
+# Migrates one site when its schema revision is behind the code's.
+#
+# Mirrors the migration half of fsupgrade-<N>.sh rather than calling it: those
+# scripts also perform filesystem work keyed to a specific release, and there is
+# no release boundary to key to here.
+upgrade_site_schema() {
+    local sitename="$1"
+    local -i code_schema_version="$2"
+    local sqlconf="${OE_ROOT}/sites/${sitename}/sqlconf.php"
+
+    # An unconfigured site has nothing to migrate. This also covers the fresh
+    # install case, where check_upgrade runs before auto-configuration.
+    if [[ ! -f "${sqlconf}" ]]; then
+        return 0
+    fi
+    local site_config_state
+    site_config_state=$(php -r "require '${sqlconf}'; echo isset(\$config) && \$config ? 1 : 0;" 2>/dev/null || echo 0)
+    if [[ "${site_config_state}" != "1" ]]; then
+        return 0
+    fi
+
     wait_for_mysql
+
+    # Connect as the site's own user against the site's own database, which is
+    # the only way to read a non-default site's version table.
+    local db_params
+    db_params=$(php -r "require '${sqlconf}'; echo implode(\"\t\", [\$host, \$port, \$login, \$pass, \$dbase]);") || {
+        echo "ERROR: could not read database parameters from ${sqlconf}." >&2
+        return 1
+    }
+    local db_host db_port db_login db_pass db_name
+    IFS=$'\t' read -r db_host db_port db_login db_pass db_name <<< "${db_params}"
 
     # One row, two columns: the installed schema revision and the release it
     # belongs to. sql_upgrade.php keys its migration files on the latter.
-    #
-    # This reads the container's configured database, which is the site the
-    # image provisions. It is the trigger only -- once drift is detected the
-    # migration below covers every site under sites/.
     local version_row
     version_row=$(mariadb \
-        --host="${MYSQL_HOST}" \
-        --port="${MYSQL_PORT}" \
-        --user="${MYSQL_ROOT_USER}" \
-        --password="${MYSQL_ROOT_PASS}" \
+        --host="${db_host}" \
+        --port="${db_port}" \
+        --user="${db_login}" \
+        --password="${db_pass}" \
         "${MYSQL_SSL_OPTS[@]}" \
         --skip-column-names \
         --batch \
-        "${MYSQL_DATABASE}" \
+        "${db_name}" \
         -e 'SELECT v_database, CONCAT_WS(".", v_major, v_minor, v_patch) FROM version LIMIT 1') || {
-        echo "ERROR: could not read the version table from ${MYSQL_DATABASE}; cannot tell whether a schema upgrade is due." >&2
+        echo "ERROR: could not read the version table for ${sitename}; cannot tell whether a schema upgrade is due." >&2
         return 1
     }
 
@@ -589,56 +627,32 @@ check_schema_upgrade() {
         return 0
     fi
 
-    echo "Schema upgrade detected: database is at revision ${installed_schema_version} (${installed_release}), code needs ${code_schema_version}"
-    run_schema_upgrade "${installed_release}"
-}
-
-# Applies sql_upgrade.php to every site, starting from the release the database
-# is currently at.
-#
-# Mirrors the migration half of fsupgrade-<N>.sh rather than calling it: those
-# scripts also perform filesystem work keyed to a specific release, and there is
-# no release boundary to key to here.
-run_schema_upgrade() {
-    local from_release="$1"
-
+    echo "Schema upgrade detected for ${sitename}: database is at revision ${installed_schema_version} (${installed_release}), code needs ${code_schema_version}"
     [[ "${AUTHORITY}" = "yes" ]] && update_leader_heartbeat
 
-    local dirdata
-    local sitename
-    for dirdata in "${OE_ROOT}"/sites/*/; do
-        sitename="${dirdata%/}"
-        sitename="${sitename##*/}"
-
-        echo "Start: Upgrade database for ${sitename} from ${from_release}"
-        [[ "${AUTHORITY}" = "yes" ]] && update_leader_heartbeat
-
-        # sql_upgrade.php resolves its site from $_GET['site'], so prepend the
-        # assignment rather than editing the script in place.
-        if ! {
-            echo "<?php \$_GET['site'] = '${sitename}'; ?>"
-            cat "${OE_ROOT}/sql_upgrade.php"
-        } > "${OE_ROOT}/TEMPsql_upgrade.php"; then
-            echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
-            rm -f "${OE_ROOT}/TEMPsql_upgrade.php"
-            return 1
-        fi
-
-        # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-        if ! su-exec apache php -f "${OE_ROOT}/TEMPsql_upgrade.php" -- --from="${from_release}"; then
-            echo "ERROR: Database upgrade failed for ${sitename} from ${from_release}" >&2
-            echo "The database may be partially upgraded. Review the errors above and either" >&2
-            echo "correct the underlying problem or restore your pre-upgrade backup." >&2
-            rm -f "${OE_ROOT}/TEMPsql_upgrade.php"
-            return 1
-        fi
-
+    # sql_upgrade.php resolves its site from $_GET['site'], so prepend the
+    # assignment rather than editing the script in place.
+    if ! {
+        echo "<?php \$_GET['site'] = '${sitename}'; ?>"
+        cat "${OE_ROOT}/sql_upgrade.php"
+    } > "${OE_ROOT}/TEMPsql_upgrade.php"; then
+        echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
         rm -f "${OE_ROOT}/TEMPsql_upgrade.php"
-        echo "Completed: Upgrade database for ${sitename} from ${from_release}"
-    done
+        return 1
+    fi
 
+    # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
+    if ! su-exec apache php -f "${OE_ROOT}/TEMPsql_upgrade.php" -- --from="${installed_release}"; then
+        echo "ERROR: Database upgrade failed for ${sitename} from ${installed_release}" >&2
+        echo "The database may be partially upgraded. Review the errors above and either" >&2
+        echo "correct the underlying problem or restore your pre-upgrade backup." >&2
+        rm -f "${OE_ROOT}/TEMPsql_upgrade.php"
+        return 1
+    fi
+
+    rm -f "${OE_ROOT}/TEMPsql_upgrade.php"
     [[ "${AUTHORITY}" = "yes" ]] && update_leader_heartbeat
-    echo "Schema upgrade completed successfully"
+    echo "Completed: schema upgrade for ${sitename} from ${installed_release}"
 }
 
 # Performs the actual OpenEMR upgrade by running upgrade scripts.

--- a/docker/release/openemr.sh
+++ b/docker/release/openemr.sh
@@ -601,7 +601,10 @@ if (!isset($config) || !$config) {
     echo 'unconfigured';
     exit(0);
 }
-echo implode("\t", [$host, $port, $login, $pass, $dbase]);
+// Unit separator, not a tab: tab is IFS whitespace, so read would collapse a
+// run of them and an empty field -- a site with no database password -- would
+// shift every later value one position left.
+echo implode("\x1f", [$host, $port, $login, $pass, $dbase]);
 PHP
     ) || {
         echo "ERROR: could not read database parameters from ${sqlconf}." >&2
@@ -615,7 +618,7 @@ PHP
 
     wait_for_mysql
     local db_host db_port db_login db_pass db_name
-    IFS=$'\t' read -r db_host db_port db_login db_pass db_name <<< "${db_params}"
+    IFS=$'\x1f' read -r db_host db_port db_login db_pass db_name <<< "${db_params}"
 
     # One row, two columns: the installed schema revision and the release it
     # belongs to. sql_upgrade.php keys its migration files on the latter.

--- a/docker/release/openemr.sh
+++ b/docker/release/openemr.sh
@@ -579,26 +579,41 @@ upgrade_site_schema() {
     local -i code_schema_version="$2"
     local sqlconf="${OE_ROOT}/sites/${sitename}/sqlconf.php"
 
-    # An unconfigured site has nothing to migrate. This also covers the fresh
-    # install case, where check_upgrade runs before auto-configuration.
+    # A site directory without a sqlconf.php has no database to migrate.
     if [[ ! -f "${sqlconf}" ]]; then
         return 0
     fi
-    local site_config_state
-    site_config_state=$(php -r "require '${sqlconf}'; echo isset(\$config) && \$config ? 1 : 0;" 2>/dev/null || echo 0)
-    if [[ "${site_config_state}" != "1" ]]; then
+
+    # Connect as the site's own user against the site's own database, which is
+    # the only way to read a non-default site's version table.
+    #
+    # The path reaches PHP through the environment rather than interpolated into
+    # the source. A site directory name is an arbitrary filesystem string -- it
+    # may hold a quote, a backslash, a dollar sign or a newline -- so pasting one
+    # into a PHP literal would make the site list an eval surface.
+    local db_params
+    db_params=$(OPENEMR_SQLCONF="${sqlconf}" php <<'PHP'
+<?php
+require getenv('OPENEMR_SQLCONF');
+// An unconfigured site has nothing to migrate, which is not a failure: report
+// it in band so a nonzero status still means the file could not be read.
+if (!isset($config) || !$config) {
+    echo 'unconfigured';
+    exit(0);
+}
+echo implode("\t", [$host, $port, $login, $pass, $dbase]);
+PHP
+    ) || {
+        echo "ERROR: could not read database parameters from ${sqlconf}." >&2
+        return 1
+    }
+
+    # Fresh install: check_upgrade runs before auto-configuration.
+    if [[ "${db_params}" = 'unconfigured' ]]; then
         return 0
     fi
 
     wait_for_mysql
-
-    # Connect as the site's own user against the site's own database, which is
-    # the only way to read a non-default site's version table.
-    local db_params
-    db_params=$(php -r "require '${sqlconf}'; echo implode(\"\t\", [\$host, \$port, \$login, \$pass, \$dbase]);") || {
-        echo "ERROR: could not read database parameters from ${sqlconf}." >&2
-        return 1
-    }
     local db_host db_port db_login db_pass db_name
     IFS=$'\t' read -r db_host db_port db_login db_pass db_name <<< "${db_params}"
 
@@ -631,10 +646,13 @@ upgrade_site_schema() {
     [[ "${AUTHORITY}" = "yes" ]] && update_leader_heartbeat
 
     # sql_upgrade.php resolves its site from $_GET['site'], so prepend the
-    # assignment rather than editing the script in place.
+    # assignment rather than editing the script in place. The name is read from
+    # the environment at run time rather than written into the generated source,
+    # so the prologue is a fixed string no site name can reshape.
     if ! {
-        # shellcheck disable=SC2016 # $_GET is PHP source, not a shell expansion.
-        printf '<?php $_GET["site"] = "%s"; ?>\n' "${sitename}"
+        cat <<'PHP'
+<?php $_GET['site'] = getenv('OPENEMR_UPGRADE_SITE'); ?>
+PHP
         cat "${OE_ROOT}/sql_upgrade.php"
     } > "${OE_ROOT}/TEMPsql_upgrade.php"; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2
@@ -643,7 +661,7 @@ upgrade_site_schema() {
     fi
 
     # Drop privileges to apache: RootCliGuard (openemr#12267) refuses root for OpenEMR CLI scripts.
-    if ! su-exec apache php -f "${OE_ROOT}/TEMPsql_upgrade.php" -- --from="${installed_release}"; then
+    if ! OPENEMR_UPGRADE_SITE="${sitename}" su-exec apache php -f "${OE_ROOT}/TEMPsql_upgrade.php" -- --from="${installed_release}"; then
         echo "ERROR: Database upgrade failed for ${sitename} from ${installed_release}" >&2
         echo "The database may be partially upgraded. Review the errors above and either" >&2
         echo "correct the underlying problem or restore your pre-upgrade backup." >&2

--- a/docker/release/openemr.sh
+++ b/docker/release/openemr.sh
@@ -623,7 +623,7 @@ upgrade_site_schema() {
     local installed_release
     IFS=$'\t' read -r installed_schema_version installed_release <<< "${version_row}"
 
-    if [[ "${code_schema_version}" -le "${installed_schema_version}" ]]; then
+    if (( code_schema_version <= installed_schema_version )); then
         return 0
     fi
 
@@ -633,7 +633,8 @@ upgrade_site_schema() {
     # sql_upgrade.php resolves its site from $_GET['site'], so prepend the
     # assignment rather than editing the script in place.
     if ! {
-        echo "<?php \$_GET['site'] = '${sitename}'; ?>"
+        # shellcheck disable=SC2016 # $_GET is PHP source, not a shell expansion.
+        printf '<?php $_GET["site"] = "%s"; ?>\n' "${sitename}"
         cat "${OE_ROOT}/sql_upgrade.php"
     } > "${OE_ROOT}/TEMPsql_upgrade.php"; then
         echo "ERROR: could not stage sql_upgrade.php for ${sitename} (file missing?)" >&2

--- a/oauth2/authorize.php
+++ b/oauth2/authorize.php
@@ -31,6 +31,10 @@ try {
 } catch (\Throwable $e) {
     // TODO: handle exceptions properly
     error_log($e->getMessage());
-    // should never get here, but if we do, we can return a generic error response
-    die("An error occurred while processing the request. Please check the logs for more details.");
+    // Only answer when nothing has gone out yet -- see the matching note in
+    // apis/dispatch.php. After headers are sent this text would be appended to a
+    // response the client is already parsing, corrupting a payload that was correct.
+    if (!headers_sent()) {
+        die("An error occurred while processing the request. Please check the logs for more details.");
+    }
 }

--- a/oauth2/authorize.php
+++ b/oauth2/authorize.php
@@ -13,7 +13,9 @@
 use OpenEMR\BC\FallbackRouter;
 use OpenEMR\Common\Http\CurrentRequest;
 use OpenEMR\Common\Http\HttpRestRequest;
+use OpenEMR\Common\Http\RequestTerminator;
 use OpenEMR\RestControllers\ApiApplication;
+use Symfony\Component\HttpFoundation\Response;
 
 require_once "../vendor/autoload.php";
 
@@ -35,6 +37,9 @@ try {
     // apis/dispatch.php. After headers are sent this text would be appended to a
     // response the client is already parsing, corrupting a payload that was correct.
     if (!headers_sent()) {
-        die("An error occurred while processing the request. Please check the logs for more details.");
+        (new RequestTerminator())->error(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            'An error occurred while processing the request. Please check the logs for more details.'
+        );
     }
 }

--- a/tests/Acceptance/FhirSmokeTest.php
+++ b/tests/Acceptance/FhirSmokeTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Acceptance;
 
 use OpenEMR\Tests\Acceptance\Support\ArtifactBrowser;
+use OpenEMR\Tests\Acceptance\Support\JsonBody;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
@@ -58,10 +59,11 @@ final class FhirSmokeTest extends TestCase
             'FHIR /metadata must return 200 without auth per FHIR spec — 401/403 means the routing added an auth check',
         );
 
-        $body = json_decode($response->getContent(), true);
+        $body = JsonBody::decode($response);
         self::assertIsArray(
             $body,
-            'FHIR /metadata should return a JSON object; a non-JSON body means the response is an HTML error page',
+            'FHIR /metadata should return a JSON object; a non-JSON body means the response is an HTML error page. '
+                . JsonBody::describe($response),
         );
         self::assertSame(
             'CapabilityStatement',
@@ -95,10 +97,10 @@ final class FhirSmokeTest extends TestCase
             'SMART .well-known/smart-configuration must return 200 without auth per the SMART conformance spec',
         );
 
-        $body = json_decode($response->getContent(), true);
+        $body = JsonBody::decode($response);
         self::assertIsArray(
             $body,
-            'SMART well-known should return a JSON object',
+            'SMART well-known should return a JSON object. ' . JsonBody::describe($response),
         );
         // authorization_endpoint + token_endpoint are the minimum
         // signals a SMART client uses to bootstrap the auth flow. If

--- a/tests/Acceptance/OAuth2SmokeTest.php
+++ b/tests/Acceptance/OAuth2SmokeTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace OpenEMR\Tests\Acceptance;
 
 use OpenEMR\Tests\Acceptance\Support\ArtifactBrowser;
+use OpenEMR\Tests\Acceptance\Support\JsonBody;
 use OpenEMR\Tests\Acceptance\Support\ResponseHeaders;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
@@ -94,10 +95,11 @@ final class OAuth2SmokeTest extends TestCase
             'API-disabled response must be served as application/json — a text/html response means an unhandled framework exception rendered the default HTML error page instead of the RestConfig-shaped JSON error body',
         );
 
-        $body = json_decode($response->getContent(), true);
+        $body = JsonBody::decode($response);
         self::assertIsArray(
             $body,
-            'API-disabled response should be a JSON error object — a non-JSON body (raw HTML, empty response, redirect) means the response shape has regressed and machine-readable error handling is broken',
+            'API-disabled response should be a JSON error object — a non-JSON body (raw HTML, empty response, redirect) means the response shape has regressed and machine-readable error handling is broken. '
+                . JsonBody::describe($response),
         );
         self::assertArrayHasKey('message', $body, 'API-disabled response must carry a machine-readable "message" field');
         self::assertIsString($body['message']);
@@ -148,8 +150,11 @@ final class OAuth2SmokeTest extends TestCase
             'API-disabled DCR response must be served as application/json for machine-readable error handling',
         );
 
-        $body = json_decode($response->getContent(), true);
-        self::assertIsArray($body, 'API-disabled DCR response should be a JSON error object');
+        $body = JsonBody::decode($response);
+        self::assertIsArray(
+            $body,
+            'API-disabled DCR response should be a JSON error object. ' . JsonBody::describe($response),
+        );
         self::assertArrayHasKey('message', $body);
         self::assertIsString($body['message']);
         self::assertStringContainsString(

--- a/tests/Acceptance/Support/JsonBody.php
+++ b/tests/Acceptance/Support/JsonBody.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Acceptance\Support;
+
+use Symfony\Component\BrowserKit\Response;
+
+/**
+ * Decode a JSON response body, keeping enough of the raw bytes in the
+ * failure message to identify why it did not decode.
+ *
+ * `assertIsArray(json_decode(...))` on its own reports "Failed asserting
+ * that null is of type array" and throws the body away, which says only
+ * that the response was not the JSON the test wanted -- not whether it was
+ * an HTML error page, an empty body, a truncated payload, or valid JSON
+ * with something appended. Those need different fixes and the acceptance
+ * suite runs against a container that is torn down at the end of the job,
+ * so a body that is not in the failure output cannot be recovered later.
+ * openemr#13905 was a week of guesswork for exactly this reason: the
+ * bodies were correct JSON documents with a second document concatenated
+ * onto the end, which the discarded suffix would have shown immediately.
+ */
+final class JsonBody
+{
+    /**
+     * Bytes of the body to quote from each end. Large enough to show a
+     * decode-breaking prefix or suffix, small enough that a 36 KB
+     * CapabilityStatement does not bury the rest of the failure output.
+     */
+    private const EXCERPT_BYTES = 300;
+
+    /**
+     * @return array<array-key, mixed>|null Decoded object/array, or null when the body is not a JSON structure.
+     */
+    public static function decode(Response $response): ?array
+    {
+        $decoded = json_decode($response->getContent(), true);
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * Human-readable diagnosis of a body that failed to decode, for use as
+     * the tail of an assertion message.
+     */
+    public static function describe(Response $response): string
+    {
+        $body = $response->getContent();
+        if ($body === '') {
+            return 'Response body was empty.';
+        }
+
+        // Decode again rather than reading json_last_error_msg() from the
+        // caller's decode(): that error state is global to the process and any
+        // json_* call in between would silently replace it with an unrelated one.
+        json_decode($body, true);
+
+        return sprintf(
+            'json_decode: %s. Body was %d bytes: %s',
+            json_last_error_msg(),
+            strlen($body),
+            self::excerpt($body),
+        );
+    }
+
+    private static function excerpt(string $body): string
+    {
+        if (strlen($body) <= self::EXCERPT_BYTES * 2) {
+            return var_export($body, true);
+        }
+
+        return sprintf(
+            '%s ...[%d bytes elided]... %s',
+            var_export(substr($body, 0, self::EXCERPT_BYTES), true),
+            strlen($body) - (self::EXCERPT_BYTES * 2),
+            var_export(substr($body, -self::EXCERPT_BYTES), true),
+        );
+    }
+}

--- a/tests/Tests/Isolated/Acceptance/JsonBodyTest.php
+++ b/tests/Tests/Isolated/Acceptance/JsonBodyTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * @package   OpenEMR
+ *
+ * @link      https://www.open-emr.org
+ *
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc <https://opencoreemr.com/>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Acceptance;
+
+use OpenEMR\Tests\Acceptance\Support\JsonBody;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\BrowserKit\Response;
+
+/**
+ * The acceptance suite runs against a container that is destroyed when the CI
+ * job ends, so whatever a failure message does not carry is gone. These tests
+ * pin the two properties that make the message worth reading: the raw bytes
+ * survive into it, and a body too large to quote whole is still quoted at both
+ * ends -- openemr#13905 was a valid JSON document with a second one appended,
+ * which only the tail reveals.
+ */
+#[Group('isolated')]
+final class JsonBodyTest extends TestCase
+{
+    public function testDecodeReturnsTheDecodedStructure(): void
+    {
+        $decoded = JsonBody::decode(new Response('{"resourceType":"CapabilityStatement"}'));
+
+        $this->assertSame(['resourceType' => 'CapabilityStatement'], $decoded);
+    }
+
+    public function testDecodeReturnsNullForANonStructure(): void
+    {
+        // A bare JSON scalar decodes without error but is not the object the
+        // smoke tests are asserting on, so it has to read as a failure.
+        $this->assertNull(JsonBody::decode(new Response('"just a string"')));
+    }
+
+    public function testDescribeReportsAnEmptyBody(): void
+    {
+        $this->assertSame('Response body was empty.', JsonBody::describe(new Response('')));
+    }
+
+    public function testDescribeQuotesAShortBodyInFull(): void
+    {
+        $description = JsonBody::describe(new Response('<html>gateway timeout</html>'));
+
+        $this->assertStringContainsString('<html>gateway timeout</html>', $description);
+        $this->assertStringContainsString('28 bytes', $description);
+        $this->assertStringContainsString('Syntax error', $description);
+    }
+
+    public function testDescribeQuotesBothEndsOfALongBody(): void
+    {
+        // The openemr#13905 shape: a complete document with a second one
+        // appended by a post-response failure. The head alone looks correct, so
+        // a message that elides the tail cannot explain the decode failure.
+        $body = '{"resourceType":"CapabilityStatement","filler":"' . str_repeat('x', 2000) . '"}'
+            . '{"error":"An error occurred while processing the request."}';
+
+        $description = JsonBody::describe(new Response($body));
+
+        $this->assertStringContainsString('{"resourceType":"CapabilityStatement"', $description);
+        $this->assertStringContainsString('An error occurred while processing the request.', $description);
+        $this->assertStringContainsString('bytes elided', $description);
+    }
+
+    public function testDescribeDoesNotDependOnAPriorDecodeCall(): void
+    {
+        // json_last_error() is process-global, so describe() has to re-decode
+        // rather than read the error state left by the caller's decode().
+        $response = new Response('{"resourceType":"CapabilityStatement"}{"error":"boom"}');
+        JsonBody::decode($response);
+        json_decode('{"unrelated":true}');
+
+        $this->assertStringContainsString('Syntax error', JsonBody::describe($response));
+    }
+}


### PR DESCRIPTION
Fixes #13905.

## What was happening

The four failing assertions were decoding bodies that were **valid JSON with a second document concatenated onto the end** — which is why the status codes and `Content-Type` assertions above them all passed, and only `json_decode` noticed:

```
{"resourceType":"CapabilityStatement",...}{"error":"...","message":"An exception occurred
while executing a query: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'client_id'
in 'INSERT INTO'"}
```

Two independent defects stacked up.

**The database was never migrated.** `check_upgrade()` gated the migration solely on `docker/release/upgrade/docker-version`, which only advances at a release branch-cut. `version.php`'s `$v_database` moves as soon as the upgrade SQL merges, so an image built mid-cycle carries a newer schema than its marker admits. Booting one over an existing install runs new code against the previous release's schema with nothing to migrate it — here, master (`v_database` 543) over an 8.3.0 install (541), missing the `api_log.client_id` column that `8_3_0-to-8_4_0_upgrade.sql` adds.

**A post-response failure corrupted the body.** That column is written from a `kernel.terminate` listener, which runs *after* `$response->send()`. The exception could not change the status line or headers — they were already on the wire — but it unwound into the entry point's `catch`, which appended its own error output to a body the client was already reading. `apis/dispatch.php` guarded its `header()` call with `headers_sent()` and left the `die()` below it unconditional.

Docker Hub `next` passes because it was last built 2026-08-18 from the rel-830 line, predating the `client_id` insert — so `latest` → `next` has no drift to expose.

## Changes

- `docker/release/openemr.sh` — `check_schema_upgrade()` compares `$v_database` against the `version` table and runs `sql_upgrade.php` per site when the code is ahead. It cannot fire on the paths that already work: a fresh install is not configured yet when it runs, and a release upgrade has already advanced the version table via its `fsupgrade-<N>.sh`.
- `apis/dispatch.php`, `oauth2/authorize.php` — emit an error body only while `headers_sent()` is false. Both still log the failure.
- `tests/Acceptance/Support/JsonBody.php` — the smoke tests reported only "Failed asserting that null is of type array" and discarded the bytes, head and tail both, so a correct document with something appended read the same as an HTML error page. Failure messages now quote both ends of an undecodable body. The acceptance container is torn down with the job, so a body absent from the output cannot be recovered afterward.

## Verification

Against a locally built release image, booted over an 8.3.0 install:

| Path | Result |
|---|---|
| Upgrade 8.3.0 → PR-built | Migration runs, 541 → 543, `api_log.client_id` created |
| Second boot | No-op |
| Fresh install of PR-built | Untouched at 543, migration not triggered |

All four endpoints then return decodable JSON at the same sizes as a healthy `latest` (35809 / 7971 / 81 / 81), with zero `SQLSTATE` errors in the log. The response-body fix was verified separately against the *un*migrated schema, so it holds even when a post-response write fails for some other reason.

This PR touches `docker/release/**`, so `Acceptance test (docker)` auto-enables `build_locally` and the `Upgrade from_tag -> to_tag` jobs exercise the real path rather than the stale Docker Hub `next` tag.
