### PR TITLE
refactor(deleter): scope document deletion to the submitted patient context

### DIFF
--- a/interface/patient_file/deleter.php
+++ b/interface/patient_file/deleter.php
@@ -295,6 +295,19 @@ function popup_close() {
                     AccessDeniedHelper::deny('Unauthorized document deletion attempt');
                 }
 
+                // Scope the delete to the submitted patient context — the
+                // document's foreign_id must match. Mirrors the read/download
+                // path pattern so a mutation stays inside the caller's current
+                // patient rather than running against an arbitrary document id.
+                $documentRow = QueryUtils::querySingleRow(
+                    "SELECT foreign_id FROM documents WHERE id = ?",
+                    [$document]
+                );
+                $documentForeignId = is_array($documentRow) ? ($documentRow['foreign_id'] ?? null) : null;
+                if (!is_numeric($documentForeignId) || (int) $documentForeignId !== $patient) {
+                    AccessDeniedHelper::deny('Unauthorized document deletion attempt - patient context mismatch');
+                }
+
                 delete_document($document);
             } elseif ($payment) {
                 if (!AclMain::aclCheckCore('admin', 'super')) {

--- a/templates/documents/general_view.html
+++ b/templates/documents/general_view.html
@@ -25,7 +25,7 @@
 
  // Process click on Delete link.
  function deleteme(docid) {
-  dlgopen('interface/patient_file/deleter.php?document=' + encodeURIComponent(docid) + '&csrf_token_form=' + {$csrf_token_form|js_url}, '_blank', 500, 450);
+  dlgopen('interface/patient_file/deleter.php?patient=' + encodeURIComponent({$patient_id|js_url}) + '&document=' + encodeURIComponent(docid) + '&csrf_token_form=' + {$csrf_token_form|js_url}, '_blank', 500, 450);
   return false;
  }
 


### PR DESCRIPTION
## Summary

The document-delete branch of `interface/patient_file/deleter.php` runs only
the `patients/docs_rm` ACL check before calling `delete_document()` — the
submitted `patient` parameter is ignored. That's inconsistent with the
read/download paths in the same document workflow, which look up
`documents.foreign_id` and verify it belongs to the requested patient context
before returning the file.

This change adds the same `foreign_id` lookup + comparison to the delete
branch so it matches the read-side behavior. On mismatch, rejects via the
standard `AccessDeniedHelper::deny()` path already used a few lines above for
the ACL failure.

Also threads `patient=` through the delete URL in
`templates/documents/general_view.html` so the view-side UI supplies the
parameter (already had `patient_id` in scope from `view_action()`).

## Files

- `interface/patient_file/deleter.php` (+13) — foreign_id check before `delete_document()`
- `templates/documents/general_view.html` (+1/-1) — thread `patient=` into the delete URL

## Test plan

- [ ] Delete a document from a patient's document view — succeeds normally
- [ ] Attempt to delete a document with a mismatched `patient=` parameter — access-denied
- [ ] Existing read/download flow unchanged