### PR TITLE
fix(billing): show patient on payment receipts

### DIFF
--- a/interface/patient_file/front_payment.php
+++ b/interface/patient_file/front_payment.php
@@ -522,6 +522,13 @@ function toencounter(enc, datestr, topframe) {
                             <?php echo text("[Phone]" . $frow['phone']) ?><br />
                             <?php echo text("[Email] " . $frow['email']) ?><br />
 
+                            <br />
+                            <?php echo xlt('Patient'); ?>:
+                            <?php echo text(trim(($patdata['fname'] ?? '') . ' ' . ($patdata['mname'] ?? '') . ' ' . ($patdata['lname'] ?? ''))); ?>
+
+                            <br />
+                            <?php echo xlt('Patient ID'); ?>:
+                            <?php echo text($patdata['pubpid'] ?? ''); ?>
 
                             <br />
                             <?php echo xlt('How Paid'); ?>:


### PR DESCRIPTION
Fixes #13968

### Summary

- Display the patient's escaped full name on the fee-payment receipt.
- Display the escaped public patient ID below the patient name.
- Leave the existing facility, payment, and print workflow unchanged.

### Testing

- `git diff --check`
- Collect a fee payment and verify the printable receipt identifies the patient by name and public patient ID.
