### PR TITLE
fix(core): fall back instead of fataling when a global is unusable (rel-840 backport)

### DIFF
--- a/src/Core/OEGlobalsBag.php
+++ b/src/Core/OEGlobalsBag.php
@@ -13,6 +13,7 @@
 namespace OpenEMR\Core;
 
 use OpenEMR\BC\Deprecation;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\Traits\SingletonTrait;
 use Symfony\Component\HttpFoundation\ParameterBag;
 
@@ -169,5 +170,91 @@ class OEGlobalsBag extends ParameterBag
         return $this->hasKernel()
             ? $this->getKernel()->getIncludeRoot()
             : $this->getString('include_root');
+    }
+
+    public function getString(string $key, string $default = ''): string
+    {
+        try {
+            return parent::getString($key, $default);
+        } catch (\UnexpectedValueException $e) {
+                $this->reportUnusableValue($key, $default, $e);
+                return $default;
+        }
+    }
+
+    /**
+     * Falls back to the default when a stored global cannot satisfy the requested filter,
+     * instead of throwing the way ParameterBag does.
+     *
+     * ParameterBag is built for HTTP request input, where rejecting a malformed value loudly is
+     * the correct behavior -- the request is the untrusted thing and failing it is cheap. This
+     * bag wraps persisted configuration read from the `globals` table, where the same policy is
+     * actively harmful: every typed getter runs during interface/globals.php, so a single bad row
+     * takes down every page in the installation, including the Administration > Globals screen an
+     * operator would use to correct it. Recovery then requires direct SQL access.
+     *
+     * The bar is low to trip: `globals`.`gl_value` is `varchar(255) NOT NULL DEFAULT ''`, and an
+     * empty string fails FILTER_VALIDATE_INT, so any integer-typed global present in the table
+     * with no value is enough.
+     *
+     * Falling back to the caller's default makes a corrupt value behave exactly like an absent
+     * one, which is a state every caller already handles. The substitution is recorded so it does
+     * not pass silently.
+     *
+     * @param array{flags?: int, options?: array<mixed>}|int $options
+     */
+    public function filter(string $key, mixed $default = null, int $filter = \FILTER_UNSAFE_RAW, mixed $options = []): mixed
+    {
+        try {
+            return parent::filter($key, $default, $filter, $options);
+        } catch (\UnexpectedValueException $e) {
+            $this->reportUnusableValue($key, $default, $e);
+            return $default;
+        }
+    }
+
+    /**
+     * Same fallback as {@see self::filter()}; getEnum() raises its own exception rather than
+     * going through filter(), so it needs its own guard.
+     *
+     * @template T of \BackedEnum
+     *
+     * @param class-string<T> $class
+     * @param ?T $default
+     * @return ($default is null ? T|null : T)
+     */
+    public function getEnum(string $key, string $class, ?\BackedEnum $default = null): ?\BackedEnum
+    {
+        try {
+            return parent::getEnum($key, $class, $default);
+        } catch (\UnexpectedValueException $e) {
+            $this->reportUnusableValue($key, $default, $e);
+            return $default;
+        }
+    }
+
+    /**
+     * Records a global that could not be read as its declared type.
+     *
+     * Safe to call from filter(): SystemLogger reads its own configuration with get(), which does
+     * not route through filter(), so logging a bad value cannot re-enter this path.
+     */
+    private function reportUnusableValue(string $key, mixed $default, \UnexpectedValueException $e): void
+    {
+        $stored = $this->get($key);
+        ServiceContainer::getLogger()->warning(
+            'Global is not usable as its declared type; falling back to the default. '
+            . 'Correct it in Administration > Globals.',
+            [
+                'global' => $key,
+                'stored' => is_scalar($stored) ? (string) $stored : get_debug_type($stored),
+                'default' => match (true) {
+                    $default instanceof \BackedEnum => $default->value,
+                    is_scalar($default), $default === null => $default,
+                    default => get_debug_type($default),
+                },
+                'exception' => $e,
+            ]
+        );
     }
 }

--- a/tests/Tests/Isolated/Core/OEGlobalsBagIsolatedTest.php
+++ b/tests/Tests/Isolated/Core/OEGlobalsBagIsolatedTest.php
@@ -13,15 +13,128 @@
 namespace OpenEMR\Tests\Isolated\Core;
 
 use ErrorException;
+use OpenEMR\BC\ServiceContainer;
 use OpenEMR\Core\OEGlobalsBag;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 #[Group('isolated')]
 #[Group('core')]
 class OEGlobalsBagIsolatedTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        ServiceContainer::reset();
+    }
+
+    /**
+     * A global that cannot be read as its declared type must not take the installation down.
+     *
+     * interface/globals.php calls getInt('user_php_debug', 0) during bootstrap. ParameterBag
+     * throws UnexpectedValueException when the stored value fails the filter, which fatals every
+     * page -- including Administration > Globals, the screen needed to fix it. `gl_value` is
+     * `varchar(255) NOT NULL DEFAULT ''` and an empty string fails FILTER_VALIDATE_INT, so an
+     * integer global present with no value is enough to trigger it.
+     *
+     * @param scalar $stored
+     */
+    #[DataProvider('unusableIntValueProvider')]
+    public function testGetIntFallsBackInsteadOfThrowing(mixed $stored, string $case): void
+    {
+        $bag = new OEGlobalsBag(['user_php_debug' => $stored]);
+
+        $this->assertSame(0, $bag->getInt('user_php_debug', 0), $case);
+        $this->assertSame(7, $bag->getInt('user_php_debug', 7), $case . ' (caller default is honoured)');
+    }
+
+    /**
+     * @return array<string, array{mixed, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function unusableIntValueProvider(): array
+    {
+        return [
+            'empty string (the gl_value column default)' => ['', 'empty string'],
+            'whitespace only' => ['   ', 'whitespace'],
+            'non-numeric text' => ['off', 'non-numeric'],
+            'partially numeric' => ['2abc', 'partially numeric'],
+        ];
+    }
+
+    public function testGetIntStillReturnsValidStoredValues(): void
+    {
+        $bag = new OEGlobalsBag(['user_php_debug' => '2']);
+
+        $this->assertSame(2, $bag->getInt('user_php_debug', 0));
+    }
+
+    public function testGetBooleanFallsBackOnAnUnusableValue(): void
+    {
+        $bag = new OEGlobalsBag(['some_flag' => 'maybe']);
+
+        $this->assertFalse($bag->getBoolean('some_flag'));
+        $this->assertTrue($bag->getBoolean('some_flag', true), 'caller default is honoured');
+    }
+
+    public function testGetBooleanStillReturnsValidStoredValues(): void
+    {
+        $bag = new OEGlobalsBag(['on_flag' => '1', 'off_flag' => '0']);
+
+        $this->assertTrue($bag->getBoolean('on_flag'));
+        $this->assertFalse($bag->getBoolean('off_flag', true));
+    }
+
+    public function testGetEnumFallsBackOnAnUnusableValue(): void
+    {
+        $bag = new OEGlobalsBag(['suit' => 'not-a-case']);
+
+        $this->assertNull($bag->getEnum('suit', OEGlobalsBagTestSuit::class));
+        $this->assertSame(
+            OEGlobalsBagTestSuit::Hearts,
+            $bag->getEnum('suit', OEGlobalsBagTestSuit::class, OEGlobalsBagTestSuit::Hearts)
+        );
+    }
+
+    public function testGetEnumStillReturnsValidStoredValues(): void
+    {
+        $bag = new OEGlobalsBag(['suit' => 'spades']);
+
+        $this->assertSame(OEGlobalsBagTestSuit::Spades, $bag->getEnum('suit', OEGlobalsBagTestSuit::class));
+    }
+
+    /**
+     * The substitution must be recorded rather than passing silently.
+     */
+    public function testAnUnusableValueIsReported(): void
+    {
+        $logger = new class extends AbstractLogger {
+            /** @var list<array{level: mixed, message: string|\Stringable, context: array<mixed>}> */
+            public array $records = [];
+
+            /** @param array<mixed> $context */
+            public function log($level, string|\Stringable $message, array $context = []): void
+            {
+                $this->records[] = ['level' => $level, 'message' => $message, 'context' => $context];
+            }
+        };
+        ServiceContainer::override(LoggerInterface::class, $logger);
+
+        (new OEGlobalsBag(['user_php_debug' => 'off']))->getInt('user_php_debug', 0);
+
+        $this->assertCount(1, $logger->records);
+        $record = $logger->records[0];
+        $this->assertSame(LogLevel::WARNING, $record['level']);
+        $this->assertStringContainsString('Administration > Globals', (string) $record['message']);
+        $this->assertSame('user_php_debug', $record['context']['global'] ?? null);
+        $this->assertSame('off', $record['context']['stored'] ?? null);
+        $this->assertSame(0, $record['context']['default'] ?? null);
+    }
+
     public function testGlobalsBagInit(): void
     {
         $key = 'dummy-key';
@@ -83,4 +196,13 @@ class OEGlobalsBagIsolatedTest extends TestCase
         $this->expectException(ErrorException::class);
         $bag->has($key);
     }
+}
+
+/**
+ * Backed enum fixture for the getEnum() cases above.
+ */
+enum OEGlobalsBagTestSuit: string
+{
+    case Hearts = 'hearts';
+    case Spades = 'spades';
 }


### PR DESCRIPTION
Backport of #13950 to `rel-840` for the upcoming 8.4.0 release.

Fixes #13948 on the release branch.

Cherry-picked from master commit `5f09c1b8445841a1ed084349d2d2fa70458c808f` (PR #13950 by @sjpadgett). Verified byte-equal to the master commit via `git patch-id --stable`:

```
master:  8c5f05a13ceb13d73955ffd77c50159c228a93b7
rel-840: 8c5f05a13ceb13d73955ffd77c50159c228a93b7
```

#### Was an AI assistant used? Yes — Claude Code assisted with the mechanical cherry-pick, patch-id verification, and PR creation.