### PR TITLE
test(docker): pin code-version via bind-mount in Docker Upgrade Process test

### DIFF
--- a/docker/container_benchmarking/test_suite.sh
+++ b/docker/container_benchmarking/test_suite.sh
@@ -1319,6 +1319,28 @@ test_docker_upgrade() {
     local flex_env_vars
     flex_env_vars=$(get_flex_env_vars)
 
+    # Pre-write the code-version bind-mount source (see openemr volumes below).
+    # openemr.sh's check_upgrade requires /root/docker-version to equal the code
+    # copy at ${OE_ROOT}/docker-version for an upgrade to fire. In a production
+    # image both come from the same build so they always match; in a locally-
+    # built branch-cut PR image the /root/ copy is ahead (bumped by the PR)
+    # while the code copy came from a fresh git clone of the target branch
+    # that predates the PR merge. openemr.sh resyncs at fresh-install but that
+    # write lives in the writable layer and is wiped by Step 3's recreate.
+    # Bind-mounting a host file over the code copy makes the value survive.
+    if ! docker run --rm --entrypoint cat "${IMAGE_TAG}" /root/docker-version \
+            > "${test_dir}/code-version-override" 2>/dev/null; then
+        log_test_result "${test_name}" "FAIL" "Could not read /root/docker-version from image for bind-mount override"
+        return 1
+    fi
+    if [[ ! -s "${test_dir}/code-version-override" ]]; then
+        log_test_result "${test_name}" "FAIL" "/root/docker-version was empty in image; cannot prepare bind-mount override"
+        return 1
+    fi
+    local override_version
+    override_version=$(cat "${test_dir}/code-version-override" 2>/dev/null || echo "?")
+    log_info "Code-version bind-mount override pinned to: ${override_version}"
+
     cat > "${test_dir}/docker-compose.yml" <<EOF
 
 services:
@@ -1357,6 +1379,10 @@ services:
       - "8088:80"
     volumes:
       - upgrade_sites:/var/www/localhost/htdocs/openemr/sites
+      # Bind-mount pins the code-version file so it survives Step 3's recreate.
+      # Prepared above from /root/docker-version inside the built image; see
+      # the comment on that block for the full rationale.
+      - ${test_dir}/code-version-override:/var/www/localhost/htdocs/openemr/docker-version:ro
     healthcheck:
       test: ["CMD", "curl", "-fsSLo", "/dev/null", "http://localhost/"]
       start_period: 10m


### PR DESCRIPTION
## Summary

Fixes the Docker Upgrade Process test on branch-cut PRs (e.g. #13924, #13926).

The test recreates its container mid-test to simulate an upgrade (Step 3, since #13614). Recreating wipes the writable layer, including the `${OE_ROOT}/docker-version` file that `openemr.sh` writes back on fresh-install to match `/root/docker-version`.

For a normal production image both files come from the same build so they always match. On a branch-cut PR the `docker/release/` files bump ahead (new `fsupgrade-N.sh`, `docker-version` += 1) while the openemr source cloned inside the image at build time still points at the pre-PR branch tip. Result: `/root/docker-version` = N, code copy = N-1, so `check_upgrade`'s `root == code` guard fails and no upgrade fires — the test asserts `Upgrade started: 0` and fails.

**Fix:** bind-mount the code-version file from a host-side source that we pre-populate from the built image's `/root/docker-version`. The mount survives the recreate, keeps root == code, and lets the guard fire.

Test-only change; no production code touched.

## Test plan

- [ ] Container Functionality (release) turns green on this PR (baseline confirmation on master where the mismatch doesn't manifest)
- [ ] Rebase branch-cut PRs #13924 (rel-840) and #13926 (master-side) after this + the rel-840 sibling PR land — expect their Container Functionality release check to go green

## Notes

- `docker/container_benchmarking/` is not on the byte-identical sync list, so a sibling PR against `rel-840` is opened separately with the identical change.
- Medium-term direction is switching the release image build to a package-style source (respects `.gitattributes`), at which point this test-time mismatch stops occurring — the bind-mount becomes a no-op it can safely be removed.