### PR TITLE
fix(portal): restrict secure message editor toolbar

### DIFF
--- a/portal/messaging/js/messages.js
+++ b/portal/messaging/js/messages.js
@@ -103,6 +103,30 @@
         return str.length > limit ? str.substring(0, limit) : str;
     }
 
+    function secureMessageEditorOptions(height) {
+        return {
+            focus: true,
+            height: height,
+            width: '100%',
+            tabsize: 4,
+            disableDragAndDrop: true,
+            dialogsInBody: true,
+            dialogsFade: true,
+            // Secure messages deliberately do not support links or uploaded
+            // media. Keep the editor UI aligned with what rendering permits.
+            toolbar: [
+                ['style', ['bold', 'italic', 'underline', 'clear']],
+                ['para', ['ul', 'ol', 'paragraph']],
+                ['view', ['codeview', 'help']]
+            ],
+            popover: {
+                image: [],
+                link: [],
+                air: []
+            }
+        };
+    }
+
     async function postForm(url, params) {
         const response = await fetch(url, {
             method: 'POST',
@@ -614,15 +638,7 @@
             state.compose.noteid = $(relatedTarget).attr('data-noteid');
             updateComposeForm();
         } else if (mode === 'reply') {
-            $('#inputBody').show().summernote({
-                focus: true,
-                height: '225px',
-                width: '100%',
-                tabsize: 4,
-                disableDragAndDrop: true,
-                dialogsInBody: true,
-                dialogsFade: true
-            });
+            $('#inputBody').show().summernote(secureMessageEditorOptions('225px'));
             $('#finputBody').hide();
             $('#selForwardto').hide();
             $('#selSendto').show();
@@ -643,20 +659,7 @@
             state.compose.noteid = chain;
             updateComposeForm();
         } else {
-            $('#inputBody').show().summernote({
-                width: '100%',
-                focus: true,
-                height: '375px',
-                tabsize: 4,
-                disableDragAndDrop: true,
-                dialogsInBody: true,
-                dialogsFade: true,
-                popover: {
-                    image: [],
-                    link: [],
-                    air: []
-                }
-            });
+            $('#inputBody').show().summernote(secureMessageEditorOptions('375px'));
             $('#finputBody').hide();
             $('#selForwardto').hide();
             $('#selSendto').show().prop('disabled', false);
@@ -810,6 +813,7 @@
             escapeHtml,
             htmlToText,
             limitTo,
+            secureMessageEditorOptions,
             renderMessageBody,
             paginate,
             groupChain

--- a/tests/js/portal-messaging-helpers.test.js
+++ b/tests/js/portal-messaging-helpers.test.js
@@ -191,6 +191,21 @@ describe('messages.js limitTo', () => {
     });
 });
 
+describe('messages.js secureMessageEditorOptions', () => {
+    const { secureMessageEditorOptions } = messagesHelpers;
+
+    test('does not offer links or uploaded media', () => {
+        const options = secureMessageEditorOptions('225px');
+        const buttons = options.toolbar.flatMap(group => group[1]);
+
+        expect(buttons).not.toContain('link');
+        expect(buttons).not.toContain('picture');
+        expect(buttons).not.toContain('video');
+        expect(options.disableDragAndDrop).toBe(true);
+        expect(options.popover).toEqual({ image: [], link: [], air: [] });
+    });
+});
+
 // ---------------------------------------------------------------------------
 // messages.js: renderMessageBody — the only sink that passes user-supplied
 // HTML straight into innerHTML. Must be DOMPurify-sanitized and must forbid


### PR DESCRIPTION
Fixes #13966

### Summary

- Centralize the Summernote configuration used by new-message and reply editors.
- Limit the toolbar to supported basic formatting.
- Disable link, image, video, drag-and-drop, and related popovers.
- Add a JavaScript regression test for the restricted configuration.
- Audit review is not setting disposition flags. i.e. after charting audit item is still in todo table.
- SyntaxError: expected expression, got '<' URL: https://opensourcedemr.com/portal/patient/onsiteactivityviews Line: 2 Column: 1 Error object: "{}"
- Styles need attention.

### Testing

- `git diff --check`
- `node --check portal/messaging/js/messages.js`
- Run `tests/js/portal-messaging-helpers.test.js` through the project JavaScript test suite.
- Open both compose and reply editors and verify unsupported controls are absent.
