### PR TITLE
ci(rector): drop removed list-rules command

### DIFF
--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -55,8 +55,5 @@ jobs:
     - name: Create Rector cache directory
       run: mkdir -p /tmp/rector
 
-    - name: Rector List Rules
-      run: vendor/bin/rector list-rules
-
     - name: Rector Dry Run
       run: vendor/bin/rector process --dry-run


### PR DESCRIPTION
Rector 2.6.5 deprecated the `list-rules` command ([rector-src#8396](https://github.com/rectorphp/rector-src/pull/8396)) and 2.6.6 removed it, so the step fails the job outright:

```
 [ERROR] The "list-rules" command is deprecated and no longer provided.
         Run Rector with the set or rules you desire instead.
```

This is what blocks the `rector/rector` 2.6.6 bump in #13878. The step only printed diagnostic output and upstream offers no replacement command, so it is dropped; `rector process --dry-run` remains the actual check.
