### PR TITLE
chore(release): rel-840 8.4.0 backport batch (6 commits)

### DIFF
--- a/.phpstan/baseline/argument.type.php
+++ b/.phpstan/baseline/argument.type.php
@@ -577,11 +577,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../controllers/C_Document.class.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Parameter \\#1 \\$id of class Document constructor expects int, float\\|int\\|string given\\.$#',
-    'count' => 2,
-    'path' => __DIR__ . '/../../controllers/C_Document.class.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Parameter \\#1 \\$id of class Document constructor expects int, mixed given\\.$#',
     'count' => 4,
     'path' => __DIR__ . '/../../controllers/C_Document.class.php',

--- a/.phpstan/baseline/cast.string.php
+++ b/.phpstan/baseline/cast.string.php
@@ -2744,11 +2744,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
     'message' => '#^Cannot cast mixed to string\\.$#',
     'count' => 2,
-    'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Cannot cast mixed to string\\.$#',
-    'count' => 2,
     'path' => __DIR__ . '/../../src/Common/Command/CreateAPIDocumentationCommand.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/deadCode.unreachable.php
+++ b/.phpstan/baseline/deadCode.unreachable.php
@@ -286,10 +286,5 @@ $ignoreErrors[] = [
     'count' => 1,
     'path' => __DIR__ . '/../../tests/Tests/Services/Qrda/QrdaReportServiceTest.php',
 ];
-$ignoreErrors[] = [
-    'message' => '#^Unreachable statement \\- code above always terminates\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Unit/Common/Auth/OpenIDConnect/Repositories/ScopeRepositoryTest.php',
-];
 
 return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/.phpstan/baseline/empty.notAllowed.php
+++ b/.phpstan/baseline/empty.notAllowed.php
@@ -3333,7 +3333,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#',
-    'count' => 8,
+    'count' => 10,
     'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/method.deprecated.php
+++ b/.phpstan/baseline/method.deprecated.php
@@ -649,12 +649,6 @@ use setLogger\\(\\)$#',
     'path' => __DIR__ . '/../../tests/Tests/Services/Modules/Carecoordination/Model/CcdaServiceDocumentRequestorTest.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Call to deprecated method setSystemLogger\\(\\) of class OpenEMR\\\\Common\\\\Auth\\\\OpenIDConnect\\\\Repositories\\\\ScopeRepository\\:
-use setLogger\\(\\)$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../tests/Tests/Unit/Common/Auth/OpenIDConnect/Repositories/ScopeRepositoryTest.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Call to deprecated method requestHasScope\\(\\) of class OpenEMR\\\\Common\\\\Http\\\\HttpRestRequest\\:
 use requestHasScopeEntity\\(\\) instead which receives a ScopeEntity object$#',
     'count' => 12,

--- a/.phpstan/baseline/missingType.iterableValue.php
+++ b/.phpstan/baseline/missingType.iterableValue.php
@@ -4007,26 +4007,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OpenIDConnect\\\\Repositories\\\\ScopeRepository\\:\\:hasScopesThatRequireManualApproval\\(\\) has parameter \\$scopes with no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OpenIDConnect\\\\Repositories\\\\ScopeRepository\\:\\:hasSystemScopes\\(\\) has parameter \\$scopes with no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OpenIDConnect\\\\Repositories\\\\ScopeRepository\\:\\:hasUserScopes\\(\\) has parameter \\$scopes with no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OpenIDConnect\\\\Repositories\\\\ScopeRepository\\:\\:scopeArrayHasString\\(\\) has parameter \\$scopes with no value type specified in iterable type array\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OpenIDConnect\\\\SMARTSessionTokenContextBuilder\\:\\:getContextForScopesWithExistingContext\\(\\) has parameter \\$context with no value type specified in iterable type array\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/SMARTSessionTokenContextBuilder.php',

--- a/.phpstan/baseline/missingType.parameter.php
+++ b/.phpstan/baseline/missingType.parameter.php
@@ -29307,11 +29307,6 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OpenIDConnect\\\\Repositories\\\\ScopeRepository\\:\\:scopeArrayHasString\\(\\) has parameter \\$str with no type specified\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Method OpenEMR\\\\Common\\\\Auth\\\\OpenIDConnect\\\\Repositories\\\\UserRepository\\:\\:__construct\\(\\) has parameter \\$fhirBaseUrl with no type specified\\.$#',
     'count' => 1,
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/Repositories/UserRepository.php',

--- a/.phpstan/baseline/nullCoalesce.expr.php
+++ b/.phpstan/baseline/nullCoalesce.expr.php
@@ -223,11 +223,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^Expression on left side of \\?\\? is not nullable\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../src/Common/Auth/OneTimeAuth.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Expression on left side of \\?\\? is not nullable\\.$#',
     'count' => 2,
     'path' => __DIR__ . '/../../src/Common/Auth/OpenIDConnect/IdTokenSMARTResponse.php',
 ];

--- a/.phpstan/baseline/openemr.exitInCatchOrFinally.php
+++ b/.phpstan/baseline/openemr.exitInCatchOrFinally.php
@@ -148,7 +148,7 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
     'message' => '#^exit/die inside a catch block swallows the caught exception and aborts the process\\.$#',
-    'count' => 2,
+    'count' => 4,
     'path' => __DIR__ . '/../../portal/index.php',
 ];
 $ignoreErrors[] = [

--- a/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
+++ b/.phpstan/baseline/openemr.forbiddenRequestGlobals.php
@@ -3997,18 +3997,8 @@ $ignoreErrors[] = [
     'path' => __DIR__ . '/../../portal/patient/index.php',
 ];
 $ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object instead\\.$#',
-    'count' => 1,
-    'path' => __DIR__ . '/../../portal/patient/libs/Controller/OnsiteActivityViewController.php',
-];
-$ignoreErrors[] = [
     'message' => '#^Direct access to \\$_GET is forbidden\\. Use Symfony\'s Request object instead\\.$#',
     'count' => 25,
-    'path' => __DIR__ . '/../../portal/patient/libs/Controller/OnsiteDocumentController.php',
-];
-$ignoreErrors[] = [
-    'message' => '#^Direct access to \\$_REQUEST is forbidden\\. Use Symfony\'s Request object instead\\.$#',
-    'count' => 1,
     'path' => __DIR__ . '/../../portal/patient/libs/Controller/OnsiteDocumentController.php',
 ];
 $ignoreErrors[] = [

--- a/controllers/C_Document.class.php
+++ b/controllers/C_Document.class.php
@@ -358,6 +358,17 @@ class C_Document extends Controller
             return;
         }
         $session = SessionWrapperFactory::getInstance()->getActiveSession();
+
+        // Anti-IDOR: a note association or document email always targets a
+        // document via foreign_id; restrict it to a document the caller can
+        // access in the current patient context so an arbitrary document cannot
+        // be emailed out or annotated.
+        $documentForeignId = filter_input(INPUT_POST, 'foreign_id');
+        if (is_string($documentForeignId) && $documentForeignId !== '') {
+            $patientContext = is_scalar($patient_id) ? (string) $patient_id : null;
+            $this->authorizeDocumentWrite($patientContext, $documentForeignId);
+        }
+
         $n = new Note();
         $n->set_owner($session->get('authUserID'));
         parent::populate_object($n);
@@ -963,6 +974,95 @@ class C_Document extends Controller
         }
     }
 
+    /**
+     * Authorize a mutating action against an existing document (anti-IDOR guard).
+     *
+     * The document read path (retrieve_action()/view_action()) is deliberately
+     * hardened against IDOR, but the write path historically was not: any
+     * authenticated user could reassign or otherwise mutate an arbitrary
+     * document by id - for example move it to a patient/category they legitimately
+     * have access to - and then read it back through the ACL-checked download
+     * path, bypassing document access controls entirely.
+     *
+     * This guard mirrors the read-path checks so a caller may only mutate a
+     * document they can already access in its current state:
+     *   1. The caller must satisfy the ACL (aco_spec) of every category the
+     *      document currently belongs to (Document::can_access()).
+     *   2. The document must belong to the patient context supplied with the
+     *      request (foreign_id === patient_id), matching the read-path check.
+     *
+     * Denials are logged and audited, then the request is terminated with a
+     * 403 through the standard controller exception path.
+     *
+     * Service/CLI callers that have explicitly opted out of ACL enforcement
+     * (see skipAclCheck(), used by background/import processes) are exempt.
+     *
+     * @param ?string $patient_id  Patient context (pid) from the request
+     * @param mixed   $document_id documents.id being mutated
+     * @return Document The loaded, access-checked document
+     */
+    private function authorizeDocumentWrite(?string $patient_id, $document_id): Document
+    {
+        $d = new Document($document_id);
+
+        if ($this->isSkipAclCheck()) {
+            return $d;
+        }
+
+        $docPid = $d->get_foreign_id();
+        // The document must belong to the requested patient context. Fail closed:
+        // a null/absent patient context, or a missing/non-numeric document
+        // foreign_id, can never establish that the caller is operating on this
+        // document within the patient it belongs to, so all three are treated as
+        // a mismatch. Note that empty request parameters (e.g. "patient_id=")
+        // arrive here as null via Controller::dispatch(), so a permissive null
+        // would let a caller drop the patient context and bypass this check while
+        // still passing the category ACL below.
+        $patientMismatch = $patient_id === null
+            || !is_numeric($docPid)
+            || (int) $docPid !== (int) $patient_id;
+
+        if (!$d->can_access() || $patientMismatch) {
+            $session = SessionWrapperFactory::getInstance()->getActiveSession();
+            $documentIdLabel = is_scalar($document_id) ? (string) $document_id : '';
+            $docPidLabel = is_scalar($docPid) ? (string) $docPid : '';
+            ServiceContainer::getLogger()->warning(
+                "An attempt was made to modify a document without authorization",
+                [
+                    'user-id' => $session->get('authUserID'),
+                    'requested-patient-id' => $patient_id,
+                    'document-patient-id' => $docPid,
+                    'document-id' => $document_id,
+                ]
+            );
+            $this->throwAccessDenied(
+                "Unauthorized attempt to modify document " . $documentIdLabel . " belonging to pid " . $docPidLabel,
+                xl("Not authorized to modify the requested document")
+            );
+        }
+
+        return $d;
+    }
+
+    /**
+     * Verify the caller may file a document into the given destination category.
+     *
+     * Mirrors the destination-category ACL check performed on upload
+     * (upload_action_process()) so a move cannot place a document into a
+     * category the caller is not permitted to write to.
+     *
+     * @param mixed $category_id categories.id being targeted
+     */
+    private function canAccessDestinationCategory($category_id): bool
+    {
+        if ($this->isSkipAclCheck()) {
+            return true;
+        }
+        $category = QueryUtils::querySingleRow("SELECT `aco_spec` FROM `categories` WHERE `id` = ?", [$category_id]);
+        $acoSpec = is_array($category) ? ($category['aco_spec'] ?? null) : null;
+        return AclMain::aclCheckAcoSpec($acoSpec) !== false;
+    }
+
     public function move_action_process(?string $patient_id, $document_id)
     {
         if ($_POST['process'] != "true") {
@@ -972,22 +1072,23 @@ class C_Document extends Controller
         if (!is_numeric($document_id)) {
             $this->throwAccessDenied("Invalid document id for move", xl("Documents"));
         }
-        $docIdInt = (int) $document_id;
 
-        // Require write authorization plus per-doc access before mutating any state.
+        // Require the blanket document-write ACL before mutating any state
+        // (upstream #13353). CONTROLLER_ACL_MAP has no 'document' entry, so this
+        // is the coarse gate; the per-document guard below adds the fine-grained,
+        // context-bound check.
         if (!AclMain::aclCheckCore('patients', 'docs', '', ['write', 'addonly'])) {
             $this->throwAccessDenied("ACL check failed for patients/docs write|addonly: Documents", xl("Documents"));
         }
-        $sourceDoc = new Document($docIdInt);
-        $sourceDocForeignId = $sourceDoc->get_foreign_id();
-        if (
-            !is_numeric($sourceDoc->get_id())
-            || !is_numeric($sourceDocForeignId)
-            || (int) $sourceDocForeignId <= 0
-            || !$sourceDoc->can_access()
-        ) {
-            AccessDeniedHelper::deny("Unauthorized attempt to move document $docIdInt");
-        }
+
+        // Anti-IDOR: the caller must be able to access the document in its
+        // current state before they may move it. Without this a low-privilege
+        // user could reassign a document out of a restricted category/patient
+        // and then read it via the ACL-checked download path.
+        // authorizeDocumentWrite() subsumes the per-document existence/can_access()
+        // check and additionally binds the mutation to the request's patient
+        // context, and returns the loaded document for reuse below.
+        $d = $this->authorizeDocumentWrite($patient_id, $document_id);
 
         $messages = '';
 
@@ -996,6 +1097,13 @@ class C_Document extends Controller
 
         //move to new category
         if (is_numeric($new_category_id)) {
+            // caller must also be permitted to file into the destination category
+            if (!$this->canAccessDestinationCategory($new_category_id)) {
+                $this->throwAccessDenied(
+                    "Unauthorized attempt to move document " . $document_id . " to category " . $new_category_id,
+                    xl("Not authorized to move the document to the selected category")
+                );
+            }
             $sql = "UPDATE categories_to_documents set category_id = ? where document_id = ?";
             $messages .= sprintf("%s '%s' %s\n", xl('Document moved to new category'), $this->tree->_id_name[$new_category_id]['name'], xl('successfully.'));
             //echo $sql;
@@ -1004,7 +1112,7 @@ class C_Document extends Controller
 
         //move to new patient
         if (is_numeric($new_patient_id)) {
-            $d = new Document((int) $document_id);
+            // $d was already loaded and access-checked by authorizeDocumentWrite() above
             $sql = "SELECT pid from patient_data where pid = ?";
             $result = QueryUtils::querySingleRow($sql, [$new_patient_id]);
 
@@ -1028,8 +1136,9 @@ class C_Document extends Controller
 
     public function validate_action_process(?string $patient_id, $document_id)
     {
-
-        $d = new Document($document_id);
+        // Anti-IDOR: validation reads the document's file content and may
+        // persist a hash, so restrict it to a document the caller can access.
+        $d = $this->authorizeDocumentWrite($patient_id, $document_id);
         if ($d->couch_docid && $d->couch_revid) {
             $file_path = OEGlobalsBag::getInstance()->get('OE_SITE_DIR') . '/documents/temp/';
             $url = $file_path . $d->get_url();
@@ -1113,13 +1222,16 @@ class C_Document extends Controller
             return;
         }
 
+        // Anti-IDOR: only permit metadata updates on a document the caller can
+        // already access in its current patient/category context.
+        $d = $this->authorizeDocumentWrite($patient_id, $document_id);
+
         $docdate = $_POST['docdate'];
         $docname = $_POST['docname'];
         $issue_id = $_POST['issue_id'];
 
         if (is_numeric($document_id)) {
             $messages = '';
-            $d = new Document($document_id);
             $file_name = $d->get_name();
             if (
                 $docname != '' &&
@@ -1348,6 +1460,9 @@ class C_Document extends Controller
             return;
         }
         $session = SessionWrapperFactory::getInstance()->getActiveSession();
+        // Anti-IDOR: only permit tagging a document the caller can already
+        // access in its current patient/category context.
+        $d = $this->authorizeDocumentWrite($patient_id, $document_id);
         // Create Encounter and Tag it.
         $event_date = date('Y-m-d H:i:s');
         $encounter_id = $_POST['encounter_id'];
@@ -1356,7 +1471,6 @@ class C_Document extends Controller
 
         if (is_numeric($document_id)) {
             $messages = '';
-            $d = new Document($document_id);
             $file_name = $d->get_url_file();
             if (!is_numeric($encounter_id)) {
                 $encounter_id = 0;
@@ -1410,6 +1524,8 @@ class C_Document extends Controller
 
     public function image_procedure_action(?string $patient_id, $document_id)
     {
+        // Anti-IDOR: only permit tagging a document the caller can already access.
+        $this->authorizeDocumentWrite($patient_id, $document_id);
 
         $img_procedure_id = $_POST['image_procedure_id'];
         $proc_code = $_POST['procedure_code'];
@@ -1435,6 +1551,8 @@ class C_Document extends Controller
 
     public function clear_procedure_tag_action(?string $patient_id, $document_id)
     {
+        // Anti-IDOR: only permit clearing tags on a document the caller can access.
+        $this->authorizeDocumentWrite($patient_id, $document_id);
         if (is_numeric($document_id)) {
             sqlStatement("delete from procedure_result where document_id = ?", [$document_id]);
         }
@@ -1477,6 +1595,9 @@ class C_Document extends Controller
 //clear encounter tag public function
     public function clear_encounter_tag_action(?string $patient_id, $document_id)
     {
+        // Anti-IDOR: only permit clearing the encounter tag on a document the
+        // caller can already access.
+        $this->authorizeDocumentWrite($patient_id, $document_id);
         if (is_numeric($document_id)) {
             sqlStatement("update documents set encounter_id='0' where foreign_id=? and id = ?", [$patient_id,$document_id]);
         }

--- a/interface/patient_file/deleter.php
+++ b/interface/patient_file/deleter.php
@@ -295,6 +295,19 @@ function popup_close() {
                     AccessDeniedHelper::deny('Unauthorized document deletion attempt');
                 }
 
+                // Scope the delete to the submitted patient context — the
+                // document's foreign_id must match. Mirrors the read/download
+                // path pattern so a mutation stays inside the caller's current
+                // patient rather than running against an arbitrary document id.
+                $documentRow = QueryUtils::querySingleRow(
+                    "SELECT foreign_id FROM documents WHERE id = ?",
+                    [$document]
+                );
+                $documentForeignId = is_array($documentRow) ? ($documentRow['foreign_id'] ?? null) : null;
+                if (!is_numeric($documentForeignId) || (int) $documentForeignId !== $patient) {
+                    AccessDeniedHelper::deny('Unauthorized document deletion attempt - patient context mismatch');
+                }
+
                 delete_document($document);
             } elseif ($payment) {
                 if (!AclMain::aclCheckCore('admin', 'super')) {

--- a/library/ESign/Router.php
+++ b/library/ESign/Router.php
@@ -21,16 +21,49 @@ require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/Abstract/Control
 
 class Router
 {
+    /**
+     * The only modules the ESign router may dispatch to, mapping the
+     * request value (compared case-insensitively) to its canonical class
+     * prefix and on-disk directory. The `module` request parameter is
+     * developer-supplied in normal use (see Form_Configuration::getModule()
+     * and Encounter_Configuration::getModule()); treating it as an open
+     * string let a crafted value traverse out of the ESign directory into
+     * an arbitrary require_once. Resolving through this closed allowlist
+     * ensures no caller-controlled bytes ever reach the include path or the
+     * instantiated class name.
+     */
+    private const MODULES = [
+        'form' => 'Form',
+        'encounter' => 'Encounter',
+    ];
+
     public function route()
     {
         $request = new Request();
-        $moduleParam = $request->getParam('module');
-        $Module = ucfirst((string) $moduleParam);
+        $Module = self::resolveModule($request->getParam('module'));
         require_once OEGlobalsBag::getInstance()->getSrcDir() . '/ESign/' . $Module . '/Controller.php';
         $controllerClass = "\\ESign\\" . $Module . "_Controller";
         $controller = new $controllerClass($request);
         if ($controller instanceof Abstract_Controller) {
             $controller->run();
         }
+    }
+
+    /**
+     * Resolve a raw `module` request value to its canonical class prefix,
+     * rejecting anything outside the allowlist. Pure and dependency-free so
+     * it can be unit tested in isolation.
+     *
+     * @param  mixed $moduleParam Raw request value (untrusted).
+     * @return string             Canonical prefix, e.g. "Form" or "Encounter".
+     * @throws \InvalidArgumentException When the module is not allowlisted.
+     */
+    public static function resolveModule($moduleParam): string
+    {
+        $key = strtolower(trim((string) $moduleParam));
+        if (!isset(self::MODULES[$key])) {
+            throw new \InvalidArgumentException('Unknown ESign module requested');
+        }
+        return self::MODULES[$key];
     }
 }

--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -2216,6 +2216,13 @@ $GLOBALS_METADATA = [
             xl('Time (seconds) to Reset Maximum Failed Login Attempts Counter From IP Address (0 for no reset).')
         ],
 
+        'portal_onetime_max_pin_attempts' => [
+            xl('Portal One-Time Token Maximum PIN Attempts'),
+            'num',                            // data type
+            '5',                              // default
+            xl('Maximum PIN attempts allowed for a patient portal one-time (e.g. invoice) token before it is refused. 0 or blank uses the built-in default.')
+        ],
+
         'gbl_fac_warehouse_restrictions' => [
             xl('Enable Facility/Warehouse Permissions'),
             'bool',                           // data type

--- a/portal/index.php
+++ b/portal/index.php
@@ -106,7 +106,38 @@ if (!empty($_REQUEST['service_auth'] ?? null)) {
         // an external site domain.  We used to auto process via GET but now we submit via the POST in order to make it
         // a same site cookie origin request. This is a workaround for the Same-Site cookie blocking.
         $token = $_GET['service_auth'];
-        $ot = $oneTime->decodePortalOneTime($token, logUpdate: false);
+        try {
+            // Decoding now enforces the token's consumption policy (expiry,
+            // one-time use, max access count), so an already-consumed or expired
+            // token is refused here instead of rendering the autologin form.
+            $ot = $oneTime->decodePortalOneTime($token, logUpdate: false);
+        } catch (OneTimeAuthExpiredException $exception) {
+            // '&oe' is read below (see the $_GET['oe'] handler) to alert the
+            // patient that the one-time link has expired.
+            $logit->portalLog(
+                'onetime login attempt',
+                $exception->getPid() ?? '',
+                ':invalid one time',
+                '',
+                '0'
+            );
+            SessionUtil::portalSessionCookieDestroy();
+            header('Location: ' . $landingpage . '&oe');
+            exit();
+        } catch (OneTimeAuthException $exception) {
+            // '&oi' is read below (see the $_GET['oi'] handler) to alert the
+            // patient that the one-time link is invalid or already consumed.
+            $logit->portalLog(
+                'onetime login attempt',
+                $exception->getPid() ?? '',
+                ':invalid one time',
+                '',
+                '0'
+            );
+            SessionUtil::portalSessionCookieDestroy();
+            header('Location: ' . $landingpage . '&oi');
+            exit();
+        }
         $pin_required = $ot['actions']['enforce_auth_pin'] ? 1 : 0;
         CsrfUtils::setupCsrfKey($session);
         echo ServiceContainer::getTwig()->render('portal/login/autologin.html.twig', [

--- a/portal/patient/fwk/libs/verysimple/Phreeze/Criteria.php
+++ b/portal/patient/fwk/libs/verysimple/Phreeze/Criteria.php
@@ -264,11 +264,18 @@ class Criteria
                         $this->_where_delim = " and";
                     } elseif (str_ends_with((string) $prop, "_BitwiseOr") && strlen($this->$prop ?? '')) {
                         $dbfield = $this->GetFieldFromProp(str_replace("_BitwiseOr", "", $prop));
-                        $this->_where .= $this->_where_delim . " (" . $dbfield . " | '" . $this->Escape($val) . ")";
+                        // Bitwise operands are integers by definition. Emit the value as an
+                        // integer literal rather than string-escaping it: this is an unquoted
+                        // SQL context, where Escape() (a quote-context str_replace) does not
+                        // neutralise spaces, operators or keywords and would allow injection.
+                        $bitmask = is_numeric($val) ? (int) $val : 0;
+                        $this->_where .= $this->_where_delim . " (" . $dbfield . " | " . $bitmask . ")";
                         $this->_where_delim = " and";
                     } elseif (str_ends_with((string) $prop, "_BitwiseAnd") && strlen($this->$prop ?? '')) {
                         $dbfield = $this->GetFieldFromProp(str_replace("_BitwiseAnd", "", $prop));
-                        $this->_where .= $this->_where_delim . " (" . $dbfield . " & " . $this->Escape($val) . ")";
+                        // See _BitwiseOr above: emit an integer literal for this unquoted context.
+                        $bitmask = is_numeric($val) ? (int) $val : 0;
+                        $this->_where .= $this->_where_delim . " (" . $dbfield . " & " . $bitmask . ")";
                         $this->_where_delim = " and";
                     } elseif (str_ends_with((string) $prop, "_LiteralFunction") && strlen($this->$prop ?? '')) {
                         $dbfield = $this->GetFieldFromProp(str_replace("_LiteralFunction", "", $prop));

--- a/portal/patient/libs/Controller/AppBasePortalController.php
+++ b/portal/patient/libs/Controller/AppBasePortalController.php
@@ -81,6 +81,38 @@ class AppBasePortalController extends PortalController
     }
 
     /**
+     * Apply request parameters as equality filters on a query Criteria.
+     *
+     * Request input may only ever drive equality (`_Equals`) filters. The
+     * comparator applied to a column is a code-level decision and must never be
+     * selectable from the request: assigning arbitrary criteria properties from
+     * request keys (e.g. `*_BitwiseAnd`, `*_In`, `*_LiteralFunction`, or the
+     * framework `Filters` property) is a mass-assignment weakness (CWE-915) and,
+     * for the bitwise comparators, reaches an unquoted SQL context (CWE-89).
+     *
+     * Both the bare-column convenience form (`?Id=5` -> `Id_Equals`) and the
+     * explicit form (`?Id_Equals=5`) are preserved.
+     *
+     * @param Criteria $criteria the query criteria to populate
+     */
+    protected function ApplyRequestEqualsFilters(Criteria $criteria): void
+    {
+        $request = \OpenEMR\Common\Http\CurrentRequest::get();
+        $keys = array_unique(array_merge($request->query->keys(), $request->request->keys()));
+
+        foreach ($keys as $prop) {
+            $prop_normal = ucfirst((string) $prop);
+
+            if (str_ends_with($prop_normal, '_Equals') && property_exists($criteria, $prop_normal)) {
+                $criteria->$prop_normal = RequestUtil::Get($prop);
+            } elseif (property_exists($criteria, $prop_normal . '_Equals')) {
+                // convenience so that the _Equals suffix is not needed
+                $criteria->{$prop_normal . '_Equals'} = RequestUtil::Get($prop);
+            }
+        }
+    }
+
+    /**
      * Helper utility that calls RenderErrorJSON
      * @param mixed $exception
      */

--- a/portal/patient/libs/Controller/OnsiteActivityViewController.php
+++ b/portal/patient/libs/Controller/OnsiteActivityViewController.php
@@ -76,18 +76,9 @@ class OnsiteActivityViewController extends AppBasePortalController
                 $criteria->AddFilter(new CriteriaFilter('Id,Date,PatientId,Activity,RequireAudit,PendingAction,ActionTaken,Status,Narrative,TableAction,TableArgs,ActionUser,ActionTakenTime,Checksum,Title,Fname,Lname,Mname,Dob,Ss,Street,PostalCode,City,State,Referrerid,Providerid,RefProviderid,Pubpid,CareTeam,Username,Authorized,Ufname,Umname,Ulname,Facility,Active,Utitle,PhysicianType', '%' . $filter . '%'));
             }
 
-            // TODO: this is generic query filtering based only on criteria properties
-            foreach (array_keys($_REQUEST) as $prop) {
-                $prop_normal = ucfirst((string) $prop);
-                $prop_equals = $prop_normal . '_Equals';
-
-                if (property_exists($criteria, $prop_normal)) {
-                    $criteria->$prop_normal = RequestUtil::Get($prop);
-                } elseif (property_exists($criteria, $prop_equals)) {
-                    // this is a convenience so that the _Equals suffix is not needed
-                    $criteria->$prop_equals = RequestUtil::Get($prop);
-                }
-            }
+            // generic query filtering: request input may only drive equality
+            // (_Equals) filters, never arbitrary criteria properties (CWE-915)
+            $this->ApplyRequestEqualsFilters($criteria);
 
             $output = new stdClass();
 

--- a/portal/patient/libs/Controller/OnsiteDocumentController.php
+++ b/portal/patient/libs/Controller/OnsiteDocumentController.php
@@ -140,18 +140,9 @@ class OnsiteDocumentController extends AppBasePortalController
                 );
             }
 
-            // TODO: this is generic query filtering based only on criteria properties
-            foreach (array_keys($_REQUEST) as $prop) {
-                $prop_normal = ucfirst((string) $prop);
-                $prop_equals = $prop_normal . '_Equals';
-
-                if (property_exists($criteria, $prop_normal)) {
-                    $criteria->$prop_normal = RequestUtil::Get($prop);
-                } elseif (property_exists($criteria, $prop_equals)) {
-                    // this is a convenience so that the _Equals suffix is not needed
-                    $criteria->$prop_equals = RequestUtil::Get($prop);
-                }
-            }
+            // generic query filtering: request input may only drive equality
+            // (_Equals) filters, never arbitrary criteria properties (CWE-915)
+            $this->ApplyRequestEqualsFilters($criteria);
 
             $output = new stdClass();
 

--- a/src/Common/Auth/OneTimeAuth.php
+++ b/src/Common/Auth/OneTimeAuth.php
@@ -31,6 +31,18 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class OneTimeAuth
 {
+    /**
+     * Built-in fallback cap on the number of consumption attempts allowed for a
+     * token that requires a PIN, regardless of the other policy flags. Because a
+     * token's access_count is incremented on every POST consumption attempt
+     * (including a wrong PIN), this bounds PIN guessing even when a caller does
+     * not also set enforce_onetime_use. Administrators can override the effective
+     * cap with the 'portal_onetime_max_pin_attempts' global; this constant is used
+     * when that setting is unset or non-positive so the throttle can never be
+     * disabled outright.
+     */
+    public const MAX_PIN_ATTEMPTS = 5;
+
     private readonly LoggerInterface $systemLogger;
     private readonly SessionInterface $session;
     private readonly OEGlobalsBag $globalsBag;
@@ -169,6 +181,17 @@ class OneTimeAuth
         }
         $redirect = $t_info['redirect_url'] ?? null;
 
+        // Enforce the per-token consumption policy carried in onetime_actions.
+        // This runs before the access_count increment below and for both the GET
+        // (form render, logUpdate=false) and POST (processOnetime, logUpdate=true)
+        // paths, so a token that has already reached its configured limit is
+        // rejected rather than replayed or brute-forced.
+        $actions = is_array($t_info['onetime_actions'] ?? null) ? $t_info['onetime_actions'] : [];
+        if (self::usageLimitReached($actions, (int)($t_info['access_count'] ?? 0), $this->pinAttemptLimit())) {
+            $this->systemLogger->error("Onetime token refused: usage limit reached", ['token' => $tokenFingerprint]);
+            throw new OneTimeAuthException("Onetime token usage limit reached");
+        }
+
         $rtn['pid'] = $auth['pid'];
         $rtn['pin'] = $t_info['onetime_pin'];
         $rtn['redirect'] = $redirect;
@@ -281,6 +304,70 @@ class OneTimeAuth
     }
 
     /**
+     * Decide whether a token has already reached its configured consumption
+     * policy and must be refused. The token's access_count is incremented on
+     * every POST consumption attempt (including a failed PIN), so enforcing these
+     * flags against it throttles both token replay and PIN brute force without
+     * any schema change.
+     *
+     * @param array $actions        Decoded onetime_actions for the token.
+     * @param int   $accessCount     Current onetime_auth.access_count for the token.
+     * @param int   $maxPinAttempts  Effective cap for PIN-protected tokens (see
+     *                               MAX_PIN_ATTEMPTS / the portal_onetime_max_pin_attempts global).
+     * @return bool True when the token must be rejected.
+     */
+    public static function usageLimitReached(array $actions, int $accessCount, int $maxPinAttempts = self::MAX_PIN_ATTEMPTS): bool
+    {
+        // One-time tokens are spent by the first consumption attempt.
+        if (!empty($actions['enforce_onetime_use']) && $accessCount > 0) {
+            return true;
+        }
+
+        // Explicit cap set by the caller (0 = unlimited).
+        $maxAccess = (int)($actions['max_access_count'] ?? 0);
+        if ($maxAccess > 0 && $accessCount >= $maxAccess) {
+            return true;
+        }
+
+        // Hard safety cap on PIN-protected tokens, independent of the flags above,
+        // so PIN guessing is always bounded.
+        if (!empty($actions['enforce_auth_pin']) && $accessCount >= $maxPinAttempts) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Effective per-token PIN-attempt cap: the 'portal_onetime_max_pin_attempts'
+     * global when configured to a positive value, otherwise the built-in
+     * MAX_PIN_ATTEMPTS default. The throttle cannot be disabled with 0/blank.
+     */
+    private function pinAttemptLimit(): int
+    {
+        $configured = $this->globalsBag->getInt('portal_onetime_max_pin_attempts');
+
+        return $configured > 0 ? $configured : self::MAX_PIN_ATTEMPTS;
+    }
+
+    /**
+     * Strict, constant-time PIN comparison. Rejects non-string input and any
+     * numeric-equivalent form of the expected PIN (leading-zero, scientific
+     * notation, decimal, zero-padded), which a loose (!=) compare would accept.
+     *
+     * @param mixed $expected  The stored PIN.
+     * @param mixed $submitted The client-supplied value.
+     */
+    public static function pinMatches(mixed $expected, mixed $submitted): bool
+    {
+        if (!is_string($submitted) || !is_scalar($expected)) {
+            return false;
+        }
+
+        return hash_equals((string)$expected, $submitted);
+    }
+
+    /**
      * @param $token
      * @return array
      */
@@ -290,7 +377,11 @@ class OneTimeAuth
             $auth = $this->decodePortalOneTime($token);
             if ($auth["actions"]["enforce_auth_pin"]) {
                 $this->systemLogger->debug("Pin auth required");
-                if ($auth['pin'] != $_POST['login_pin'] ?? null) {
+                // Strict, constant-time comparison. A loose (!=) compare treats two
+                // numeric strings as numbers, so "012345" would match "12345",
+                // "12345e0", "12345.0" etc.; hash_equals plus the is_string guard in
+                // pinMatches() blocks those type-juggling equivalents.
+                if (!self::pinMatches($auth['pin'], $_POST['login_pin'] ?? null)) {
                     $this->systemLogger->error("Failed Pin auth");
                     throw new OneTimeAuthException(xlt("Pin Authentication Failed! Contact administrator."));
                 }

--- a/src/Common/Auth/OneTimeAuth.php
+++ b/src/Common/Auth/OneTimeAuth.php
@@ -146,6 +146,7 @@ class OneTimeAuth
      * @param $onetime_token
      * @return array
      * @throws OneTimeAuthExpiredException
+     * @throws OneTimeAuthException
      */
     public function decodePortalOneTime($onetime_token, $logUpdate = true): array
     {
@@ -187,7 +188,9 @@ class OneTimeAuth
         // paths, so a token that has already reached its configured limit is
         // rejected rather than replayed or brute-forced.
         $actions = is_array($t_info['onetime_actions'] ?? null) ? $t_info['onetime_actions'] : [];
-        if (self::usageLimitReached($actions, (int)($t_info['access_count'] ?? 0), $this->pinAttemptLimit())) {
+        $accessCountRaw = $t_info['access_count'] ?? 0;
+        $accessCount = is_numeric($accessCountRaw) ? (int) $accessCountRaw : 0;
+        if (self::usageLimitReached($actions, $accessCount, $this->pinAttemptLimit())) {
             $this->systemLogger->error("Onetime token refused: usage limit reached", ['token' => $tokenFingerprint]);
             throw new OneTimeAuthException("Onetime token usage limit reached");
         }
@@ -310,7 +313,7 @@ class OneTimeAuth
      * flags against it throttles both token replay and PIN brute force without
      * any schema change.
      *
-     * @param array $actions        Decoded onetime_actions for the token.
+     * @param array<array-key, mixed> $actions Decoded onetime_actions for the token.
      * @param int   $accessCount     Current onetime_auth.access_count for the token.
      * @param int   $maxPinAttempts  Effective cap for PIN-protected tokens (see
      *                               MAX_PIN_ATTEMPTS / the portal_onetime_max_pin_attempts global).
@@ -324,7 +327,8 @@ class OneTimeAuth
         }
 
         // Explicit cap set by the caller (0 = unlimited).
-        $maxAccess = (int)($actions['max_access_count'] ?? 0);
+        $maxAccessRaw = $actions['max_access_count'] ?? 0;
+        $maxAccess = is_numeric($maxAccessRaw) ? (int) $maxAccessRaw : 0;
         if ($maxAccess > 0 && $accessCount >= $maxAccess) {
             return true;
         }

--- a/src/Common/Auth/OpenIDConnect/Entities/ScopeEntity.php
+++ b/src/Common/Auth/OpenIDConnect/Entities/ScopeEntity.php
@@ -6,7 +6,9 @@
  * @package   OpenEMR
  * @link      https://www.open-emr.org
  * @author    Jerry Padgett <sjpadgett@gmail.com>
+ * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2020 Jerry Padgett <sjpadgett@gmail.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
  * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
  */
 
@@ -49,12 +51,36 @@ class ScopeEntity implements ScopeEntityInterface
     }
 
     /**
+     * SMART launch contexts that legitimately use the colon delimiter and must
+     * NOT be rejected (e.g. api:oemr, api:fhir, api:port, site:default). Every
+     * other context (system, user, patient, or any future context) using the
+     * colon delimiter is rejected at parse time so downstream substring
+     * searches for 'system/' / 'user/' / 'patient/' cannot be bypassed by
+     * submitting the colon variant. See rejectNonLegacyColonDelimiter().
+     */
+    private const COLON_LEGACY_CONTEXTS = ['api', 'site'];
+
+    /**
      * @param string $scopeString
-     * @throws \InvalidArgumentException if the scope string is invalid
+     * @throws \InvalidArgumentException if the scope string is invalid or if
+     *         a non-legacy context uses the colon delimiter
      * @return ScopeEntity
      */
     public static function createFromString(string $scopeString): ScopeEntity
     {
+        // Reject colon-form delimiter for permission-bearing contexts (system,
+        // user, patient, and anything else outside COLON_LEGACY_CONTEXTS). The
+        // parser regex accepts both '/' and ':' between context and resource,
+        // which historically allowed 'system:Patient.read' to sneak past
+        // literal-substring 'system/' searches. Runtime helpers on this class
+        // (arrayHasContext / scopeListHasContext) already handle both spellings
+        // correctly for their known call sites; this parse-time rejection adds
+        // a model-layer defense so any future caller that reads getIdentifier()
+        // or getScopeLookupKey() cannot receive a colon-form privileged scope.
+        // Legacy colon-form contexts (api:oemr, api:fhir, api:port,
+        // site:default) are allowed through unchanged.
+        self::rejectNonLegacyColonDelimiter($scopeString);
+
         $scope = new self();
         $scope->setIdentifier($scopeString);
 
@@ -85,6 +111,35 @@ class ScopeEntity implements ScopeEntityInterface
         return $scope;
     }
 
+    /**
+     * Throw when a scope string uses the colon delimiter for a context that is
+     * NOT one of the SMART launch contexts allow-listed in
+     * COLON_LEGACY_CONTEXTS. Preserves api:oemr / api:fhir / api:port /
+     * site:default as-is. Scopes that do not contain a colon after their
+     * leading context word are unaffected.
+     *
+     * @throws \InvalidArgumentException
+     */
+    private static function rejectNonLegacyColonDelimiter(string $scopeString): void
+    {
+        // Match only the leading '<context>:<resource>' pattern; anything past
+        // the first colon that isn't a bare context+resource segment (e.g.
+        // 'api:fhir?something', 'system/Patient.read.something') is left to
+        // the main parser regex.
+        if (!preg_match('/^([a-zA-Z_]+):[a-zA-Z0-9\*_\-]+/', $scopeString, $matches)) {
+            return;
+        }
+        if (in_array($matches[1], self::COLON_LEGACY_CONTEXTS, true)) {
+            return;
+        }
+        throw new \InvalidArgumentException(sprintf(
+            "Scope '%s' uses the colon delimiter for context '%s'; use the slash form ('%s/...') instead.",
+            $scopeString,
+            $matches[1],
+            $matches[1]
+        ));
+    }
+
     public function getPermissions(): ScopePermissionObject
     {
         return $this->permissions;
@@ -100,6 +155,54 @@ class ScopeEntity implements ScopeEntityInterface
         } else {
             return $this->getIdentifier();
         }
+    }
+
+    /**
+     * Determine whether any scope in the given array resolves to the given SMART
+     * context ("system", "user", "patient", ...).
+     *
+     * Each scope is parsed into a canonical ScopeEntity and compared on its parsed
+     * context rather than by substring-matching the raw registration string. This
+     * ensures every equivalent spelling of a privileged scope (for example the
+     * slash form "system/Patient.read" and the colon form "system:Patient.read")
+     * is treated identically, so context-based authorization gates cannot be
+     * bypassed by respelling the delimiter. Scope strings that cannot be parsed
+     * are ignored for the purposes of context detection; they cannot be granted
+     * (getScopeEntityByIdentifier() rejects them with the same parser), so they
+     * cannot smuggle in a privileged context.
+     *
+     * @param string[] $scopes The requested scope strings
+     * @param string $context The SMART context to look for (e.g. "system", "user")
+     * @return bool
+     */
+    public static function arrayHasContext(array $scopes, string $context): bool
+    {
+        foreach ($scopes as $scope) {
+            try {
+                $parsed = self::createFromString((string) $scope);
+            } catch (\InvalidArgumentException) {
+                continue;
+            }
+            if ($parsed->getContext() === $context) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Convenience wrapper for a raw, whitespace-delimited scope list string (as
+     * received in an OAuth2 registration or authorization request). Splits the
+     * list and delegates to arrayHasContext().
+     *
+     * @param string $scopeList Whitespace-delimited scope list
+     * @param string $context The SMART context to look for
+     * @return bool
+     */
+    public static function scopeListHasContext(string $scopeList, string $context): bool
+    {
+        $scopes = preg_split('/\s+/', trim($scopeList)) ?: [];
+        return self::arrayHasContext(array_filter($scopes, static fn($s): bool => $s !== ''), $context);
     }
 
     public function getContext()
@@ -153,13 +256,13 @@ class ScopeEntity implements ScopeEntityInterface
         }
         // Check if permissions match
         $otherPermissions = $otherScope->getPermissions();
-        if ($otherPermissions->v1Read) {
-            return $otherPermissions->v1Read;
-        }
-        if ($otherPermissions->v1Write) {
-            return $otherPermissions->v1Write;
-        }
         $containsScope = true;
+        if ($otherPermissions->v1Read && !$this->permissions->v1Read) {
+            $containsScope = false; // We don't have v1 read permission
+        }
+        if ($otherPermissions->v1Write && !$this->permissions->v1Write) {
+            $containsScope = false; // We don't have v1 write permission
+        }
         if ($otherPermissions->read && !$this->permissions->read) {
             $containsScope = false; // We don't have read permission
         }

--- a/src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php
+++ b/src/Common/Auth/OpenIDConnect/Repositories/ScopeRepository.php
@@ -323,7 +323,7 @@ class ScopeRepository implements ScopeRepositoryInterface
     /**
      * Checks if the given scopes array requires any manual approval by an administrator before an oauth2 client can be authorized
      * @param bool $is_confidential_client Whether the client is confidential (can keep a secret safe) or a public app
-     * @param array $scopes The scopes to be checked to see if we need manual approval
+     * @param string[] $scopes The scopes to be checked to see if we need manual approval
      * @param string $oauthManualApprovalSetting The OAuthManualApproval setting from the globals table
      * @return bool true if there exist scopes that require manual review by an administrator, false otherwise
      */
@@ -359,35 +359,20 @@ class ScopeRepository implements ScopeRepositoryInterface
     }
 
     /**
-     * @param array $scopes
+     * @param string[] $scopes
      * @return bool
      */
     private function hasUserScopes(array $scopes): bool
     {
-        return $this->scopeArrayHasString($scopes, 'user/');
+        return ScopeEntity::arrayHasContext($scopes, 'user');
     }
 
     /**
-     * @param array $scopes
+     * @param string[] $scopes
      * @return bool
      */
     private function hasSystemScopes(array $scopes): bool
     {
-        return $this->scopeArrayHasString($scopes, 'system/');
-    }
-
-    /**
-     * @param array $scopes
-     * @param $str
-     * @return bool
-     */
-    private function scopeArrayHasString(array $scopes, $str): bool
-    {
-        foreach ($scopes as $scope) {
-            if (str_contains((string) $scope, (string) $str)) {
-                return true;
-            }
-        }
-        return false;
+        return ScopeEntity::arrayHasContext($scopes, 'system');
     }
 }

--- a/src/RestControllers/AuthorizationController.php
+++ b/src/RestControllers/AuthorizationController.php
@@ -323,17 +323,20 @@ class AuthorizationController implements LoggerAwareInterface
                 $params['client_secret'] = $client_secret;
                 $params['client_role'] = 'user';
 
-                // don't allow system scopes without a jwk or jwks_uri value
+                // don't allow system scopes without a jwk or jwks_uri value.
+                // Compare on the parsed SMART context so alternate spellings of the
+                // delimiter (e.g. "system:Patient.read") cannot bypass this check.
                 if (
-                    str_contains($scope, 'system/')
+                    ScopeEntity::scopeListHasContext($scope, 'system')
                     && !$data->has('jwks') && !$data->has('jwks_uri')
                 ) {
                     throw new OAuthServerException('jwks is invalid', 0, 'invalid_client_metadata');
                 }
-                // don't allow user, system scopes, and offline_access for public apps
+                // don't allow user, system scopes, and offline_access for public apps.
+                // Parse-and-compare on context so colon-form scopes cannot bypass this gate.
             } elseif (
-                str_contains($scope, 'system/')
-                || str_contains($scope, 'user/')
+                ScopeEntity::scopeListHasContext($scope, 'system')
+                || ScopeEntity::scopeListHasContext($scope, 'user')
             ) {
                 throw new OAuthServerException("system and user scopes are only allowed for confidential clients", 0, 'invalid_client_metadata');
             }

--- a/templates/documents/general_view.html
+++ b/templates/documents/general_view.html
@@ -25,7 +25,7 @@
 
  // Process click on Delete link.
  function deleteme(docid) {
-  dlgopen('interface/patient_file/deleter.php?document=' + encodeURIComponent(docid) + '&csrf_token_form=' + {$csrf_token_form|js_url}, '_blank', 500, 450);
+  dlgopen('interface/patient_file/deleter.php?patient=' + encodeURIComponent({$patient_id|js_url}) + '&document=' + encodeURIComponent(docid) + '&csrf_token_form=' + {$csrf_token_form|js_url}, '_blank', 500, 450);
   return false;
  }
 

--- a/tests/Tests/Api/AuthorizationClientRegistrationNegativeTest.php
+++ b/tests/Tests/Api/AuthorizationClientRegistrationNegativeTest.php
@@ -217,4 +217,63 @@ class AuthorizationClientRegistrationNegativeTest extends TestCase
         ]);
         $this->assertRejected($status, $body, "unsafe jwks_uri: $jwksUri");
     }
+
+    /**
+     * 6. A confidential (private) client requesting a privileged-context scope
+     *    in colon form (e.g. system:Patient.read, user:Patient.read,
+     *    patient:Patient.read) must be rejected. The colon delimiter is
+     *    reserved for SMART launch contexts (api:oemr, site:default, etc.);
+     *    every permission-bearing context must use the slash delimiter.
+     *
+     *    ScopeEntity::createFromString throws InvalidArgumentException at
+     *    parse time; validateScopesAgainstServerApprovedScopes catches the
+     *    invalid scope and raises OAuthServerException::invalidScope, which
+     *    clientRegistration() converts to a 4xx HTTP response.
+     */
+    public function testColonFormPrivilegedScopeIsRejected(): void
+    {
+        [$status, $body] = $this->registerWith([
+            "application_type" => "private",
+            "redirect_uris" => ["http://localhost:8080/oauth2/callback"],
+            "client_name" => "Colon System Client",
+            "token_endpoint_auth_method" => "private_key_jwt",
+            "contacts" => ["test@open-emr.org"],
+            "jwks" => ["keys" => [[
+                "kty" => "RSA",
+                "n" => "sXchDaQebHnPiGvyDOAT4saGEUetSyo9MKLOoWFsueri23bOdgWp4Dy1WlUzewbgBHod5pcM9H95GQRV3JDXboIRROSBigeC5yjU1hGzHHyXss8UDprecbAYxknTcQkhslANGRUZmdTOQ5ZTsSt1RwbGSKcNIGVpxKn5Fz-3wZ_wMg-BiTL7uKb1YnLBLK6zTOevD5rG-oJ2Xh0Rj_5Fk-oxaGdD1CInGGm4L5rNe6ULiNyk3z8hE0PBBJnpP4-VfXlOFA3zJPBSjA3W9CXCTn5H6DVoI9FUeS29H0Kzu9jGXm2y7pMBpUvL15pw",
+                "e" => "AQAB",
+                "kid" => "colon-poc",
+                "alg" => "RS256",
+                "use" => "sig",
+            ]]],
+            "scope" => "openid api:fhir system:Patient.read",
+        ]);
+        $this->assertRejected($status, $body, "colon-form system: scope");
+    }
+
+    public function testColonFormUserScopeIsRejected(): void
+    {
+        [$status, $body] = $this->registerWith([
+            "application_type" => "private",
+            "redirect_uris" => ["http://localhost:8080/oauth2/callback"],
+            "client_name" => "Colon User Client",
+            "token_endpoint_auth_method" => "client_secret_basic",
+            "contacts" => ["test@open-emr.org"],
+            "scope" => "openid user:Patient.read",
+        ]);
+        $this->assertRejected($status, $body, "colon-form user: scope");
+    }
+
+    public function testColonFormPatientScopeIsRejected(): void
+    {
+        [$status, $body] = $this->registerWith([
+            "application_type" => "private",
+            "redirect_uris" => ["http://localhost:8080/oauth2/callback"],
+            "client_name" => "Colon Patient Client",
+            "token_endpoint_auth_method" => "client_secret_basic",
+            "contacts" => ["test@open-emr.org"],
+            "scope" => "openid patient:Patient.read",
+        ]);
+        $this->assertRejected($status, $body, "colon-form patient: scope");
+    }
 }

--- a/tests/Tests/Isolated/Common/Auth/OneTimeAuthPolicyTest.php
+++ b/tests/Tests/Isolated/Common/Auth/OneTimeAuthPolicyTest.php
@@ -133,6 +133,11 @@ class OneTimeAuthPolicyTest extends TestCase
         );
     }
 
+    /**
+     * @return array<string, array{string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
     public static function typeJugglingBypassProvider(): array
     {
         return [
@@ -158,6 +163,11 @@ class OneTimeAuthPolicyTest extends TestCase
         $this->assertFalse(OneTimeAuth::pinMatches('123456', $submitted));
     }
 
+    /**
+     * @return array<string, array{mixed}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
     public static function nonStringProvider(): array
     {
         return [

--- a/tests/Tests/Isolated/Common/Auth/OneTimeAuthPolicyTest.php
+++ b/tests/Tests/Isolated/Common/Auth/OneTimeAuthPolicyTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * OneTimeAuthPolicyTest.
+ *
+ * Covers the token-consumption policy controls added to OneTimeAuth:
+ *   - usageLimitReached(): enforces enforce_onetime_use, max_access_count, and a
+ *     hard PIN-attempt cap against the token's access_count (token replay and PIN
+ *     brute-force throttling).
+ *   - pinMatches(): strict, constant-time PIN comparison that rejects
+ *     type-juggling numeric equivalents accepted by a loose (!=) compare.
+ *
+ * These are pure functions of their arguments, so they run in the isolated suite
+ * without a database.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Auth;
+
+use OpenEMR\Common\Auth\OneTimeAuth;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class OneTimeAuthPolicyTest extends TestCase
+{
+    // ---- usageLimitReached() : replay / brute-force throttling (V1, V2) ----
+
+    public function testOnetimeUseTokenIsRejectedAfterFirstConsumption(): void
+    {
+        $actions = ['enforce_onetime_use' => true];
+
+        // First use (count 0) is allowed; any subsequent attempt is refused.
+        $this->assertFalse(OneTimeAuth::usageLimitReached($actions, 0), 'first use must be allowed');
+        $this->assertTrue(OneTimeAuth::usageLimitReached($actions, 1), 'replay must be refused');
+        $this->assertTrue(OneTimeAuth::usageLimitReached($actions, 5), 'later replay must be refused');
+    }
+
+    public function testMaxAccessCountIsEnforced(): void
+    {
+        $actions = ['max_access_count' => 3];
+
+        $this->assertFalse(OneTimeAuth::usageLimitReached($actions, 0));
+        $this->assertFalse(OneTimeAuth::usageLimitReached($actions, 2));
+        $this->assertTrue(OneTimeAuth::usageLimitReached($actions, 3), 'at the cap must be refused');
+        $this->assertTrue(OneTimeAuth::usageLimitReached($actions, 4));
+    }
+
+    public function testPinTokenIsCappedEvenWithoutOtherFlags(): void
+    {
+        // No enforce_onetime_use and unlimited max_access_count, but a PIN is
+        // required: the hard cap must still bound guessing.
+        $actions = ['enforce_auth_pin' => true, 'max_access_count' => 0];
+
+        $this->assertFalse(OneTimeAuth::usageLimitReached($actions, OneTimeAuth::MAX_PIN_ATTEMPTS - 1));
+        $this->assertTrue(OneTimeAuth::usageLimitReached($actions, OneTimeAuth::MAX_PIN_ATTEMPTS));
+        $this->assertTrue(OneTimeAuth::usageLimitReached($actions, OneTimeAuth::MAX_PIN_ATTEMPTS + 10));
+    }
+
+    public function testPinAttemptCapIsConfigurable(): void
+    {
+        // The effective cap is injected by the caller (from the
+        // portal_onetime_max_pin_attempts global); the policy method honours it.
+        $actions = ['enforce_auth_pin' => true];
+
+        // A stricter cap of 3.
+        $this->assertFalse(OneTimeAuth::usageLimitReached($actions, 2, 3));
+        $this->assertTrue(OneTimeAuth::usageLimitReached($actions, 3, 3));
+
+        // A looser cap of 10.
+        $this->assertFalse(OneTimeAuth::usageLimitReached($actions, 9, 10));
+        $this->assertTrue(OneTimeAuth::usageLimitReached($actions, 10, 10));
+
+        // Default (no explicit limit) falls back to MAX_PIN_ATTEMPTS.
+        $this->assertTrue(OneTimeAuth::usageLimitReached($actions, OneTimeAuth::MAX_PIN_ATTEMPTS));
+    }
+
+    /**
+     * Negative test: a token that opts into no limits (the telehealth / standard
+     * portal-login / document defaults) stays reusable within its lifetime.
+     */
+    public function testUnlimitedTokenIsNeverRefusedByPolicy(): void
+    {
+        $actions = [
+            'enforce_onetime_use' => false,
+            'enforce_auth_pin' => false,
+            'max_access_count' => 0,
+        ];
+
+        foreach ([0, 1, 2, 50, 1000] as $count) {
+            $this->assertFalse(
+                OneTimeAuth::usageLimitReached($actions, $count),
+                "unlimited token must remain usable at access_count=$count"
+            );
+        }
+    }
+
+    public function testMissingOrEmptyActionsAreTreatedAsUnlimited(): void
+    {
+        $this->assertFalse(OneTimeAuth::usageLimitReached([], 0));
+        $this->assertFalse(OneTimeAuth::usageLimitReached([], 1000));
+    }
+
+    /**
+     * The shipped invoice token sets enforce_onetime_use + enforce_auth_pin: the
+     * first attempt (success or wrong PIN) consumes it, so replay and brute force
+     * are both bounded to a single attempt.
+     */
+    public function testInvoiceTokenIsSingleUse(): void
+    {
+        $actions = [
+            'enforce_onetime_use' => true,
+            'enforce_auth_pin' => true,
+            'extend_portal_visit' => false,
+        ];
+
+        $this->assertFalse(OneTimeAuth::usageLimitReached($actions, 0));
+        $this->assertTrue(OneTimeAuth::usageLimitReached($actions, 1));
+    }
+
+    // ---- pinMatches() : strict PIN comparison (V3) ----
+
+    #[DataProvider('typeJugglingBypassProvider')]
+    public function testPinMatchesRejectsTypeJugglingEquivalents(string $expected, string $submitted): void
+    {
+        $this->assertFalse(
+            OneTimeAuth::pinMatches($expected, $submitted),
+            "wrong PIN '$submitted' must not match '$expected'"
+        );
+    }
+
+    public static function typeJugglingBypassProvider(): array
+    {
+        return [
+            'leading zero stripped'   => ['012345', '12345'],
+            'leading zero stripped 2' => ['056789', '56789'],
+            'scientific notation'     => ['123456', '123456e0'],
+            'decimal equivalent'      => ['123456', '123456.0'],
+            'zero padded'             => ['123456', '0123456'],
+            'plain wrong'             => ['123456', '654321'],
+        ];
+    }
+
+    public function testPinMatchesAcceptsExactPin(): void
+    {
+        $this->assertTrue(OneTimeAuth::pinMatches('123456', '123456'));
+        // Leading-zero PIN must still work for the legitimate exact value.
+        $this->assertTrue(OneTimeAuth::pinMatches('012345', '012345'));
+    }
+
+    #[DataProvider('nonStringProvider')]
+    public function testPinMatchesRejectsNonStringInput(mixed $submitted): void
+    {
+        $this->assertFalse(OneTimeAuth::pinMatches('123456', $submitted));
+    }
+
+    public static function nonStringProvider(): array
+    {
+        return [
+            'null'    => [null],
+            'int'     => [123456],
+            'float'   => [123456.0],
+            'array'   => [['123456']],
+            'bool'    => [true],
+        ];
+    }
+
+    public function testPinMatchesRejectsEmptyString(): void
+    {
+        $this->assertFalse(OneTimeAuth::pinMatches('123456', ''));
+    }
+}

--- a/tests/Tests/Isolated/Common/Auth/OpenIDConnect/Entities/ScopeDelimiterRejectionIsolatedTest.php
+++ b/tests/Tests/Isolated/Common/Auth/OpenIDConnect/Entities/ScopeDelimiterRejectionIsolatedTest.php
@@ -1,0 +1,162 @@
+<?php
+
+/**
+ * ScopeDelimiterRejectionIsolatedTest
+ *
+ * Locks the parse-time defense in ScopeEntity::createFromString: colon-form
+ * scope delimiter is rejected for permission-bearing contexts (system, user,
+ * patient, and anything outside the COLON_LEGACY_CONTEXTS allow-list), so
+ * downstream substring searches for 'system/' / 'user/' / 'patient/' cannot
+ * be bypassed by submitting the colon variant. Legacy SMART launch contexts
+ * (api:oemr, api:fhir, api:port, site:default) continue to parse.
+ *
+ * Runtime helpers on ScopeEntity (arrayHasContext / scopeListHasContext) are
+ * also correct for both spellings; this parse-time rejection is a
+ * model-layer defense so no future caller that reads getIdentifier() or
+ * getScopeLookupKey() can receive a colon-form privileged scope.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    Brady Miller <brady.g.miller@gmail.com>
+ * @copyright Copyright (c) 2026 Brady Miller <brady.g.miller@gmail.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Common\Auth\OpenIDConnect\Entities;
+
+use InvalidArgumentException;
+use OpenEMR\Common\Auth\OpenIDConnect\Entities\ScopeEntity;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class ScopeDelimiterRejectionIsolatedTest extends TestCase
+{
+    /**
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function privilegedColonScopesProvider(): array
+    {
+        return [
+            'system:Patient.read'   => ['system:Patient.read'],
+            'system:Patient.write'  => ['system:Patient.write'],
+            'system:*.read'         => ['system:*.read'],
+            'user:Patient.read'     => ['user:Patient.read'],
+            'user:Encounter.write'  => ['user:Encounter.write'],
+            'patient:Patient.read'  => ['patient:Patient.read'],
+            'patient:Observation.read' => ['patient:Observation.read'],
+            'system:Observation.cruds' => ['system:Observation.cruds'],
+            // Unknown-context colon scopes (not on the allow-list) must also
+            // be rejected — the allow-list is api + site only.
+            'unknowncontext:X'      => ['unknowncontext:X'],
+        ];
+    }
+
+    #[DataProvider('privilegedColonScopesProvider')]
+    public function testColonFormPrivilegedContextIsRejected(string $scopeString): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/uses the colon delimiter for context/');
+        ScopeEntity::createFromString($scopeString);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function legacyColonScopesProvider(): array
+    {
+        return [
+            'api:oemr'      => ['api:oemr'],
+            'api:fhir'      => ['api:fhir'],
+            'api:port'      => ['api:port'],
+            'site:default'  => ['site:default'],
+        ];
+    }
+
+    #[DataProvider('legacyColonScopesProvider')]
+    public function testLegacyColonContextsAreAccepted(string $scopeString): void
+    {
+        $entity = ScopeEntity::createFromString($scopeString);
+        $this->assertSame($scopeString, $entity->getIdentifier(), 'Legacy colon-context scope must be stored unchanged.');
+    }
+
+    /**
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function slashScopesProvider(): array
+    {
+        return [
+            'system/Patient.read'      => ['system/Patient.read'],
+            'system/Patient.write'     => ['system/Patient.write'],
+            'system/*.read'            => ['system/*.read'],
+            'user/Patient.read'        => ['user/Patient.read'],
+            'user/Encounter.write'     => ['user/Encounter.write'],
+            'patient/Patient.read'     => ['patient/Patient.read'],
+            'patient/Observation.read' => ['patient/Observation.read'],
+        ];
+    }
+
+    #[DataProvider('slashScopesProvider')]
+    public function testSlashFormPrivilegedContextIsAccepted(string $scopeString): void
+    {
+        $entity = ScopeEntity::createFromString($scopeString);
+        $this->assertSame($scopeString, $entity->getIdentifier(), 'Slash-form scope must be stored unchanged.');
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function contextExtractionProvider(): array
+    {
+        return [
+            'system slash' => ['system/Patient.read', 'system'],
+            'user slash'   => ['user/Patient.write',  'user'],
+            'patient slash' => ['patient/Patient.read', 'patient'],
+            'api colon'    => ['api:fhir',            'api'],
+            'site colon'   => ['site:default',        'site'],
+        ];
+    }
+
+    #[DataProvider('contextExtractionProvider')]
+    public function testAcceptedScopesExposeExpectedContext(string $scopeString, string $expectedContext): void
+    {
+        $entity = ScopeEntity::createFromString($scopeString);
+        $this->assertSame($expectedContext, $entity->getContext());
+    }
+
+    public function testOpenidBareScopeAccepted(): void
+    {
+        $entity = ScopeEntity::createFromString('openid');
+        $this->assertSame('openid', $entity->getIdentifier());
+        $this->assertSame('openid', $entity->getContext());
+    }
+
+    public function testExplicitlyMalformedScopeThrows(): void
+    {
+        // A leading digit is not part of the parser's context grammar and is
+        // rejected by the main regex (not by the colon-delimiter check).
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Invalid scope format/');
+        ScopeEntity::createFromString('1bad-context');
+    }
+
+    public function testRejectionMessageIncludesContextAndSuggestion(): void
+    {
+        try {
+            ScopeEntity::createFromString('system:Patient.read');
+            $this->fail('Expected InvalidArgumentException');
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringContainsString('system', $e->getMessage(), 'Message should name the rejected context');
+            $this->assertStringContainsString('system/', $e->getMessage(), 'Message should suggest the slash-form replacement');
+        }
+    }
+}

--- a/tests/Tests/Isolated/ESign/RouterTest.php
+++ b/tests/Tests/Isolated/ESign/RouterTest.php
@@ -49,7 +49,11 @@ class RouterTest extends TestCase
         $this->assertSame($expected, Router::resolveModule($input));
     }
 
-    /** @codeCoverageIgnore Data providers run before coverage instrumentation starts. */
+    /**
+     * @return array<string, array{string, string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
     public static function validModules(): array
     {
         return [
@@ -62,13 +66,17 @@ class RouterTest extends TestCase
     }
 
     #[DataProvider('maliciousModules')]
-    public function testRejectsUnknownOrTraversalModules($input): void
+    public function testRejectsUnknownOrTraversalModules(mixed $input): void
     {
         $this->expectException(InvalidArgumentException::class);
         Router::resolveModule($input);
     }
 
-    /** @codeCoverageIgnore Data providers run before coverage instrumentation starts. */
+    /**
+     * @return array<string, array{mixed}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
     public static function maliciousModules(): array
     {
         return [

--- a/tests/Tests/Isolated/ESign/RouterTest.php
+++ b/tests/Tests/Isolated/ESign/RouterTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Isolated unit tests for the ESign Router module allowlist.
+ *
+ * Guards against the path-traversal / Local File Inclusion regression in
+ * ESign\Router: the `module` request parameter must resolve only to the
+ * fixed set of known ESign modules and reject anything else, so no
+ * attacker-controlled bytes can reach the require_once path or the
+ * instantiated controller class name.
+ *
+ * Runs in the "isolated" suite (no database or globals bootstrap). The
+ * ESign namespace is not PSR-4 autoloaded, so the router is required
+ * directly; its own top-level require resolves through OEGlobalsBag, which
+ * we seed with the library path.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @copyright Copyright (c) 2026 OpenEMR Foundation
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\ESign;
+
+use ESign\Router;
+use InvalidArgumentException;
+use OpenEMR\Core\OEGlobalsBag;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class RouterTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        $srcDir = dirname(__DIR__, 4) . '/library';
+        // getSrcDir() falls back to the 'srcdir' global when no Kernel is
+        // booted (the isolated suite boots none); seed both so the router's
+        // top-level require_once resolves.
+        $GLOBALS['srcdir'] = $srcDir;
+        OEGlobalsBag::getInstance()->set('srcdir', $srcDir);
+        require_once $srcDir . '/ESign/Router.php';
+    }
+
+    #[DataProvider('validModules')]
+    public function testResolvesKnownModulesCaseInsensitively(string $input, string $expected): void
+    {
+        $this->assertSame($expected, Router::resolveModule($input));
+    }
+
+    /** @codeCoverageIgnore Data providers run before coverage instrumentation starts. */
+    public static function validModules(): array
+    {
+        return [
+            'lowercase form'      => ['form', 'Form'],
+            'lowercase encounter' => ['encounter', 'Encounter'],
+            'ucfirst form'        => ['Form', 'Form'],
+            'upper encounter'     => ['ENCOUNTER', 'Encounter'],
+            'padded form'         => ['  form  ', 'Form'],
+        ];
+    }
+
+    #[DataProvider('maliciousModules')]
+    public function testRejectsUnknownOrTraversalModules($input): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Router::resolveModule($input);
+    }
+
+    /** @codeCoverageIgnore Data providers run before coverage instrumentation starts. */
+    public static function maliciousModules(): array
+    {
+        return [
+            'empty string'       => [''],
+            'null'               => [null],
+            'traversal to tmp'   => ['../../../../../../../../tmp/send'],
+            'absolute path'      => ['/etc/passwd'],
+            'dot dot'            => ['..'],
+            'sibling Abstract'   => ['Abstract'],
+            'sibling Utils'      => ['Utils'],
+            'embedded null byte' => ["fo\0rm"],
+            'unknown module'     => ['admin'],
+            'nested valid name'  => ['../form'],
+        ];
+    }
+}

--- a/tests/Tests/Isolated/Portal/OnsiteDocumentCriteriaSqlInjectionTest.php
+++ b/tests/Tests/Isolated/Portal/OnsiteDocumentCriteriaSqlInjectionTest.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * OnsiteDocumentCriteriaSqlInjectionTest
+ *
+ * Regression test for the patient-portal OnsiteDocument query builder. The
+ * bitwise comparators of the shared Phreeze Criteria builder previously
+ * concatenated request values into an unquoted SQL context, allowing an
+ * authenticated patient to inject arbitrary SQL into the WHERE clause via
+ * mass-assigned criteria properties such as `Id_BitwiseAnd`.
+ *
+ * These tests drive the real OnsiteDocumentCriteria (plus its generated field
+ * map) through the shared builder and assert that bitwise operands are emitted
+ * as integer literals, so attacker input can never change the query structure,
+ * while legitimate integer bitmasks and quoted equality filters are unaffected.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    OpenEMR Security Team <security@open-emr.org>
+ * @copyright Copyright (c) 2026 OpenEMR <info@open-emr.org>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Tests\Isolated\Portal;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class OnsiteDocumentCriteriaSqlInjectionTest extends TestCase
+{
+    private const PORTAL = __DIR__ . '/../../../../portal/patient';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $fwk = self::PORTAL . '/fwk/libs';
+        $model = self::PORTAL . '/libs';
+        set_include_path($fwk . PATH_SEPARATOR . $model . PATH_SEPARATOR . get_include_path());
+
+        require_once($fwk . '/verysimple/Phreeze/Criteria.php');
+        require_once($fwk . '/verysimple/Phreeze/DataAdapter.php');
+        require_once($fwk . '/verysimple/DB/DataDriver/MySQLi.php');
+        require_once(self::PORTAL . '/libs/Model/OnsiteDocumentCriteria.php');
+
+        // Escape()/GetQuotedSql() dispatch to the active driver; wire the MySQLi
+        // driver directly so the builder runs without a live DB connection. The
+        // legacy static is untyped, so set it via reflection.
+        (new \ReflectionClass(\DataAdapter::class))
+            ->setStaticPropertyValue('DRIVER_INSTANCE', new \DataDriverMySQLi());
+    }
+
+    /**
+     * Error-based and boolean-based payloads that the reporter demonstrated, plus
+     * simpler structure-breaking inputs. None must survive into the WHERE clause.
+     *
+     * @return array<string, array{string}>
+     *
+     * @codeCoverageIgnore Data providers run before coverage instrumentation starts.
+     */
+    public static function injectionPayloadProvider(): array
+    {
+        return [
+            'extractvalue error-based' => ['0 OR extractvalue(1,concat(0x7e,(select concat(username,0x7c,left(password,12)) from users_secure limit 1),0x7e))'],
+            'boolean OR 1=1'          => ['0 OR 1=1'],
+            'subselect'               => ['0 UNION SELECT password FROM users_secure'],
+            'comment-obfuscated'      => ['0/**/or/**/1=1'],
+        ];
+    }
+
+    #[DataProvider('injectionPayloadProvider')]
+    public function testBitwiseAndNeutralisesInjection(string $payload): void
+    {
+        $criteria = new \OnsiteDocumentCriteria();
+        $criteria->Pid_Equals = 42;
+        $criteria->Id_BitwiseAnd = $payload;
+
+        $where = $criteria->GetWhere();
+        $this->assertIsString($where);
+
+        $this->assertStringNotContainsStringIgnoringCase('extractvalue', $where);
+        $this->assertStringNotContainsStringIgnoringCase('users_secure', $where);
+        $this->assertStringNotContainsStringIgnoringCase('union', $where);
+        $this->assertStringNotContainsStringIgnoringCase(' or ', $where);
+        // Operand collapses to the integer 0 for any non-numeric leading input.
+        $this->assertStringContainsString('(`onsite_documents`.`id` & 0)', $where);
+    }
+
+    #[DataProvider('injectionPayloadProvider')]
+    public function testBitwiseOrNeutralisesInjection(string $payload): void
+    {
+        $criteria = new \OnsiteDocumentCriteria();
+        $criteria->Pid_Equals = 42;
+        $criteria->Id_BitwiseOr = $payload;
+
+        $where = $criteria->GetWhere();
+        $this->assertIsString($where);
+
+        $this->assertStringNotContainsStringIgnoringCase('extractvalue', $where);
+        $this->assertStringNotContainsStringIgnoringCase('users_secure', $where);
+        $this->assertStringContainsString('(`onsite_documents`.`id` | 0)', $where);
+        // Regression: the old branch emitted a stray unbalanced single quote.
+        $this->assertStringNotContainsString("| '", $where);
+    }
+
+    public function testBitwiseAndPreservesLegitimateBitmask(): void
+    {
+        $criteria = new \OnsiteDocumentCriteria();
+        $criteria->Pid_Equals = 42;
+        $criteria->Id_BitwiseAnd = '4';
+
+        $where = $criteria->GetWhere();
+        $this->assertIsString($where);
+
+        $this->assertStringContainsString('(`onsite_documents`.`id` & 4)', $where);
+    }
+
+    public function testEqualsFilterStillQuotesAndEscapes(): void
+    {
+        // A comparator that legitimately takes a string must remain quoted and
+        // escaped — proving the fix is scoped to the bitwise branches only.
+        $criteria = new \OnsiteDocumentCriteria();
+        $criteria->Pid_Equals = "1' OR '1'='1";
+
+        $where = $criteria->GetWhere();
+        $this->assertIsString($where);
+
+        $this->assertStringContainsString("`onsite_documents`.`pid` = '1\\' OR \\'1\\'=\\'1'", $where);
+    }
+}

--- a/tests/Tests/Services/DocumentControllerWriteAclTest.php
+++ b/tests/Tests/Services/DocumentControllerWriteAclTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * DocumentControllerWriteAclTest verifies that C_Document's write path enforces
+ * the same anti-IDOR checks as its read path: a caller may only mutate a
+ * document they can already access in its current patient/category context.
+ *
+ * @package   OpenEMR
+ * @link      https://www.open-emr.org
+ * @author    OpenEMR Security
+ * @copyright Copyright (c) 2026 OpenEMR Foundation
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Services;
+
+use C_Document;
+use Document;
+use OpenEMR\Common\Database\QueryUtils;
+use OpenEMR\Services\UserService;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+class DocumentControllerWriteAclTest extends TestCase
+{
+    /** Arbitrary patient id the fixture document belongs to. */
+    private const DOC_PATIENT_ID = 987654;
+
+    private int $documentId = 0;
+
+    protected function setUp(): void
+    {
+        // C_Document is a legacy (non-autoloaded) controller; the suite
+        // bootstrap has already loaded interface/globals.php, so its
+        // procedural dependencies resolve here.
+        require_once __DIR__ . '/../../../controllers/C_Document.class.php';
+
+        $GLOBALS['document_storage_method'] = Document::STORAGE_METHOD_FILESYSTEM;
+        $systemUser = (new UserService())->getSystemUser();
+        self::assertIsArray($systemUser, 'system user must be resolvable for the fixture');
+        $owner = (int) $systemUser['id'];
+
+        // A document tied to DOC_PATIENT_ID with no category. An empty category
+        // set makes Document::can_access() grant access, which isolates the
+        // patient-context check that these tests exercise from category ACL.
+        $data = 'write-acl-test';
+        $document = new Document();
+        $document->createDocument(
+            (string) self::DOC_PATIENT_ID,
+            0,
+            'write-acl-test-' . uniqid() . '.txt',
+            'text/plain',
+            $data,
+            '',
+            1,
+            $owner
+        );
+        $rawDocumentId = $document->get_id();
+        self::assertTrue(is_numeric($rawDocumentId), 'fixture document should expose a numeric id');
+        $this->documentId = (int) $rawDocumentId;
+        self::assertNotSame(0, $this->documentId, 'fixture document should have been created');
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->documentId !== 0) {
+            QueryUtils::sqlStatementThrowException('DELETE FROM categories_to_documents WHERE document_id = ?', [$this->documentId]);
+            QueryUtils::sqlStatementThrowException('DELETE FROM documents WHERE id = ?', [$this->documentId]);
+        }
+    }
+
+    /**
+     * Invoke the private write-authorization guard with the given patient context.
+     */
+    private function authorizeWrite(?string $patientContext): Document
+    {
+        $controller = new C_Document();
+        $guard = new ReflectionMethod(C_Document::class, 'authorizeDocumentWrite');
+
+        $result = $guard->invoke($controller, $patientContext, $this->documentId);
+        self::assertInstanceOf(Document::class, $result);
+        return $result;
+    }
+
+    public function testWriteAllowedWhenPatientContextMatchesDocument(): void
+    {
+        $document = $this->authorizeWrite((string) self::DOC_PATIENT_ID);
+        $documentId = $document->get_id();
+        self::assertTrue(is_numeric($documentId));
+        self::assertSame($this->documentId, (int) $documentId);
+    }
+
+    public function testWriteDeniedWhenPatientContextMismatchesDocument(): void
+    {
+        // A caller operating in a different patient context must not be able to
+        // mutate (e.g. reassign) a document belonging to another patient.
+        $this->expectException(AccessDeniedHttpException::class);
+        $this->authorizeWrite((string) (self::DOC_PATIENT_ID + 1));
+    }
+
+    public function testWriteDeniedWhenPatientContextIsNull(): void
+    {
+        // Regression for the null-patient_id bypass: an empty "patient_id="
+        // request parameter is normalised to null by Controller::dispatch().
+        // The guard must fail closed on a null patient context instead of
+        // skipping the patient-ownership check and relying on the category ACL
+        // alone, which passes for any category the caller can already reach.
+        $this->expectException(AccessDeniedHttpException::class);
+        $this->authorizeWrite(null);
+    }
+}

--- a/tests/Tests/Unit/Common/Auth/OpenIDConnect/Entities/ScopeEntityContextTest.php
+++ b/tests/Tests/Unit/Common/Auth/OpenIDConnect/Entities/ScopeEntityContextTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * ScopeEntityContextTest.php
+ *
+ * Tests for ScopeEntity::arrayHasContext() / scopeListHasContext(), the shared
+ * parse-and-compare helper used by the OAuth2 registration and manual-approval
+ * gates to detect privileged (system/user) scopes.
+ *
+ * Prior to these changes the gates substring-matched the raw scope string
+ * (str_contains($scope, 'system/')), which a client could bypass by registering
+ * the colon form (system:Patient.read). The current defense-in-depth pairs:
+ *
+ *   1. createFromString() rejects colon-form privileged scopes at parse time
+ *      (see ScopeDelimiterRejectionIsolatedTest).
+ *   2. arrayHasContext() detects the slash form via canonical parse-and-compare
+ *      and correctly skips anything the parser rejects — colon-form privileged
+ *      scopes fail-closed here rather than sneaking past a substring match.
+ *
+ * @package   openemr
+ * @link      https://www.open-emr.org
+ * @author    Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2026 Stephen Waite <stephen.waite@cmsvt.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Unit\Common\Auth\OpenIDConnect\Entities;
+
+use OpenEMR\Common\Auth\OpenIDConnect\Entities\ScopeEntity;
+use PHPUnit\Framework\TestCase;
+
+class ScopeEntityContextTest extends TestCase
+{
+    /**
+     * The slash form of a privileged scope must be detected. The colon form is
+     * rejected upstream by createFromString(); arrayHasContext() catches the
+     * parse exception and correctly skips it, so it fail-closes to false here.
+     * The colon-form rejection is covered by ScopeDelimiterRejectionIsolatedTest.
+     */
+    public function testArrayHasContextDetectsPrivilegedScopesInSlashForm(): void
+    {
+        $this->assertTrue(ScopeEntity::arrayHasContext(["openid", "system/Patient.read"], "system"));
+        $this->assertTrue(ScopeEntity::arrayHasContext(["openid", "user/Patient.read"], "user"));
+        $this->assertFalse(ScopeEntity::arrayHasContext(["openid", "system:Patient.read"], "system"));
+        $this->assertFalse(ScopeEntity::arrayHasContext(["openid", "user:Patient.read"], "user"));
+    }
+
+    /**
+     * A privileged scope hidden among patient scopes must still be detected
+     * (slash form; the colon form is rejected upstream at parse time).
+     */
+    public function testArrayHasContextDetectsPrivilegedScopeAmongPatientScopes(): void
+    {
+        $scopes = ["patient/Patient.read", "patient/Observation.rs", "user/Encounter.read"];
+        $this->assertTrue(ScopeEntity::arrayHasContext($scopes, "user"));
+    }
+
+    /**
+     * site:default legitimately uses the colon delimiter but its context is
+     * "site", not system or user. It must not be misclassified as privileged,
+     * or the fix would break a valid scope.
+     */
+    public function testArrayHasContextDoesNotMisclassifySiteDefault(): void
+    {
+        $scopes = ["openid", "site:default", "patient/Patient.rs"];
+        $this->assertFalse(ScopeEntity::arrayHasContext($scopes, "system"));
+        $this->assertFalse(ScopeEntity::arrayHasContext($scopes, "user"));
+    }
+
+    /**
+     * Patient-only scope sets must report no system/user context.
+     */
+    public function testArrayHasContextIsFalseForPatientOnlyScopes(): void
+    {
+        $scopes = ["openid", "patient/Patient.read", "patient/Observation.rs"];
+        $this->assertFalse(ScopeEntity::arrayHasContext($scopes, "system"));
+        $this->assertFalse(ScopeEntity::arrayHasContext($scopes, "user"));
+    }
+
+    /**
+     * Wildcard and export-operation system scopes must be detected.
+     */
+    public function testArrayHasContextDetectsWildcardAndExportSystemScopes(): void
+    {
+        $this->assertTrue(ScopeEntity::arrayHasContext(["system/*.rs"], "system"));
+        $this->assertTrue(ScopeEntity::arrayHasContext(["system/Group.\$export"], "system"));
+    }
+
+    /**
+     * Unparsable scope strings are skipped for context detection. They cannot be
+     * granted (getScopeEntityByIdentifier() rejects them with the same parser),
+     * so skipping them cannot smuggle in a privileged context.
+     */
+    public function testArrayHasContextSkipsUnparsableScopes(): void
+    {
+        $scopes = ["system/Pat ient.read", "system/Patient/extra"];
+        $this->assertFalse(ScopeEntity::arrayHasContext($scopes, "system"));
+    }
+
+    /**
+     * The scopeListHasContext() wrapper accepts a raw whitespace-delimited scope
+     * list string (as received in a registration request) and behaves the same
+     * as arrayHasContext(): slash-form privileged scopes are detected; colon-form
+     * privileged scopes are rejected at parse time and correctly skipped.
+     */
+    public function testScopeListHasContextParsesRawListString(): void
+    {
+        $this->assertTrue(ScopeEntity::scopeListHasContext("openid system/Patient.read", "system"));
+        $this->assertTrue(ScopeEntity::scopeListHasContext("openid user/Patient.read patient/Patient.rs", "user"));
+        $this->assertFalse(ScopeEntity::scopeListHasContext("openid site:default patient/Patient.rs", "system"));
+        $this->assertFalse(ScopeEntity::scopeListHasContext("openid site:default patient/Patient.rs", "user"));
+        $this->assertFalse(ScopeEntity::scopeListHasContext("openid system:Patient.read", "system"));
+        $this->assertFalse(ScopeEntity::scopeListHasContext("openid user:Patient.read patient/Patient.rs", "user"));
+    }
+
+    /**
+     * Empty and whitespace-only scope lists resolve to no context.
+     */
+    public function testScopeListHasContextHandlesEmptyInput(): void
+    {
+        $this->assertFalse(ScopeEntity::scopeListHasContext("", "system"));
+        $this->assertFalse(ScopeEntity::scopeListHasContext("   ", "user"));
+    }
+}

--- a/tests/Tests/Unit/Common/Auth/OpenIDConnect/Entities/ScopeEntityTest.php
+++ b/tests/Tests/Unit/Common/Auth/OpenIDConnect/Entities/ScopeEntityTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * ScopeEntityTest.php
+ *
+ * Tests for ScopeEntity::containsScope(), in particular the v1 (read/write)
+ * permission handling. Prior to this fix, containsScope() returned true for
+ * any scope requesting v1Read or v1Write without checking whether the
+ * containing scope actually granted those permissions.
+ *
+ * @package   openemr
+ * @link      https://www.open-emr.org
+ * @author    Stephen Waite <stephen.waite@cmsvt.com>
+ * @copyright Copyright (c) 2026 Stephen Waite <stephen.waite@cmsvt.com>
+ * @license   https://github.com/openemr/openemr/blob/master/LICENSE GNU General Public License 3
+ */
+
+namespace OpenEMR\Tests\Unit\Common\Auth\OpenIDConnect\Entities;
+
+use OpenEMR\Common\Auth\OpenIDConnect\Entities\ScopeEntity;
+use PHPUnit\Framework\TestCase;
+
+class ScopeEntityTest extends TestCase
+{
+    public function testContainsScopeIdenticalScopes(): void
+    {
+        $scope = ScopeEntity::createFromString("patient/Patient.read");
+        $other = ScopeEntity::createFromString("patient/Patient.read");
+        $this->assertTrue($scope->containsScope($other), "A scope should contain an identical scope");
+    }
+
+    public function testContainsScopeDifferentResource(): void
+    {
+        $scope = ScopeEntity::createFromString("patient/Patient.read");
+        $other = ScopeEntity::createFromString("patient/Observation.read");
+        $this->assertFalse($scope->containsScope($other), "Scopes with different resources should not contain each other");
+    }
+
+    /**
+     * Regression test: before the fix, a scope with only update permission was
+     * reported as containing a v1 read scope because containsScope() returned
+     * true whenever the other scope had v1Read set, without checking $this.
+     */
+    public function testContainsScopeDeniesV1ReadWhenNotGranted(): void
+    {
+        $scope = ScopeEntity::createFromString("patient/Patient.u");
+        $other = ScopeEntity::createFromString("patient/Patient.read");
+        $this->assertFalse($scope->containsScope($other), "An update-only scope must not contain a v1 read scope");
+    }
+
+    /**
+     * Regression test: same bypass as above but for v1Write.
+     */
+    public function testContainsScopeDeniesV1WriteWhenNotGranted(): void
+    {
+        $scope = ScopeEntity::createFromString("patient/Patient.r");
+        $other = ScopeEntity::createFromString("patient/Patient.write");
+        $this->assertFalse($scope->containsScope($other), "A read-only scope must not contain a v1 write scope");
+    }
+
+    /**
+     * v1 'read' is equivalent to v2 'rs' (read + search), so containment
+     * should hold in both directions.
+     */
+    public function testContainsScopeV1ReadEquivalentToReadSearch(): void
+    {
+        $v2 = ScopeEntity::createFromString("patient/Patient.rs");
+        $v1 = ScopeEntity::createFromString("patient/Patient.read");
+        $this->assertTrue($v2->containsScope($v1), "'rs' should contain v1 'read'");
+        $this->assertTrue($v1->containsScope($v2), "v1 'read' should contain 'rs'");
+    }
+
+    /**
+     * v1 'write' is equivalent to v2 'cud' (create + update + delete), so
+     * containment should hold in both directions.
+     */
+    public function testContainsScopeV1WriteEquivalentToCud(): void
+    {
+        $v2 = ScopeEntity::createFromString("patient/Patient.cud");
+        $v1 = ScopeEntity::createFromString("patient/Patient.write");
+        $this->assertTrue($v2->containsScope($v1), "'cud' should contain v1 'write'");
+        $this->assertTrue($v1->containsScope($v2), "v1 'write' should contain 'cud'");
+    }
+
+    public function testContainsScopeWriteDoesNotContainRead(): void
+    {
+        $write = ScopeEntity::createFromString("patient/Patient.write");
+        $read = ScopeEntity::createFromString("patient/Patient.read");
+        $this->assertFalse($write->containsScope($read), "v1 'write' must not contain v1 'read'");
+        $this->assertFalse($read->containsScope($write), "v1 'read' must not contain v1 'write'");
+    }
+
+    /**
+     * The v1 flags are normally derived from the CRUD flags by
+     * ScopePermissionObject::createFromString(). Exercise the new checks
+     * directly by setting v1Read on the requested scope's permission object,
+     * so containment cannot pass by way of the CRUD checks alone.
+     */
+    public function testContainsScopeChecksV1FlagsIndependentlyOfCrudFlags(): void
+    {
+        // note: identifiers must differ or the identity short-circuit in
+        // containsScope() returns true before any permission checks run
+        $scope = ScopeEntity::createFromString("patient/Patient.cr");
+        $other = ScopeEntity::createFromString("patient/Patient.c");
+        $other->getPermissions()->v1Read = true;
+        $this->assertFalse($scope->containsScope($other), "A scope without v1Read must not contain a scope requiring v1Read");
+    }
+
+    /**
+     * Regression test for GHSA-6cmr-r2rh-755m. A confidential client approved
+     * only for a read-only user-context scope must not be treated as containing
+     * the corresponding write scope. This is the exact shape reported: a
+     * user/<resource>.read registration was preserving user/<resource>.write
+     * at scope finalization. Covers the user context and the appointment
+     * resource from the reported proof of concept, alongside the patient-context
+     * cases above.
+     */
+    public function testContainsScopeReadOnlyClientDoesNotContainWriteUserContext(): void
+    {
+        $appointmentRead = ScopeEntity::createFromString("user/appointment.read");
+        $appointmentWrite = ScopeEntity::createFromString("user/appointment.write");
+        $this->assertFalse(
+            $appointmentRead->containsScope($appointmentWrite),
+            "user/appointment.read must not contain user/appointment.write"
+        );
+
+        $patientRead = ScopeEntity::createFromString("user/patient.read");
+        $patientWrite = ScopeEntity::createFromString("user/patient.write");
+        $this->assertFalse(
+            $patientRead->containsScope($patientWrite),
+            "user/patient.read must not contain user/patient.write"
+        );
+    }
+}

--- a/tests/Tests/Unit/Common/Auth/OpenIDConnect/Repositories/ScopeRepositoryTest.php
+++ b/tests/Tests/Unit/Common/Auth/OpenIDConnect/Repositories/ScopeRepositoryTest.php
@@ -88,7 +88,7 @@ class ScopeRepositoryTest extends TestCase
                 ,'user/medical_problem.cruds'
             ]);
         $scopeRepository = $this->scopeRepository;
-        $scopeRepository->setSystemLogger($this->createMock(LoggerInterface::class));
+        $scopeRepository->setLogger($this->createMock(LoggerInterface::class));
         $scopeRepository->setServerScopeList($serverScopeListEntity);
 
         $validSubSets = [
@@ -222,27 +222,170 @@ class ScopeRepositoryTest extends TestCase
         $this->assertEquals("patient/Patient.ruds", $allowedScopes[2]->getIdentifier(), "Allowed scope should be patient/Patient.ruds");
     }
 
-    public function finalizeScopesWithInvalidSubScopeWillFail(): never
+    public function testFinalizeScopesFiltersOutInvalidSubScope(): void
     {
-        // tests we need to handle here
-        $this->markTestIncomplete("ScopeRepository::finalizeScopes() needs to be implemented and tested.");
-
-        // verify a client with a full scope, will still fail if a request is made for an invalid sub scope
+        // A client registered only with read/search permissions must not receive
+        // a create/update/delete scope it did not register for. finalizeScopes()
+        // filters unsatisfiable scopes rather than failing the whole grant, so
+        // the write scope is dropped while satisfiable scopes are retained.
         $scopeRepository = $this->scopeRepository;
         $requestedScopes = [
-            ScopeEntity::createFromString("patient/Patient.cud")
+            ScopeEntity::createFromString("patient/Patient.cud"), // not registered — must be dropped
+            ScopeEntity::createFromString("patient/Patient.rs"),  // registered — must survive
         ];
         $client = new ClientEntity();
         $client->setScopes([
-            "patient/Patient.rs"
-            ,"patient/Patient.r"
-            ,"patient/Patient.s"
-            ,"openid"
-            ,"api:fhir"
-            ,"api:oemr"
-            ,"api:portal"
+            "patient/Patient.rs",
+            "patient/Patient.r",
+            "patient/Patient.s",
+            "openid",
+            "api:fhir",
+            "api:oemr",
+            "api:portal",
         ]);
         $allowedScopes = $scopeRepository->finalizeScopes($requestedScopes, "authorization_code", $client);
-        $this->assertEmpty($allowedScopes, "Allowed scope should be empty for patient/Patient.rs as its not a subset of Patient/Patient.cud");
+
+        $allowedNames = array_map(fn($s) => $s->getIdentifier(), $allowedScopes);
+        $this->assertContains("patient/Patient.rs", $allowedNames, "A registered read/search scope should survive finalizeScopes()");
+        $this->assertNotContains("patient/Patient.cud", $allowedNames, "An unregistered write scope must be filtered out by finalizeScopes()");
+    }
+
+    public function testHasScopesThatRequireManualApprovalDetectsPrivilegedContextsInSlashSpellings(): void
+    {
+        $scopeRepository = $this->scopeRepository;
+        $scopeRepository->setLogger($this->createMock(LoggerInterface::class));
+
+        // Every slash-form spelling of a system/user scope must gate a confidential
+        // client for manual approval. Colon-form privileged scopes never reach
+        // this gate — they are rejected upstream at parse time by
+        // ScopeEntity::createFromString() and by validateScopesAgainstServerApprovedScopes().
+        $privilegedScopeSets = [
+            'slash form system scope' => ["openid", "system/Patient.read"],
+            'slash form user scope' => ["openid", "user/Patient.read"],
+            'system export operation' => ["system/Group.\$export"],
+            'system wildcard scope' => ["system/*.rs"],
+            'bare system context' => ["system"],
+            'bare user context' => ["user"],
+            'privileged scope hidden among patient scopes' => ["patient/Patient.read", "patient/Observation.rs", "user/Encounter.read"],
+        ];
+        foreach ($privilegedScopeSets as $description => $scopes) {
+            $this->assertTrue(
+                $scopeRepository->hasScopesThatRequireManualApproval(true, $scopes),
+                "Confidential client with {$description} should require manual approval"
+            );
+        }
+    }
+
+    /**
+     * Colon-form privileged scopes (system:, user:) are rejected at parse time
+     * by ScopeEntity::createFromString(). arrayHasContext() catches the parse
+     * exception and skips them, so this gate returns false for a client whose
+     * only privileged scope is colon-form. That is the correct fail-closed
+     * behavior — the client cannot obtain a working token because the colon-
+     * form scope is also rejected upstream by
+     * validateScopesAgainstServerApprovedScopes() before reaching this gate.
+     * Documented so a future loosening of the parser cannot silently open a
+     * bypass here without failing this test.
+     */
+    public function testHasScopesThatRequireManualApprovalSkipsColonFormPrivilegedScopes(): void
+    {
+        $scopeRepository = $this->scopeRepository;
+        $scopeRepository->setLogger($this->createMock(LoggerInterface::class));
+
+        $colonFormOnly = [
+            'colon form system scope only' => ["openid", "system:Patient.read"],
+            'colon form user scope only' => ["openid", "user:Patient.read"],
+        ];
+        foreach ($colonFormOnly as $description => $scopes) {
+            $this->assertFalse(
+                $scopeRepository->hasScopesThatRequireManualApproval(true, $scopes),
+                "Confidential client with {$description} should be skipped by arrayHasContext (rejected upstream at parse time)"
+            );
+        }
+    }
+
+    public function testHasScopesThatRequireManualApprovalAutoEnablesPatientOnlyConfidentialClients(): void
+    {
+        $scopeRepository = $this->scopeRepository;
+        $scopeRepository->setLogger($this->createMock(LoggerInterface::class));
+
+        // ONC information blocking rule: confidential apps using ONLY patient/* scopes
+        // (plus openid connect & site scopes) must be allowed to auto-enable
+        $patientOnlyScopes = [
+            "openid", "fhirUser", "email", "offline_access",
+            "launch/patient",
+            "api:fhir", "api:oemr", "api:port", "api:portal", "site:default",
+            "patient/Patient.read", "patient/Observation.rs", "patient/Encounter.cruds",
+        ];
+        $this->assertFalse(
+            $scopeRepository->hasScopesThatRequireManualApproval(true, $patientOnlyScopes),
+            "Confidential client with only patient/openid/site scopes should be auto-enabled"
+        );
+    }
+
+    public function testHasScopesThatRequireManualApprovalPublicClientWithLaunchScope(): void
+    {
+        $scopeRepository = $this->scopeRepository;
+        $scopeRepository->setLogger($this->createMock(LoggerInterface::class));
+
+        $this->assertTrue(
+            $scopeRepository->hasScopesThatRequireManualApproval(false, ["openid", "launch", "patient/Patient.read"]),
+            "Public client requesting the launch scope should require manual approval"
+        );
+        $this->assertFalse(
+            $scopeRepository->hasScopesThatRequireManualApproval(false, ["openid", "launch/patient", "patient/Patient.read"]),
+            "Public client without the standalone launch scope should be auto-enabled"
+        );
+    }
+
+    public function testHasScopesThatRequireManualApprovalHonorsGlobalSetting(): void
+    {
+        $scopeRepository = $this->scopeRepository;
+        $scopeRepository->setLogger($this->createMock(LoggerInterface::class));
+
+        $this->assertTrue(
+            $scopeRepository->hasScopesThatRequireManualApproval(false, ["openid", "patient/Patient.read"], '1'),
+            "OAuthManualApproval global setting of '1' should require manual approval regardless of scopes"
+        );
+    }
+
+    /**
+     * Encodes the fail-closed invariant that makes it safe for the manual-approval
+     * gate to skip unparsable scopes: getScopeEntityByIdentifier() uses the same
+     * ScopeEntity parser at grant time, so any scope the gate ignores as unparsable
+     * can never actually be granted. If the grant-time parser is ever loosened
+     * without also tightening the gate, this test should catch the divergence.
+     */
+    public function testUnparsableSystemLookingScopeIsSkippedButFailsClosedAtGrantTime(): void
+    {
+        $scopeRepository = $this->scopeRepository;
+
+        $scopeRepository->setLogger($this->createMock(LoggerInterface::class));
+
+        $serverScopeListEntity = $this->getMockBuilder(ServerScopeListEntity::class)
+            ->onlyMethods(['getAllSupportedScopesList'])
+            ->getMock();
+        $serverScopeListEntity->expects($this->any())
+            ->method('getAllSupportedScopesList')
+            ->willReturn([
+                "system/Patient.cruds"
+            ]);
+        $scopeRepository->setServerScopeList($serverScopeListEntity);
+
+        $unparsableScopes = [
+            "system/Patient.bogus"      // invalid permission string
+            , "system/Patient/extra"    // extra path segment
+            , "system/Pat ient.read"    // whitespace inside resource
+        ];
+        foreach ($unparsableScopes as $scope) {
+            $this->assertFalse(
+                $scopeRepository->hasScopesThatRequireManualApproval(true, [$scope]),
+                "Unparsable scope {$scope} should be skipped by the manual-approval gate"
+            );
+            $this->assertEmpty(
+                $scopeRepository->getScopeEntityByIdentifier($scope),
+                "Unparsable scope {$scope} must also be rejected at grant time (fail-closed invariant)"
+            );
+        }
     }
 }


### PR DESCRIPTION
Cherry-picks the 6 fix commits that landed on `master` for the 8.4.0 release into `rel-840`.

## Commits (master → rel-840)

Each cherry-pick was verified against its source commit via `git patch-id --stable` to confirm byte-equal diff content.

| # | master SHA | rel-840 SHA | patch-id | subject |
|---|---|---|---|---|
| 1 | `156bb97916` | `17c5007e5c` | `afa4c67d5b` | Merge commit from fork |
| 2 | `817c5c8b5e` | `5fb5495482` | `4b43d29b0c` | Merge commit from fork |
| 3 | `5403342975` | `c4e7188c84` | `d385682dab` | Merge commit from fork |
| 4 | `68f9bfbf25` | `9e2e5cb988` | `dd3e461fe0` | Merge commit from fork |
| 5 | `fc5de974c3` | `262d4c466f` | `a2fb267269` | Merge commit from fork |
| 6 | `1104bf995e` | `a6d9ae70e3` | `5aeaacf59f` | refactor(deleter): scope document deletion to the submitted patient context (#13958) |

All 6 cherry-picks applied cleanly with no context drift; all patch-ids match master source byte-for-byte.

## Test plan

- [ ] CI (green on master already; rel-840 has minor divergence — 2 backports + branch-cut + 2 docker-test tweaks — none of which touch the same files as the 6 fixes)
- [ ] Merge once green; ship 8.4.0 from `rel-840`