### PR TITLE
fix(api): honour the medication flag when creating a prescription

### DIFF
--- a/library/classes/Prescription.class.php
+++ b/library/classes/Prescription.class.php
@@ -93,6 +93,7 @@ use OpenEMR\Common\Lists\IssueTypeRegistry;
 use OpenEMR\Common\ORDataObject\ORDataObject;
 use OpenEMR\Common\ORDataObject\Person;
 use OpenEMR\Common\Session\SessionWrapperFactory;
+use OpenEMR\Common\Uuid\UuidRegistry;
 use OpenEMR\Core\OEGlobalsBag;
 use OpenEMR\Services\FHIR\Enum\FHIRMedicationIntentEnum;
 use OpenEMR\Services\ListService;
@@ -295,6 +296,23 @@ class Prescription extends ORDataObject
     }
 
     /**
+     * Apply the medication list mirror for this prescription.
+     *
+     * `persist()` runs the mirror only when the `medication` flag CHANGES.
+     * That is correct for the edit form: loading a row and saving it unchanged
+     * must not rewrite the medication list. A caller that creates a
+     * prescription outside this class has no previous value to change from, so
+     * it needs a way to run the mirror once, explicitly.
+     *
+     * Safe to call more than once. The mirror looks for an existing list entry
+     * by prescription id, then by drug title, before it inserts anything.
+     */
+    public function syncMedicationList(): void
+    {
+        $this->handle_medication_list_updates();
+    }
+
+    /**
      * Handle medication list updates moved from set_medication function
      */
     private function handle_medication_list_updates(): void
@@ -361,10 +379,20 @@ class Prescription extends ORDataObject
 
             if (!isset($inactiveDataRow['id'])) {
                 //add the record to the medication list
+                // The row needs a uuid at insert time. Without one, anything
+                // that reads the medication list through the service layer
+                // (GET /api/patient/{pid}/medication, FHIR) fails on the null
+                // until the missing-uuid backfill happens to run.
                 $medListId = QueryUtils::sqlInsert(
-                    "insert into lists(date,begdate,type,activity,pid,user,groupname,title) "
-                    . " values (now(),cast(now() as date),'medication',1,?,?,?,?)",
-                    [$this->patient->id, $session->get('authUser'), $session->get('authProvider'), $this->drug]
+                    "insert into lists(uuid,date,begdate,type,activity,pid,user,groupname,title) "
+                    . " values (?,now(),cast(now() as date),'medication',1,?,?,?,?)",
+                    [
+                        UuidRegistry::getRegistryForTable('lists')->createUuid(),
+                        $this->patient->id,
+                        $session->get('authUser'),
+                        $session->get('authProvider'),
+                        $this->drug,
+                    ]
                 );
                 $this->gen_lists_medication($medListId);
             } else {

--- a/src/Services/ListService.php
+++ b/src/Services/ListService.php
@@ -185,7 +185,12 @@ class ListService
 
     public function insert($data)
     {
+        // The row needs a uuid at insert time. Without one, reading the list
+        // back through this same service throws on the null until the
+        // missing-uuid backfill happens to run, so POST then GET on the same
+        // collection returns 500 and then heals on its own.
         $sql  = " INSERT INTO lists SET";
+        $sql .= "     uuid=?,";
         $sql .= "     date=NOW(),";
         $sql .= "     activity=1,";
         $sql .= "     pid=?,";
@@ -198,6 +203,7 @@ class ListService
         return sqlInsert(
             $sql,
             [
+                UuidRegistry::getRegistryForTable('lists')->createUuid(),
                 $data['pid'],
                 $data['type'],
                 $data["title"],

--- a/src/Services/PrescriptionService.php
+++ b/src/Services/PrescriptionService.php
@@ -631,6 +631,7 @@ class PrescriptionService extends BaseService
         $results = QueryUtils::sqlInsert($sql, $binds);
 
         if ($results) {
+            $this->syncMedicationList((int) $results, $filteredData);
             $processingResult->addData([
                 'id' => $results,
                 'uuid' => UuidRegistry::uuidToString($filteredData['uuid'])
@@ -640,6 +641,36 @@ class PrescriptionService extends BaseService
         }
 
         return $processingResult;
+    }
+
+    /**
+     * Mirror a newly created prescription onto the patient medication list.
+     *
+     * `prescriptions.medication` means "this drug also belongs on the patient's
+     * medication list". The UI honours that: {@see \Prescription::persist()}
+     * inserts the `lists` row and links it through
+     * `lists_medication.prescription_id`. This service accepted the field,
+     * wrote the column, and did none of that work, so a prescription created
+     * over the API claimed to be on the medication list while nothing had put
+     * it there.
+     *
+     * The link is not cosmetic. FHIR `MedicationRequest` reads
+     * `prescriptions UNION lists`, and the `lists` half of that union excludes
+     * rows whose `lists_medication.prescription_id` is set. Writing the `lists`
+     * row WITHOUT the link would return the same drug twice. Delegating to the
+     * legacy class keeps both writes in one place rather than duplicating them.
+     *
+     * @param int                  $prescriptionId The id of the row just inserted.
+     * @param array<string, mixed> $data           The filtered insert payload.
+     */
+    private function syncMedicationList(int $prescriptionId, array $data): void
+    {
+        $flag = $data['medication'] ?? null;
+        if (!is_scalar($flag) || (int) $flag === 0) {
+            return;
+        }
+
+        (new \Prescription($prescriptionId))->syncMedicationList();
     }
 
     /**

--- a/tests/Tests/Api/PrescriptionApiTest.php
+++ b/tests/Tests/Api/PrescriptionApiTest.php
@@ -22,11 +22,14 @@ class PrescriptionApiTest extends TestCase
 {
     private const PRESCRIPTION_API_ENDPOINT = "/apis/default/api/prescription";
     private const PATIENT_API_ENDPOINT = "/apis/default/api/patient";
+    private const MEDICATION_LIST_ENDPOINT = "/apis/default/api/patient/%d/medication";
+    private const FHIR_MEDICATION_REQUEST_ENDPOINT = "/apis/default/fhir/MedicationRequest";
 
     private ApiTestClient $testClient;
     private FixtureManager $fixtureManager;
     private int $testPatientPid;
     private string $testPatientUuid;
+    private string $drugSuffix;
 
     protected function setUp(): void
     {
@@ -35,6 +38,10 @@ class PrescriptionApiTest extends TestCase
         $this->testClient->setAuthToken(ApiTestClient::OPENEMR_AUTH_ENDPOINT);
 
         $this->fixtureManager = new FixtureManager();
+        // Prescriptions and list rows outlive removePatientFixtures(), and pids
+        // are reused, so a fixed drug name would let one run see the previous
+        // run's rows. Make every drug name unique to this test instance.
+        $this->drugSuffix = ' ' . bin2hex(random_bytes(4));
 
         // Create a patient via API for prescriptions
         $patientFixture = $this->fixtureManager->getSinglePatientFixture();
@@ -207,6 +214,113 @@ class PrescriptionApiTest extends TestCase
 
     /**
      * @param array<string, mixed> $data
+     * @return array{id: int, uuid: string}
+     */
+    /**
+     * `prescriptions.medication` means "this drug also belongs on the patient's
+     * medication list". The UI honours that by inserting the `lists` row and
+     * linking it. The API accepted the field, wrote the column, and did none of
+     * that work, so the row claimed a list entry that did not exist.
+     */
+    public function testPostWithMedicationFlagAddsToMedicationList(): void
+    {
+        $data = $this->buildPrescriptionData($this->drugName('Medication List Drug'));
+        $data['medication'] = 1;
+        $this->createPrescription($data);
+
+        $entries = $this->medicationListEntries();
+        $titles = array_column($entries, 'title');
+        $this->assertContains($this->drugName('Medication List Drug'), $titles, 'drug should appear on the medication list');
+
+        $entry = null;
+        foreach ($entries as $candidate) {
+            if (($candidate['title'] ?? null) === $this->drugName('Medication List Drug')) {
+                $entry = $candidate;
+                break;
+            }
+        }
+        $this->assertIsArray($entry);
+        // The list row is read back through the service layer, which needs a
+        // uuid. A row inserted without one fails on read until the
+        // missing-uuid backfill happens to run.
+        $this->assertIsString($entry['uuid'] ?? null);
+        $this->assertNotEmpty($entry['uuid']);
+    }
+
+    /**
+     * FHIR MedicationRequest reads `prescriptions UNION lists`, and the `lists`
+     * half excludes rows that carry `lists_medication.prescription_id`. Writing
+     * the list row WITHOUT that link returns the same drug twice, which is a
+     * worse outcome than the missing list entry it would fix.
+     */
+    public function testPostWithMedicationFlagDoesNotDuplicateMedicationRequest(): void
+    {
+        $data = $this->buildPrescriptionData($this->drugName('No Duplicate Drug'));
+        $data['medication'] = 1;
+        $this->createPrescription($data);
+
+        $response = $this->testClient->get(
+            self::FHIR_MEDICATION_REQUEST_ENDPOINT,
+            ['patient' => $this->testPatientUuid]
+        );
+        $this->assertEquals(200, $response->getStatusCode());
+        /** @var array{entry?: array<int, array{resource?: array<string, mixed>}>} $bundle */
+        $bundle = json_decode((string) $response->getBody(), true);
+
+        $matches = 0;
+        foreach ($bundle['entry'] ?? [] as $bundleEntry) {
+            $concept = $bundleEntry['resource']['medicationCodeableConcept'] ?? [];
+            if (is_array($concept) && ($concept['text'] ?? null) === $this->drugName('No Duplicate Drug')) {
+                $matches++;
+            }
+        }
+        $this->assertSame(1, $matches, 'one prescription must not produce two MedicationRequest resources');
+    }
+
+    public function testPostWithoutMedicationFlagLeavesItOffTheMedicationList(): void
+    {
+        $data = $this->buildPrescriptionData($this->drugName('Prescription Only Drug'));
+        $data['medication'] = 0;
+        $this->createPrescription($data);
+
+        $titles = array_column($this->medicationListEntries(), 'title');
+        $this->assertNotContains($this->drugName('Prescription Only Drug'), $titles);
+    }
+
+    private function drugName(string $base): string
+    {
+        return $base . $this->drugSuffix;
+    }
+
+    /**
+     * The medication list endpoint answers 404 rather than an empty array when
+     * the patient has no medications, so treat anything but 200 as empty.
+     *
+     * @return list<array<mixed>>
+     */
+    private function medicationListEntries(): array
+    {
+        $response = $this->testClient->get(sprintf(self::MEDICATION_LIST_ENDPOINT, $this->testPatientPid));
+        if ($response->getStatusCode() !== 200) {
+            return [];
+        }
+        $decoded = json_decode((string) $response->getBody(), true);
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        $entries = [];
+        foreach ($decoded as $row) {
+            if (is_array($row)) {
+                $entries[] = $row;
+            }
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @param  array<string, mixed> $data
      * @return array{id: int, uuid: string}
      */
     private function createPrescription(array $data): array


### PR DESCRIPTION
Fixes #13939.

## What is wrong

`POST /api/prescription` accepts a `medication` field and writes it to the column. The column means "this drug also belongs on the patient's medication list", and the UI honours that: `Prescription::persist()` inserts the `lists` row and `gen_lists_medication()` links it through `lists_medication.prescription_id`.

`PrescriptionService::insert()` does a plain `INSERT` and none of that work, so a prescription created over the API asserts a medication list entry that does not exist.

## Why the naive fix is wrong

Writing the `lists` row without the link duplicates the drug in FHIR. The `lists` half of the union in `PrescriptionService` ends with:

```sql
WHERE type = 'medication'
  AND lists_medication.prescription_id IS NULL
```

I measured this on a first attempt: five medications returned ten `MedicationRequest` resources. **One of the added tests exists purely to fail if a later change reintroduces that**, since the symptom it produces is quieter than the one being fixed.

## Approach

Rather than reimplement the mirror in the service, expose it on the legacy class and call it. `persist()` runs the mirror only when the flag CHANGES, which is correct for the edit form but means a caller that has just created a row has no way to trigger it. Loading the row and saving it sets the original value equal to the new one, so nothing fires.

There is no `PUT` route for prescriptions, only create and soft delete, so `insert()` is the whole writable surface and no update path needs the same treatment.

## Second commit

`ListService::insert()` sets no `uuid`, so reading the medication list back through the service layer throws on the null until the missing-uuid backfill runs. That matters here because the first commit creates `lists` rows, and without this they would be unreadable by the endpoint meant to display them. It is also a defect on its own: `POST` then `GET` on the same collection returns 500 and then heals by itself, which presents as an intermittent fault.

**Happy to split that into its own pull request if you would prefer.**

## Verification

All against a local instance, OpenEMR flex, PHP 8.5.10, MariaDB 12.3.3.

| | before | after |
|---|---|---|
| `lists` row of type medication | none | present |
| `lists_medication` link | none | present, carries the prescription id |
| `GET /api/patient/{pid}/medication` | 404 | 200, drug present, uuid populated |
| FHIR `MedicationRequest` | 1 | **1**, not 2 |
| Generated C-CDA | drug present | drug present |

`medication: 0` creates no list row.

| check | result |
|---|---|
| `phpunit --testsuite api` | 175 tests, 1215 assertions, 0 failures |
| `phpunit --testsuite api --filter PrescriptionApiTest`, fix reverted | fails, as it should |
| `phpunit --testsuite unit` | 373 tests, 0 failures |
| `phpcs` on the changed files | clean |
| `phpstan`, full run, 4567 files | no errors |

## Tests added

Three, on `PrescriptionApiTest`, plus type annotations on an existing helper so the file stays clean under phpstan after the line numbers move.

- the flag puts the drug on the medication list, and the row carries a uuid
- one prescription produces exactly one `MedicationRequest`
- `medication: 0` leaves it off the list

Drug names carry a random suffix per run. The fixtures remove the patient but leave prescriptions and list rows behind, and pids get reused, so a fixed name lets one run read the previous run's data and pass when it should fail. My first version of these tests did exactly that.

---

Developed with AI assistance (Claude). The reproduction, the measurements, the patch and every test run above were performed and verified by me on a local instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139nhdMmDonALJW7mT5xHSD
