### PR TITLE
fix(appointments): advance pc_time when appointment status changes

### DIFF
--- a/src/Services/AppointmentService.php
+++ b/src/Services/AppointmentService.php
@@ -598,7 +598,9 @@ class AppointmentService extends BaseService
             $appt = $appt[0];
         }
 
-        $sql = "UPDATE " . self::TABLE_NAME . " SET pc_apptstatus = ? WHERE pc_eid = ? ";
+        // pc_time is the record's last modified timestamp and is surfaced as meta.lastUpdated
+        // by FhirAppointmentService, so it must move whenever the appointment changes.
+        $sql = "UPDATE " . self::TABLE_NAME . " SET pc_apptstatus = ?, pc_time = NOW() WHERE pc_eid = ? ";
         $binds = [$status, $eid];
 
         if (!empty($appt['pid'])) {

--- a/tests/Tests/Services/AppointmentServiceTest.php
+++ b/tests/Tests/Services/AppointmentServiceTest.php
@@ -16,6 +16,7 @@
 
 namespace OpenEMR\Tests\Services;
 
+use OpenEMR\Common\Database\QueryUtils;
 use OpenEMR\Services\AppointmentService;
 use OpenEMR\Tests\Fixtures\AppointmentFixtureManager;
 use Particle\Validator\ValidationResult;
@@ -238,6 +239,46 @@ class AppointmentServiceTest extends TestCase
         // Verify it's gone
         $appointment = $this->appointmentService->getAppointment($insertId);
         $this->assertEmpty($appointment, "Appointment should be deleted");
+    }
+
+    #[Test]
+    public function testUpdateAppointmentStatusUpdatesLastModifiedTime(): void
+    {
+        $insertId = $this->appointmentService->insert($this->testPid, $this->appointmentData);
+        $this->assertGreaterThan(0, $insertId);
+
+        // Backdate pc_time so the assertion does not depend on how many appointment
+        // operations happen to land inside the same second.
+        $backdated = '2020-01-01 00:00:00';
+        QueryUtils::sqlStatementThrowException(
+            "UPDATE openemr_postcalendar_events SET pc_time = ? WHERE pc_eid = ?",
+            [$backdated, $insertId]
+        );
+
+        $this->appointmentService->updateAppointmentStatus($insertId, '@', 'admin');
+
+        $row = QueryUtils::querySingleRow(
+            "SELECT pc_apptstatus, pc_time FROM openemr_postcalendar_events WHERE pc_eid = ?",
+            [$insertId]
+        );
+
+        // updateAppointmentStatus writes a patient_tracker row that the fixture manager
+        // does not own, so clean it up here before asserting.
+        QueryUtils::sqlStatementThrowException(
+            "DELETE FROM patient_tracker_element WHERE pt_tracker_id IN "
+            . "(SELECT id FROM patient_tracker WHERE eid = ?)",
+            [$insertId]
+        );
+        QueryUtils::sqlStatementThrowException("DELETE FROM patient_tracker WHERE eid = ?", [$insertId]);
+
+        $this->assertIsArray($row);
+        $this->assertEquals('@', $row['pc_apptstatus'], "Status should be updated to Arrived");
+        $this->assertGreaterThan(
+            $backdated,
+            $row['pc_time'],
+            "pc_time is surfaced as meta.lastUpdated by FhirAppointmentService and backs the "
+            . "_lastUpdated search parameter, so a status change must advance it"
+        );
     }
 
     #[Test]


### PR DESCRIPTION
### What this fixes

`AppointmentService::updateAppointmentStatus()` wrote `pc_apptstatus` without touching `pc_time`.

`FhirAppointmentService` maps `pc_time` to both the `_lastUpdated` search parameter (`src/Services/FHIR/FhirAppointmentService.php:78`) and `meta.lastUpdated` on the resource (`:94`), and derives `Appointment.status` from `pc_apptstatus` (`:101-152`). So a status change altered the resource while leaving its last-modified value untouched, and a client syncing incrementally on `_lastUpdated` never saw the change.

Other callers already keep the two in step:

- `AppointmentService::insert()` sets `pc_time = NOW()` (`src/Services/AppointmentService.php:330`)
- the calendar edit paths set `pc_apptstatus` and `pc_time = NOW()` in the same statement (`interface/main/calendar/add_edit_event.php:644`, `:766`)

This brings the status-update path in line with them.

### Scope

Deliberately narrow. This changes one method and nothing else.

Other paths change status without updating `pc_time` (`library/encounter_events.inc.php:48`, `interface/forms/group_attendance/functions.php:91`, `library/MedEx/API.php:1464` and `:1482`). They are **not** touched here, because fixing them raises a design question that belongs to a maintainer: `MedEx` reads `pc_time` as a creation time (see the comment at `library/MedEx/API.php:2337`), while the FHIR layer reads it as last-modified.

That question, the full path list, and an experiment showing what a schema-level `ON UPDATE CURRENT_TIMESTAMP` would do, are in #13922. If you would prefer the schema fix instead of this one, I am happy to send it.

### Testing

Added `testUpdateAppointmentStatusUpdatesLastModifiedTime`. It backdates `pc_time`, changes the status, and asserts the timestamp advanced. It also cleans up the `patient_tracker` rows the call creates, which the fixture manager does not own.

Verified on a local `development-easy` environment against `master`:

| | result |
|---|---|
| new test without this change | fails: `Failed asserting that '2020-01-01 00:00:00' is greater than '2020-01-01 00:00:00'` |
| new test with this change | passes |
| `AppointmentServiceTest` | 27 tests, 105 assertions, all pass |
| `--testsuite services` | 760 tests, 3509 assertions, no failures from this change |
| `vendor/bin/phpcs` on both changed files | clean |

### Disclosure

Investigated and written with AI assistance (Claude Code), per the AI-Assisted Contributions section of CONTRIBUTING.md. The commit carries a `Generated-By: Claude` trailer. All file and line references and all test results above were verified against a running instance.
