### PR TITLE
docs(claude): document module/core boundaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -649,6 +649,45 @@ class ExampleService extends BaseService
 }
 ```
 
+## Module/Core Boundaries
+
+Dependencies point one way: a module reaches core by subscribing to an event,
+and core reaches a module by dispatching one.
+
+- **Core must not name a class from a module's namespace.** A module namespace
+  (`OpenEMR\Modules\...`, or a vendor-prefixed variant such as
+  `Acme\OpenEMR\Modules\...`) must not appear in a `use` statement, a type
+  declaration, or a static call under `src/`, `library/`, `templates/`, or
+  `interface/` outside `interface/modules/`. Some modules ship in-tree under
+  `interface/modules/custom_modules/` and others arrive through Composer, so a
+  name that resolves in a development checkout is not guaranteed to resolve in
+  a given deployment — and a bundled module can still be removed or disabled.
+  Wrapping the reference in an "is this module installed" check does not fix
+  it: core's source still names a symbol it does not own, which is what static
+  analysis, `composer-require-checker`, and the test suite see. A probe that
+  assembles the class name as a string and passes it to `class_exists()` is
+  the exception, because no analyzer resolves a string as a dependency.
+- **Core robustness fixes must not be gated on a module being present.** If
+  core has a bug (null handling, escaping, error paths), fix it
+  unconditionally — the fix must hold whether or not any module is installed.
+- **Module-specific UI belongs in the module,** emitted via events
+  (`MenuEvent`, `RenderEvent`, `EncounterMenuEvent`) or module controllers,
+  not hardcoded into a core template behind a module check.
+
+When core needs a value only a module can supply, dispatch an event that
+carries the inputs, let listeners contribute, and use whatever came back.
+`OpenEMR\Events\Core\StyleFilterEvent` is the shape: core constructs the event
+with its inputs, listeners fill an accumulator, core uses the result. With no
+listener subscribed the accumulator is empty and core behaves exactly as it
+does without the module, which is also how to verify the seam — exercise it
+both ways and diff. Give the event a slot per insertion point rather than one
+trailing slot; code with early-exit paths cannot express "contribute before
+the first return" with a single append.
+
+`library/dated_reminder_functions.php` predates this rule and imports
+`OpenEMR\Modules\FaxSMS\Controller\AppDispatch` directly. Treat it as
+something to migrate to an event, not as precedent.
+
 ## File Headers
 
 When modifying PHP files, ensure proper docblock:


### PR DESCRIPTION
`CLAUDE.md` covers services, DI, typing, and error handling, but says nothing about which direction core and modules are allowed to depend on each other. With no rule written down, a core file importing a module class does not read as wrong — and `library/dated_reminder_functions.php:20` already does it (`use OpenEMR\Modules\FaxSMS\Controller\AppDispatch`).

This adds a `## Module/Core Boundaries` section stating the one-way rule — a module reaches core by subscribing to an event, core reaches a module by dispatching one — plus the seam to use when core genuinely needs a value only a module can supply.

Three things worth flagging for review:

**The rule is not "core breaks without the module."** Several modules ship in-tree (`oe-module-faxsms`, `oe-module-weno`, `oe-module-dorn`), so for those the import resolves in every checkout. The argument here is narrower: a name that resolves in a development checkout is not guaranteed to resolve in a deployment, a bundled module can still be removed or disabled, and either way the coupling is what PHPStan, `composer-require-checker`, and the test suite see. An "is this module installed" check around the call does not change what the source names.

**Module namespaces are vendor-prefixed.** `src/Core/ModulesClassLoader.php:19` documents `Acme\OpenEMR\Modules\MyUniqueModule`, so the rule names both that shape and plain `OpenEMR\Modules\...`.

**`dated_reminder_functions.php` is called out as pre-existing, not as precedent.** I have not touched it here — migrating it to an event is a separate change, and I did not want a docs PR to carry a behavior change. I also did not claim it is the only such import in the tree; I only searched for it, and a search cannot establish absence.

The event-accumulator paragraph cites `OpenEMR\Events\Core\StyleFilterEvent` as the shape to copy: core constructs the event with its inputs, listeners fill an accumulator, core uses the result, and with no listener subscribed the accumulator is empty and core behaves exactly as it does without the module. That last property is also the test — exercise the path both ways and diff.

Text is hard-wrapped to match the rest of the file. Happy to reword or drop any of the three bullets if the project would rather state the boundary more loosely.