### PR TITLE
docs(api): add the missing license header to AuthorizationListener

### DIFF
--- a/src/RestControllers/Subscriber/AuthorizationListener.php
+++ b/src/RestControllers/Subscriber/AuthorizationListener.php
@@ -9,7 +9,11 @@
  * We probably need to refactor this in the future to have a more robust policy decision point (PDP) and policy enforcement point (PEP) system.
  * This would allow for more flexibility in the authorization process and would allow for more complex authorization scenarios.
  *
- *
+ * @package   openemr
+ * @link      https://www.open-emr.org
+ * @author    Stephen Nielson <snielson@discoverandchange.com>
+ * @copyright Copyright (c) 2025 Stephen Nielson <snielson@discoverandchange.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
 namespace OpenEMR\RestControllers\Subscriber;


### PR DESCRIPTION
`src/RestControllers/Subscriber/AuthorizationListener.php` has a prose docblock describing the class, but none of the `@package`/`@link`/`@author`/`@copyright`/`@license` tags, so the GPL-3.0 grant the repository LICENSE makes is not stated at the file. This adds them to the existing docblock rather than opening a second one.

Attribution comes from the file's own history: created by Stephen Nielson in the API route refactor (#8701) and developed by him through #9457 and #9515; every later commit touching it is a tree-wide mechanical refactor. Happy to change the copyright line if it should read differently.

Comments only — no behavior change.

**The rest of the directory is in the same state.** `CORSListener`, `ExceptionHandlerListener`, `RoutesExtensionListener`, `SessionCleanupListener`, `SiteSetupListener`, `TelemetryListener`, `ViewRendererListener`, and the `src/RestControllers/Authorization/` classes all came in with #8701 and none carry a header either. I kept this PR to the one file; say the word and I'll extend it to cover the set.
